### PR TITLE
fix(netlify): set publish directory to site and add 404 fallback

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+publish = "site"
+command = ""

--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>HawkinsOps | Page not found</title>
+<link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<section style="padding-top:110px">
+  <div class="ctr" style="max-width:760px">
+    <div class="slbl">404</div>
+    <h1 class="stitle">Page not found</h1>
+    <p class="sdesc">
+      The page you requested was not found. Use the links below to return to working pages.
+    </p>
+    <div class="g2">
+      <a class="btn btn-p" href="index.html">Go to Home</a>
+      <a class="btn btn-g" href="resume.html">Resume</a>
+      <a class="btn btn-g" href="security.html">Security</a>
+      <a class="btn btn-g" href="proof.html">Proof Pack</a>
+    </div>
+  </div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
Adds `netlify.toml` to force publish directory `site/`.

## Changes
- Added `netlify.toml`:
  - `[build]`
  - `publish = "site"`
  - `command = ""`
- Added `site/404.html` as a minimal static fallback with links to working pages.

## Verification in repo
Confirmed these files exist in `main` layout for Netlify publish:
- `site/index.html`
- `site/assets/styles.css`
- `site/assets/app.js`
- `site/assets/Raylee_Hawkins_Resume.pdf`

## Netlify checks for you
- Netlify UI: **Build & deploy** -> **Publish directory** must be `site`
- Domain management: confirm `hawkinsops.com` points to this same Netlify site
