### PR TITLE
fix(home): remove oversized tool graphics, brighten dark theme, and fix resume PDF routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+CONTEXT_FILE: C:\RH\OPS\BUILD\agents\codex\codex_context_latest.txt
+
+# AGENTS.md — HawkinsOperations (Codex instructions)
+
+## Project identity
+- Purpose: evidence-first SOC portfolio for job hunting
+- Target roles: Primary SOC Analyst (T1/T2); Secondary junior detection + automation
+- Clearance line (use verbatim everywhere): “Eligible to obtain clearance; willing to pursue sponsorship.”
+
+## Environment constraints
+- Windows 11 + Linux Mint dual-boot
+- When giving commands:
+  - Prefer PowerShell (`pwsh`) for verification scripts and Windows workflows
+  - Use fish-compatible syntax on Linux (avoid bashisms)
+- Deployment: Netlify auto-deploys from `main`
+- Site publish directory is `site/` (static HTML/CSS/JS, no framework)
+
+## Source of truth (numbers)
+- All public numbers MUST match `PROOF_PACK/VERIFIED_COUNTS.md`
+- Never use “200+ detections” or any inflated claims
+- Never change counts unless verification passes and the source-of-truth file is updated
+
+## Files you must not break
+- `PROOF_PACK/VERIFIED_COUNTS.md`
+- `START_HERE.md`
+- `README.md`
+- `site/index.html`
+- `scripts/verify/verify-counts.ps1`
+- `netlify.toml`
+
+## Netlify guardrails
+- `netlify.toml` must keep `publish = "site"`
+- `site/_redirects` supports pretty URLs (`/security -> /security.html`, etc.)
+- `site/_headers` exists (security headers)
+- `site/404.html` exists (custom 404)
+- Resume PDF must exist at: `site/assets/Raylee_Hawkins_Resume.pdf`
+- Resume link must be: `/assets/Raylee_Hawkins_Resume.pdf` (absolute path)
+
+## Standard workflow (no vibes)
+1) Check repo state first (`git status`, recent commits/PR context if relevant)
+2) Make smallest change that satisfies the requested phase
+3) Run verification + local test before calling it “done”
+4) Keep diffs small; do not add dependencies unless explicitly requested
+5) Never print or commit secrets/tokens
+
+## Verification / local test
+- Verify counts:
+  - `pwsh -File scripts/verify/verify-counts.ps1`
+- Serve site locally:
+  - `python -m http.server --directory site 8000`
+- Minimum click-test paths:
+  - `/`, `/security`, `/projects`, `/resume` (PDF download), `/proof`, `/lab`, `/triage`

--- a/site/_redirects
+++ b/site/_redirects
@@ -6,3 +6,5 @@
 /triage /triage.html 200
 /case-study /case-study.html 200
 /blog-python2-to-python3 /blog-python2-to-python3.html 200
+/Raylee_Hawkins_Resume.pdf /assets/Raylee_Hawkins_Resume.pdf 301
+/assets/raylee_hawkins_resume.pdf /assets/Raylee_Hawkins_Resume.pdf 301

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -6,6 +6,30 @@
 (function () {
   const $ = (sel, root=document) => root.querySelector(sel);
   const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+  const html = document.documentElement;
+
+  // Theme toggle (dark default, persisted preference)
+  const themeToggle = $('#themeToggle');
+  const savedTheme = localStorage.getItem('rh-theme');
+  const startTheme = savedTheme || 'dark';
+  html.setAttribute('data-theme', startTheme);
+
+  function updateThemeButton(theme) {
+    if (!themeToggle) return;
+    const next = theme === 'dark' ? 'light' : 'dark';
+    themeToggle.textContent = theme === 'dark' ? 'Light' : 'Dark';
+    themeToggle.setAttribute('aria-label', `Switch to ${next} mode`);
+  }
+  updateThemeButton(startTheme);
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const current = html.getAttribute('data-theme') || 'dark';
+      const next = current === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', next);
+      localStorage.setItem('rh-theme', next);
+      updateThemeButton(next);
+    });
+  }
 
   // Mobile nav
   const mobBtn = $('#mobBtn');

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -12,7 +12,7 @@
             --sans:'Space Grotesk','Segoe UI',sans-serif;
         }
         html{scroll-behavior:smooth}
