### PR TITLE
feat(site): pastel pink homepage refresh (proof-first, accessible)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -6,6 +6,31 @@
 (function () {
   const $ = (sel, root=document) => root.querySelector(sel);
   const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+  const html = document.documentElement;
+
+  // Theme toggle (light default, persisted preference)
+  const themeToggle = $('#themeToggle');
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = localStorage.getItem('rh-theme');
+  const startTheme = savedTheme || (prefersDark ? 'dark' : 'light');
+  html.setAttribute('data-theme', startTheme);
+
+  function updateThemeButton(theme) {
+    if (!themeToggle) return;
+    const next = theme === 'dark' ? 'light' : 'dark';
+    themeToggle.textContent = theme === 'dark' ? 'Light' : 'Dark';
+    themeToggle.setAttribute('aria-label', `Switch to ${next} mode`);
+  }
+  updateThemeButton(startTheme);
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const current = html.getAttribute('data-theme') || 'light';
+      const next = current === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', next);
+      localStorage.setItem('rh-theme', next);
+      updateThemeButton(next);
+    });
+  }
 
   // Mobile nav
   const mobBtn = $('#mobBtn');

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,18 +1,29 @@
 
         *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
         :root{
-            --bg:#07070b;--bg1:#151826;--bg2:#1a1f2f;--bg3:#22293b;
-            --bdr:#272b3a;--bdr2:#373d52;
-            --txt:#f7f8fb;--dim:#c7cfdf;--faint:#a3aec4;
-            --acc:#ff3ea5;--acc2:#ff86c7;--acc-d:rgba(255,62,165,.11);--acc-g:rgba(255,62,165,.2);
+            --bg:#f8f8f8;--bg1:#fff6fa;--bg2:#ffeef5;--bg3:#ffdfe9;
+            --bdr:#f1bfd3;--bdr2:#e7a9c4;
+            --txt:#1e1e1e;--dim:#4a3a42;--faint:#6a5460;
+            --acc:#ff9ecd;--acc2:#ff9ecd;--acc-d:rgba(255,158,205,.2);--acc-g:rgba(255,158,205,.28);
             --red:#ff3b5c;--red-d:rgba(255,59,92,.1);
             --amb:#ffb020;--amb-d:rgba(255,176,32,.1);
             --blu:#3b82f6;--pur:#a78bfa;
             --mono:'JetBrains Mono','IBM Plex Mono','Consolas',monospace;
-            --sans:'Space Grotesk','Segoe UI',sans-serif;
+            --sans:'Inter','Segoe UI',sans-serif;
         }
+        [data-theme='dark']{
+            --bg:#0a0a0a;--bg1:#141018;--bg2:#1b1420;--bg3:#241827;
+            --bdr:#4a2a3f;--bdr2:#6d3b5a;
+            --txt:#f7f8fb;--dim:#d7b9c9;--faint:#b58ea3;
+            --acc:#ff9ecd;--acc2:#ffd1dc;--acc-d:rgba(255,105,180,.14);--acc-g:rgba(255,105,180,.3);
+        }
+        [data-theme='dark'] body{background:radial-gradient(900px 420px at 90% -12%,rgba(255,105,180,.14),transparent 72%),radial-gradient(760px 380px at -14% 112%,rgba(255,158,205,.12),transparent 72%),var(--bg)}
+        [data-theme='dark'] nav{background:rgba(10,10,10,.88)}
+        [data-theme='dark'] .mob-menu{background:rgba(10,10,10,.97)}
+        [data-theme='dark'] .modal-backdrop{background:rgba(8,8,8,.65)}
+        [data-theme='dark'] .logo-monogram{color:#0a0a0a}
         html{scroll-behavior:smooth}
-        body{font-family:var(--sans);background:radial-gradient(1000px 500px at 90% -10%,rgba(255,62,165,.08),transparent 70%),radial-gradient(900px 450px at -20% 115%,rgba(255,62,165,.06),transparent 70%),var(--bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+        body{font-family:var(--sans);background:radial-gradient(840px 360px at 90% -12%,rgba(255,158,205,.22),transparent 72%),radial-gradient(700px 340px at -14% 112%,rgba(255,209,220,.5),transparent 72%),var(--bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
         body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(255,255,255,.012) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.012) 1px,transparent 1px);background-size:64px 64px;pointer-events:none;z-index:0}
         .ctr{max-width:1200px;margin:0 auto;padding:0 24px;position:relative;z-index:1}
         a{color:var(--acc2);text-underline-offset:3px;text-decoration-thickness:1px}
@@ -22,19 +33,22 @@
         }
 
         /* NAV */
-        nav{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(6,8,12,.9);backdrop-filter:blur(20px);border-bottom:1px solid var(--bdr)}
+        nav{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,248,252,.88);backdrop-filter:blur(18px);border-bottom:1px solid var(--bdr)}
         .nav-i{max-width:1200px;margin:0 auto;padding:0 24px;display:flex;justify-content:space-between;align-items:center;height:60px}