-        body{font-family:var(--sans);background:radial-gradient(980px 440px at 90% -10%,rgba(255,158,205,.16),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(123,153,255,.12),transparent 72%),var(--bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+        body{font-family:var(--sans);background:radial-gradient(980px 440px at 90% -10%,rgba(255,158,205,.16),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(123,153,255,.12),transparent 72%),linear-gradient(180deg,#090d17 0%, #0b1020 50%, #0c1324 100%);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
         body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(255,255,255,.012) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.012) 1px,transparent 1px);background-size:64px 64px;pointer-events:none;z-index:0}
         .ctr{max-width:1200px;margin:0 auto;padding:0 24px;position:relative;z-index:1}
         a{color:var(--acc2);text-underline-offset:3px;text-decoration-thickness:1px}
@@ -36,19 +36,19 @@
         .theme-btn:hover{border-color:#ff9ecd;box-shadow:0 0 0 3px rgba(255,158,205,.15)}
 
         /* HERO */
-        .hero{min-height:90vh;display:flex;align-items:center;padding-top:68px;position:relative;overflow:hidden}
+        .hero{min-height:88vh;display:flex;align-items:center;padding-top:74px;position:relative;overflow:hidden}
         .hero-glow{position:absolute;width:360px;height:360px;border-radius:50%;background:radial-gradient(circle,rgba(255,158,205,.22) 0%,transparent 70%);top:-70px;right:-80px;pointer-events:none;animation:gp 8s ease-in-out infinite}
         @keyframes gp{0%,100%{opacity:.4;transform:scale(1)}50%{opacity:.65;transform:scale(1.06)}}
         .particles{position:absolute;inset:0;overflow:hidden;pointer-events:none}
         .particle{position:absolute;background:var(--acc);border-radius:50%;opacity:.2;animation:fu linear infinite}
         @keyframes fu{0%{transform:translateY(100vh);opacity:0}10%{opacity:.2}90%{opacity:.2}100%{transform:translateY(-60px);opacity:0}}
         .hero-c{max-width:700px;position:relative;z-index:2}
-        .hero-panel{max-width:760px;padding:34px 34px 28px;background:linear-gradient(145deg,rgba(23,28,43,.86),rgba(28,35,54,.93));border:1px solid var(--bdr2);border-radius:26px;box-shadow:0 16px 34px rgba(255,158,205,.16)}
+        .hero-panel{max-width:760px;padding:36px 38px 30px;background:linear-gradient(145deg,rgba(23,28,43,.86),rgba(28,35,54,.93));border:1px solid var(--bdr2);border-radius:26px;box-shadow:0 16px 34px rgba(255,158,205,.16),inset 0 1px 0 rgba(255,255,255,.06)}
         .htag{font-family:var(--mono);font-size:.7rem;color:var(--acc);letter-spacing:.15em;text-transform:uppercase;margin-bottom:16px;display:flex;align-items:center;gap:10px}
         .htag::before{content:'';width:32px;height:1px;background:var(--acc)}
-        .htitle{font-size:clamp(2rem,5vw,3.5rem);font-weight:800;line-height:1.08;letter-spacing:-.03em;margin-bottom:18px}
+        .htitle{font-size:clamp(2.2rem,5.1vw,3.9rem);font-weight:800;line-height:1.04;letter-spacing:-.03em;margin-bottom:14px}
         .htitle .hl{background:linear-gradient(135deg,var(--acc),var(--acc2));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
-        .hsub{font-size:1.05rem;color:var(--dim);max-width:520px;margin-bottom:10px;line-height:1.6}
+        .hsub{font-size:1.07rem;color:var(--dim);max-width:62ch;margin-bottom:14px;line-height:1.68}
         .hproof{font-family:var(--mono);font-size:.8rem;color:var(--txt);margin-bottom:18px;line-height:1.8}
         .hproof b{color:var(--acc);font-weight:600}
         .hero-pills{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 18px}
@@ -75,27 +75,28 @@
         .met-l{font-size:.68rem;color:var(--dim);text-transform:uppercase;letter-spacing:.07em}
 
         /* SECTIONS */
-        section{padding:80px 0;position:relative}
+        section{padding:72px 0;position:relative}
         .slbl{font-family:var(--mono);font-size:.66rem;color:var(--acc);letter-spacing:.15em;text-transform:uppercase;margin-bottom:8px;display:flex;align-items:center;gap:8px}
         .slbl::before{content:'//';color:var(--faint)}
-        .stitle{font-size:1.9rem;font-weight:700;letter-spacing:-.02em;margin-bottom:10px}
-        .sdesc{font-size:.92rem;color:var(--dim);max-width:560px;margin-bottom:36px}
+        .stitle{font-size:1.95rem;font-weight:700;letter-spacing:-.02em;margin-bottom:12px;line-height:1.18}
+        .sdesc{font-size:.95rem;color:var(--dim);max-width:62ch;margin-bottom:30px;line-height:1.72}
         .divider{height:1px;background:linear-gradient(90deg,transparent,var(--bdr2),transparent);max-width:800px;margin:0 auto}
 
         /* CARDS - clickable */
-        .card{background:var(--bg2);border:1px solid var(--bdr);padding:24px;transition:all .25s;cursor:pointer;position:relative;color:var(--txt)}
-        .card:hover{border-color:var(--acc);transform:translateY(-2px);box-shadow:0 8px 28px rgba(255,62,165,.11)}
+        .card{background:var(--bg2);border:1px solid var(--bdr);padding:24px;transition:all .24s ease;cursor:pointer;position:relative;color:var(--txt);border-radius:16px}
+        .card:hover{border-color:var(--acc);transform:translateY(-2px);box-shadow:0 10px 26px rgba(255,62,165,.14)}
         .card-click{position:absolute;top:10px;right:12px;font-family:var(--mono);font-size:.6rem;color:var(--faint);opacity:0;transition:opacity .2s}
         .card:hover .card-click{opacity:1}
         .tools-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
-        .tool-badge{display:flex;align-items:center;gap:10px;padding:12px 14px;border:1px solid var(--bdr);background:linear-gradient(145deg,rgba(29,34,54,.88),rgba(24,30,48,.92));border-radius:14px}
+        .tool-badge{display:flex;align-items:center;gap:10px;padding:12px 14px;border:1px solid var(--bdr);background:linear-gradient(145deg,rgba(29,34,54,.88),rgba(24,30,48,.92));border-radius:14px;transition:transform .22s ease,border-color .22s ease,box-shadow .22s ease}
+        .tool-badge:hover{border-color:var(--acc);transform:translateY(-1px);box-shadow:0 8px 16px rgba(255,158,205,.12)}
         .tool-glyph{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:8px;background:rgba(255,158,205,.2);color:var(--acc);font-family:var(--mono);font-size:.62rem;font-weight:700;letter-spacing:.02em;flex:0 0 28px}
         .tool-badge b{font-size:.82rem}
         .tool-badge span{display:block;color:var(--dim);font-size:.72rem}
 
         /* GRIDS */
-        .g3{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
-        .g2{display:grid;grid-template-columns:repeat(2,1fr);gap:14px}
+        .g3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+        .g2{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}
         .g-auto{display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:10px}
         .g-mitre{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:3px}
 
@@ -188,7 +189,7 @@
         .cl{font-family:var(--mono);font-size:.72rem;color:var(--acc);text-decoration:none}
         .cl:hover{text-decoration:underline}
 
-        footer{padding:36px 0;border-top:1px solid var(--bdr);text-align:center}
+        footer{padding:44px 0;border-top:1px solid var(--bdr);text-align:center}
         footer p{font-size:.75rem;color:var(--faint)}
         .fl{display:flex;justify-content:center;gap:20px;margin-top:10px}
         .fl a{font-family:var(--mono);font-size:.7rem;color:var(--dim);text-decoration:none}
@@ -210,7 +211,7 @@
         .fstat strong{color:var(--acc)}
 
         @media(max-width:900px){.g3,.g2{grid-template-columns:1fr}.mstrip{grid-template-columns:repeat(3,1fr)}}
-        @media(max-width:640px){.nav-l{display:none}.nav-l.open{display:flex;flex-direction:column;position:absolute;top:60px;left:0;right:0;background:var(--bg);border-bottom:1px solid var(--bdr);padding:20px;gap:16px}.mob-btn{display:block}.mstrip{grid-template-columns:repeat(2,1fr)}.htitle{font-size:1.8rem}section{padding:52px 0}}
+        @media(max-width:640px){.nav-l{display:none}.nav-l.open{display:flex;flex-direction:column;position:absolute;top:60px;left:0;right:0;background:var(--bg);border-bottom:1px solid var(--bdr);padding:20px;gap:16px}.mob-btn{display:block}.mstrip{grid-template-columns:repeat(2,1fr)}.hero-panel{padding:24px 18px 20px;border-radius:20px}.htitle{font-size:2rem}section{padding:54px 0}}
     
 
 /* v3 additions (non-React pages) */

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,10 +1,10 @@
 
         *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
         :root{
-            --bg:#07070b;--bg1:#151826;--bg2:#1a1f2f;--bg3:#22293b;
-            --bdr:#272b3a;--bdr2:#373d52;
-            --txt:#f7f8fb;--dim:#c7cfdf;--faint:#a3aec4;
-            --acc:#ff3ea5;--acc2:#ff86c7;--acc-d:rgba(255,62,165,.11);--acc-g:rgba(255,62,165,.2);
+            --bg:#090b13;--bg1:#151a2b;--bg2:#1b2236;--bg3:#24304a;
+            --bdr:#344262;--bdr2:#4a5e89;
+            --txt:#f7f9ff;--dim:#d7e0f4;--faint:#acbbdc;
+            --acc:#ff9ecd;--acc2:#ffd1dc;--acc-d:rgba(255,158,205,.14);--acc-g:rgba(255,158,205,.24);
             --red:#ff3b5c;--red-d:rgba(255,59,92,.1);
             --amb:#ffb020;--amb-d:rgba(255,176,32,.1);
             --blu:#3b82f6;--pur:#a78bfa;
@@ -12,7 +12,7 @@
             --sans:'Space Grotesk','Segoe UI',sans-serif;
         }
         html{scroll-behavior:smooth}
-        body{font-family:var(--sans);background:radial-gradient(1000px 500px at 90% -10%,rgba(255,62,165,.08),transparent 70%),radial-gradient(900px 450px at -20% 115%,rgba(255,62,165,.06),transparent 70%),var(--bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+        body{font-family:var(--sans);background:radial-gradient(980px 440px at 90% -10%,rgba(255,158,205,.16),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(123,153,255,.12),transparent 72%),var(--bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
         body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(255,255,255,.012) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.012) 1px,transparent 1px);background-size:64px 64px;pointer-events:none;z-index:0}
         .ctr{max-width:1200px;margin:0 auto;padding:0 24px;position:relative;z-index:1}
         a{color:var(--acc2);text-underline-offset:3px;text-decoration-thickness:1px}
@@ -22,35 +22,41 @@
         }
 
         /* NAV */
-        nav{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(6,8,12,.9);backdrop-filter:blur(20px);border-bottom:1px solid var(--bdr)}
+        nav{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(8,12,20,.88);backdrop-filter:blur(20px);border-bottom:1px solid var(--bdr)}
         .nav-i{max-width:1200px;margin:0 auto;padding:0 24px;display:flex;justify-content:space-between;align-items:center;height:60px}
-        .logo{font-family:var(--sans);font-size:1rem;font-weight:700;letter-spacing:.02em;color:var(--txt);text-decoration:none;cursor:pointer}
+        .logo{font-family:var(--sans);font-size:1rem;font-weight:700;letter-spacing:.02em;color:var(--txt);text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:8px}
         .logo b{color:var(--acc)}
+        .logo-monogram{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:var(--acc);color:#171b29;font-family:var(--mono);font-size:.72rem;font-weight:700}
         .nav-l{display:flex;gap:24px;list-style:none;align-items:center}
         .nav-l a{font-family:var(--mono);font-size:.72rem;color:var(--dim);text-decoration:none;cursor:pointer;transition:color .2s,background .2s,border-color .2s;letter-spacing:.03em;padding:6px 10px;border-radius:999px;border:1px solid transparent}
         .nav-l a:hover{color:var(--acc);background:rgba(255,62,165,.08)}
         .nav-l a.act,.nav-l a[aria-current='page']{color:var(--txt);background:rgba(255,62,165,.18);border-color:rgba(255,62,165,.4);box-shadow:inset 0 -1px 0 rgba(255,143,203,.5)}
         .mob-btn{display:none;background:none;border:1px solid var(--bdr);color:var(--txt);padding:6px 10px;font-family:var(--mono);font-size:.72rem;cursor:pointer}
+        .theme-btn{background:var(--bg2);color:var(--txt);border:1px solid var(--bdr2);padding:7px 10px;border-radius:999px;font-family:var(--mono);font-size:.68rem;cursor:pointer;transition:all .2s}
+        .theme-btn:hover{border-color:#ff9ecd;box-shadow:0 0 0 3px rgba(255,158,205,.15)}
 
         /* HERO */
-        .hero{min-height:100vh;display:flex;align-items:center;padding-top:60px;position:relative;overflow:hidden}
-        .hero-glow{position:absolute;width:600px;height:600px;border-radius:50%;background:radial-gradient(circle,rgba(255,62,165,.1) 0%,transparent 70%);top:-100px;right:-100px;pointer-events:none;animation:gp 8s ease-in-out infinite}
+        .hero{min-height:90vh;display:flex;align-items:center;padding-top:68px;position:relative;overflow:hidden}
+        .hero-glow{position:absolute;width:360px;height:360px;border-radius:50%;background:radial-gradient(circle,rgba(255,158,205,.22) 0%,transparent 70%);top:-70px;right:-80px;pointer-events:none;animation:gp 8s ease-in-out infinite}
         @keyframes gp{0%,100%{opacity:.4;transform:scale(1)}50%{opacity:.65;transform:scale(1.06)}}
         .particles{position:absolute;inset:0;overflow:hidden;pointer-events:none}
         .particle{position:absolute;background:var(--acc);border-radius:50%;opacity:.2;animation:fu linear infinite}
         @keyframes fu{0%{transform:translateY(100vh);opacity:0}10%{opacity:.2}90%{opacity:.2}100%{transform:translateY(-60px);opacity:0}}
         .hero-c{max-width:700px;position:relative;z-index:2}
+        .hero-panel{max-width:760px;padding:34px 34px 28px;background:linear-gradient(145deg,rgba(23,28,43,.86),rgba(28,35,54,.93));border:1px solid var(--bdr2);border-radius:26px;box-shadow:0 16px 34px rgba(255,158,205,.16)}
         .htag{font-family:var(--mono);font-size:.7rem;color:var(--acc);letter-spacing:.15em;text-transform:uppercase;margin-bottom:16px;display:flex;align-items:center;gap:10px}
         .htag::before{content:'';width:32px;height:1px;background:var(--acc)}
         .htitle{font-size:clamp(2rem,5vw,3.5rem);font-weight:800;line-height:1.08;letter-spacing:-.03em;margin-bottom:18px}
         .htitle .hl{background:linear-gradient(135deg,var(--acc),var(--acc2));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
         .hsub{font-size:1.05rem;color:var(--dim);max-width:520px;margin-bottom:10px;line-height:1.6}
-        .hproof{font-family:var(--mono);font-size:.8rem;color:var(--txt);margin-bottom:28px;line-height:1.8}
+        .hproof{font-family:var(--mono);font-size:.8rem;color:var(--txt);margin-bottom:18px;line-height:1.8}
         .hproof b{color:var(--acc);font-weight:600}
+        .hero-pills{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 18px}
+        .proof-pill{display:inline-flex;align-items:center;padding:7px 12px;border:1px solid var(--bdr2);background:var(--bg1);border-radius:999px;font-family:var(--mono);font-size:.67rem;color:var(--dim)}
         .hctas{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px}
         .btn{display:inline-flex;align-items:center;gap:6px;padding:12px 22px;font-family:var(--mono);font-size:.78rem;font-weight:600;text-decoration:none;border:none;cursor:pointer;transition:all .25s;letter-spacing:.02em}
         .btn-p{background:var(--acc);color:var(--bg)}
-        .btn-p:hover{box-shadow:0 0 20px rgba(255,62,165,.28);transform:translateY(-2px)}
+        .btn-p:hover{box-shadow:0 0 0 3px rgba(255,158,205,.14),0 10px 18px rgba(255,158,205,.2);transform:translateY(-2px)}
         .btn-g{background:transparent;color:var(--txt);border:1px solid var(--bdr2)}
         .btn-g:hover{border-color:var(--acc);color:var(--acc)}
         .roles{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:18px}
@@ -81,6 +87,11 @@
         .card:hover{border-color:var(--acc);transform:translateY(-2px);box-shadow:0 8px 28px rgba(255,62,165,.11)}
         .card-click{position:absolute;top:10px;right:12px;font-family:var(--mono);font-size:.6rem;color:var(--faint);opacity:0;transition:opacity .2s}
         .card:hover .card-click{opacity:1}
+        .tools-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
+        .tool-badge{display:flex;align-items:center;gap:10px;padding:12px 14px;border:1px solid var(--bdr);background:linear-gradient(145deg,rgba(29,34,54,.88),rgba(24,30,48,.92));border-radius:14px}
+        .tool-glyph{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:8px;background:rgba(255,158,205,.2);color:var(--acc);font-family:var(--mono);font-size:.62rem;font-weight:700;letter-spacing:.02em;flex:0 0 28px}
+        .tool-badge b{font-size:.82rem}
+        .tool-badge span{display:block;color:var(--dim);font-size:.72rem}
 
         /* GRIDS */
         .g3{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}

--- a/site/index.html
+++ b/site/index.html
@@ -119,10 +119,10 @@
     <div class="slbl">Tools</div>
     <h2 class="stitle">Platform fluency at a glance</h2>
     <div class="tools-grid">
-      <div class="tool-badge"><img src="assets/badges/wazuh.svg" alt="Wazuh"><div><b>Wazuh</b><span>Rule blocks + validation</span></div></div>
-      <div class="tool-badge"><img src="assets/badges/splunk.svg" alt="Splunk"><div><b>Splunk</b><span>SPL detections and pivots</span></div></div>
-      <div class="tool-badge"><img src="assets/badges/sigma.svg" alt="Sigma"><div><b>Sigma</b><span>Portable detection rules</span></div></div>
-      <div class="tool-badge"><img src="assets/badges/automation.svg" alt="Automation tooling"><div><b>Automation</b><span>Tines/Torq-ready workflow mindset</span></div></div>
+      <div class="tool-badge"><span class="tool-glyph" aria-hidden="true">W</span><div><b>Wazuh</b><span>Rule blocks + validation</span></div></div>
+      <div class="tool-badge"><span class="tool-glyph" aria-hidden="true">S</span><div><b>Splunk</b><span>SPL detections and pivots</span></div></div>
+      <div class="tool-badge"><span class="tool-glyph" aria-hidden="true">Sg</span><div><b>Sigma</b><span>Portable detection rules</span></div></div>
+      <div class="tool-badge"><span class="tool-glyph" aria-hidden="true">A</span><div><b>Automation</b><span>Tines/Torq-ready workflow mindset</span></div></div>
     </div>
   </div>
 </section>
@@ -257,6 +257,5 @@
 <script src="assets/app.js" defer></script>
 </body>
 </html>
-
 
 

--- a/site/resume.html
+++ b/site/resume.html
@@ -70,7 +70,7 @@
       <div class="card">
         <div class="card-ttl">Download</div>
         <div class="card-sub">
-          <a class="btn btn-p" href="assets/Raylee_Hawkins_Resume.pdf" download="Raylee_Hawkins_Resume.pdf" target="_blank" rel="noreferrer">Resume PDF</a>
+          <a class="btn btn-p" href="/assets/Raylee_Hawkins_Resume.pdf" download="Raylee_Hawkins_Resume.pdf" target="_blank" rel="noreferrer">Resume PDF</a>
           <div class="lupd">Verified deploy path: <code>/assets/Raylee_Hawkins_Resume.pdf</code>.</div>
         </div>
       </div>
@@ -155,6 +155,5 @@
 <script src="assets/app.js" defer></script>
 </body>
 </html>
-
 
 

--- a/site/resume.html
+++ b/site/resume.html
@@ -70,7 +70,7 @@
       <div class="card">
         <div class="card-ttl">Download</div>
         <div class="card-sub">
-          <a class="btn btn-p" href="/assets/Raylee_Hawkins_Resume.pdf" download="Raylee_Hawkins_Resume.pdf" target="_blank" rel="noreferrer">Resume PDF</a>
+          <a class="btn btn-p" href="assets/Raylee_Hawkins_Resume.pdf" download="Raylee_Hawkins_Resume.pdf" target="_blank" rel="noreferrer">Resume PDF</a>
           <div class="lupd">Verified deploy path: <code>/assets/Raylee_Hawkins_Resume.pdf</code>.</div>
         </div>
       </div>
@@ -155,7 +155,6 @@
 <script src="assets/app.js" defer></script>
 </body>
 </html>
-
 
 
 


### PR DESCRIPTION
## What this fixes
- removes oversized tool image cards on homepage and replaces them with compact glyph chips
- keeps dark aesthetic, but increases text readability and adds stronger gradient atmosphere
- restores working theme toggle with dark default
- fixes resume PDF link behavior and adds resilient redirects for common resume URL variants

## Technical changes
- site/index.html: replaced tool logo image blocks with compact text/glyph badges
- site/assets/styles.css: brighter dark palette + gradient polish + tool badge styles + hero panel styles
- site/assets/app.js: theme toggle logic with persistence (localStorage), dark default
- site/resume.html: switched resume PDF href to relative ssets/Raylee_Hawkins_Resume.pdf
- site/_redirects: added /Raylee_Hawkins_Resume.pdf and lowercase alias redirects to /assets/Raylee_Hawkins_Resume.pdf

## Verification
- counts unchanged in homepage (142 detections, 10 IR playbooks)
- local server checks return 200 for /, /resume.html, and /assets/Raylee_Hawkins_Resume.pdf