-        .logo{font-family:var(--sans);font-size:1rem;font-weight:700;letter-spacing:.02em;color:var(--txt);text-decoration:none;cursor:pointer}
+        .logo{font-family:var(--sans);font-size:1rem;font-weight:700;letter-spacing:.02em;color:var(--txt);text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:8px}
         .logo b{color:var(--acc)}
+        .logo-monogram{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:var(--acc);color:#1e1e1e;font-family:var(--mono);font-size:.72rem;font-weight:700}
         .nav-l{display:flex;gap:24px;list-style:none;align-items:center}
         .nav-l a{font-family:var(--mono);font-size:.72rem;color:var(--dim);text-decoration:none;cursor:pointer;transition:color .2s,background .2s,border-color .2s;letter-spacing:.03em;padding:6px 10px;border-radius:999px;border:1px solid transparent}
         .nav-l a:hover{color:var(--acc);background:rgba(255,62,165,.08)}
         .nav-l a.act,.nav-l a[aria-current='page']{color:var(--txt);background:rgba(255,62,165,.18);border-color:rgba(255,62,165,.4);box-shadow:inset 0 -1px 0 rgba(255,143,203,.5)}
         .mob-btn{display:none;background:none;border:1px solid var(--bdr);color:var(--txt);padding:6px 10px;font-family:var(--mono);font-size:.72rem;cursor:pointer}
+        .theme-btn{background:var(--bg2);color:var(--txt);border:1px solid var(--bdr2);padding:7px 10px;border-radius:999px;font-family:var(--mono);font-size:.68rem;cursor:pointer;transition:all .2s}
+        .theme-btn:hover{border-color:#ff69b4;box-shadow:0 0 0 3px rgba(255,105,180,.14)}
 
         /* HERO */
         .hero{min-height:100vh;display:flex;align-items:center;padding-top:60px;position:relative;overflow:hidden}
-        .hero-glow{position:absolute;width:600px;height:600px;border-radius:50%;background:radial-gradient(circle,rgba(255,62,165,.1) 0%,transparent 70%);top:-100px;right:-100px;pointer-events:none;animation:gp 8s ease-in-out infinite}
+        .hero-glow{position:absolute;width:360px;height:360px;border-radius:50%;background:radial-gradient(circle,rgba(255,158,205,.25) 0%,transparent 70%);top:-60px;right:-80px;pointer-events:none;animation:gp 9s ease-in-out infinite}
         @keyframes gp{0%,100%{opacity:.4;transform:scale(1)}50%{opacity:.65;transform:scale(1.06)}}
         .particles{position:absolute;inset:0;overflow:hidden;pointer-events:none}
         .particle{position:absolute;background:var(--acc);border-radius:50%;opacity:.2;animation:fu linear infinite}
@@ -47,6 +61,9 @@
         .hsub{font-size:1.05rem;color:var(--dim);max-width:520px;margin-bottom:10px;line-height:1.6}
         .hproof{font-family:var(--mono);font-size:.8rem;color:var(--txt);margin-bottom:28px;line-height:1.8}
         .hproof b{color:var(--acc);font-weight:600}
+        .hero-icons{display:flex;gap:10px;flex-wrap:wrap;margin:-10px 0 18px}
+        .ico-chip{display:inline-flex;align-items:center;gap:8px;padding:7px 12px;border:1px solid var(--bdr2);background:var(--bg1);border-radius:999px;font-family:var(--mono);font-size:.67rem;color:var(--dim)}
+        .ico-chip svg{width:15px;height:15px;fill:#ff69b4;flex:0 0 auto}
         .hctas{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px}
         .btn{display:inline-flex;align-items:center;gap:6px;padding:12px 22px;font-family:var(--mono);font-size:.78rem;font-weight:600;text-decoration:none;border:none;cursor:pointer;transition:all .25s;letter-spacing:.02em}
         .btn-p{background:var(--acc);color:var(--bg)}
@@ -64,7 +81,7 @@
 
         /* METRICS */
         .mstrip{display:grid;grid-template-columns:repeat(5,1fr);gap:1px;background:var(--bdr);border:1px solid var(--bdr);margin-bottom:0}
-        .met{background:var(--bg1);padding:24px 14px;text-align:center}
+        .met{background:var(--bg1);padding:24px 14px;text-align:center;border:1px solid var(--bdr2);box-shadow:0 10px 20px rgba(255,158,205,.08)}
         .met-v{font-family:var(--mono);font-size:1.6rem;font-weight:700;color:var(--acc);line-height:1;margin-bottom:4px}
         .met-l{font-size:.68rem;color:var(--dim);text-transform:uppercase;letter-spacing:.07em}
 
@@ -78,7 +95,7 @@
 
         /* CARDS - clickable */
         .card{background:var(--bg2);border:1px solid var(--bdr);padding:24px;transition:all .25s;cursor:pointer;position:relative;color:var(--txt)}
-        .card:hover{border-color:var(--acc);transform:translateY(-2px);box-shadow:0 8px 28px rgba(255,62,165,.11)}
+        .card:hover{border-color:#ff69b4;transform:translateY(-2px) scale(1.01);box-shadow:0 10px 24px rgba(255,105,180,.16)}
         .card-click{position:absolute;top:10px;right:12px;font-family:var(--mono);font-size:.6rem;color:var(--faint);opacity:0;transition:opacity .2s}
         .card:hover .card-click{opacity:1}
 
@@ -113,11 +130,11 @@
         .ptag{font-family:var(--mono);font-size:.6rem;padding:3px 8px;background:var(--bg);border:1px solid var(--bdr);color:var(--dim)}
 
         /* TERMINAL */
-        .term{background:#0a0e14;border:1px solid var(--bdr);border-radius:8px;overflow:hidden;margin:32px 0;font-family:var(--mono)}
-        .term-h{background:#0f1319;padding:10px 14px;display:flex;align-items:center;gap:6px;border-bottom:1px solid var(--bdr)}
+        .term{background:var(--bg1);border:1px solid var(--bdr);border-radius:8px;overflow:hidden;margin:32px 0;font-family:var(--mono)}
+        .term-h{background:var(--bg2);padding:10px 14px;display:flex;align-items:center;gap:6px;border-bottom:1px solid var(--bdr)}
         .td{width:9px;height:9px;border-radius:50%}.td-r{background:#ff5f57}.td-y{background:#febc2e}.td-g{background:#28c840}
         .term-t{margin-left:10px;font-size:.68rem;color:var(--faint)}
-        .term-b{padding:18px 20px;font-size:.78rem;line-height:1.75;color:#e1e7f4;overflow-x:auto;white-space:pre-wrap}
+        .term-b{padding:18px 20px;font-size:.78rem;line-height:1.75;color:var(--txt);overflow-x:auto;white-space:pre-wrap}
         .c-cmd{color:var(--acc)}.c-cmt{color:var(--faint)}.c-out{color:var(--txt)}.c-path{color:var(--amb)}.c-num{color:var(--red)}
 
         /* PLAYBOOK */
@@ -181,7 +198,7 @@
         footer p{font-size:.75rem;color:var(--faint)}
         .fl{display:flex;justify-content:center;gap:20px;margin-top:10px}
         .fl a{font-family:var(--mono);font-size:.7rem;color:var(--dim);text-decoration:none}
-        .fl a:hover{color:var(--acc)}
+        .fl a:hover{color:#ff69b4}
 
         .validate-box{background:var(--bg2);border:1px solid var(--bdr);padding:20px;margin-bottom:20px;color:var(--txt)}
         .validate-box h3{font-size:.9rem;font-weight:600;margin-bottom:10px}
@@ -205,7 +222,7 @@
 /* v3 additions (non-React pages) */
 .modal-backdrop{
   position:fixed; inset:0;
-  background:rgba(6,8,12,.92);
+  background:rgba(20,10,18,.42);
   backdrop-filter:blur(6px);
   z-index:2500;
   display:none;
@@ -257,7 +274,7 @@
   position:fixed;
   top:60px;
   left:0; right:0;
-  background:rgba(6,8,12,.95);
+  background:rgba(255,248,252,.98);
   border-bottom:1px solid var(--bdr);
   z-index:1500;
 }
@@ -270,10 +287,10 @@
   color:var(--dim);
   text-decoration:none;
 }
-.mob-menu a:hover{color:var(--acc);background:rgba(255,62,165,.08)}
+.mob-menu a:hover{color:#ff69b4;background:rgba(255,209,220,.35)}
 .mob-menu a.act,.mob-menu a[aria-current='page']{
   color:var(--txt);
-  background:rgba(255,62,165,.2);
+  background:rgba(255,209,220,.55);
   border-left:3px solid var(--acc);
   padding-left:21px;
 }
@@ -286,4 +303,7 @@
 @media (prefers-reduced-motion:reduce){
   *,*::before,*::after{animation:none !important;transition:none !important}
   html{scroll-behavior:auto}
+}
+@media(max-width:640px){
+  .theme-btn{margin-left:8px}
 }

--- a/site/index.html
+++ b/site/index.html
@@ -20,14 +20,14 @@
 <link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="assets/styles.css">
 
 </head>
 <body>
 <nav>
   <div class="nav-i">
-    <a class="logo" href="index.html"><b>Hawkins</b>Ops</a>
+    <a class="logo" href="index.html"><span class="logo-monogram" aria-hidden="true">RH</span><b>Hawkins</b>Ops</a>
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="index.html">Home</a></li>
@@ -38,6 +38,7 @@
       <li><a href="proof.html">Proof</a></li>
       <li><a href="resume.html">Resume</a></li>
     </ul>
+    <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to dark mode">Dark</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
@@ -65,6 +66,16 @@
       <br>• Clone the repo
       <br>• Run the verify commands
       <br>• Match the counts
+    </div>
+    <div class="hero-icons" aria-label="Proof highlights">
+      <span class="ico-chip">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2 4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3Zm-1 13-3-3 1.4-1.4 1.6 1.6 4-4L16.4 9 11 15Z"/></svg>
+        Verified artifacts
+      </span>
+      <span class="ico-chip">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.7 16.7-1.4 1.4L2.2 13l5.1-5.1 1.4 1.4L5 13l3.7 3.7Zm6.6 0L19 13l-3.7-3.7 1.4-1.4 5.1 5.1-5.1 5.1-1.4-1.4Z"/></svg>
+        Reproducible commands
+      </span>
     </div>
 
     <div class="roles">
@@ -257,6 +268,5 @@
 <script src="assets/app.js" defer></script>
 </body>
 </html>
-
 
 


### PR DESCRIPTION
## Root cause / intent
The homepage visual weight was skewed by oversized glow + dark-heavy baseline, which made decorative effects feel louder than evidence content. This refresh rebalances to a pastel-light default while preserving the proof-first structure and verified metrics.

## What changed
- Homepage (site/index.html)
  - Added RH monogram in navbar
  - Added lightweight Dark/Light toggle button
  - Added two small inline proof SVG chips in hero (verified artifacts + reproducible commands)
- Theme + contrast (site/assets/styles.css)
  - Introduced pastel-light palette variables (primary accent #ff9ecd, softer pink surfaces, neutral text)
  - Added dark theme overrides ([data-theme='dark']) with pink accent glows
  - Reduced oversized hero glow footprint and intensity
  - Tuned card/count hover polish and readability without layout changes
- Minimal JS (site/assets/app.js)
  - Added theme toggle with localStorage persistence and ARIA label updates
  - Kept active-nav normalization and modal accessibility logic intact

## Verification
- Verified counts text unchanged in site/index.html:
  - Verified detections (today) = 142
  - Verified IR playbooks = 10
- Local static check: python -m http.server --directory site and GET / returns 200.

## Notes
- No analytics, no dependency bloat, no core content changes.
- Pink is used as accent/surfaces while neutrals keep readability and professional tone.
