### PR TITLE
docs: add deferred Phase 5 external profile plan (doc-only)

### DIFF
--- a/PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/RESULTS.md
+++ b/PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/RESULTS.md
@@ -1,0 +1,19 @@
+# Phase 5 Deferred External Profile Doc Run Results
+
+Run: run_02-14-2026_004705
+Date: 2026-02-14 00:47:05
+
+## Requirement Checks
+
+- [PASS] Created docs/deferred/PHASE_5_EXTERNAL_PROFILE.md.
+- [PASS] Populated deferred doc with preserved Phase 5 task text verbatim from the locally preserved Phase source text referencing proxmox instructions.
+- [PASS] Added required header sentence to deferred doc.
+- [PASS] Added clearly marked DEFERRED checklist section.
+- [PASS] Added/updated docs/execution/PHASE_5_DEFERRED_EXTERNAL_PROFILE.md summarizing what was created and why.
+- [PASS] No LinkedIn, GitHub profile, resume content, or external-system edits/actions were performed in this run (repo-only docs changes).
+- [PASS] Evidence logs captured under evidence/logs/ (git status + file tree snippet).
+- [PASS] Repo build/deploy configuration unchanged (docs-only diff).
+
+## Notes
+
+- Source text for preserved Phase 5 block was taken from the locally preserved Phase plan text that references proxmox Phase 5 instructions.

--- a/PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/evidence/logs/file-tree-snippet.txt
+++ b/PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/evidence/logs/file-tree-snippet.txt
@@ -1,0 +1,6 @@
+
+FullName
+--------
+C:\RH\OPS\PUBLISH\GITHUB\repos\HawkinsOperations\docs\deferred\PHASE_5_EXTERNAL_PROFILE.md
+C:\RH\OPS\PUBLISH\GITHUB\repos\HawkinsOperations\docs\execution\PHASE_5_DEFERRED_EXTERNAL_PROFILE.md
+

--- a/PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/evidence/logs/git-status.txt
+++ b/PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/evidence/logs/git-status.txt
@@ -1,0 +1,14 @@
+On branch ops/resume-ats-txt-endpoint
+Your branch is up to date with 'origin/ops/resume-ats-txt-endpoint'.
+
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   START_HERE.md
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	docs/deferred/
+	docs/execution/PHASE_5_DEFERRED_EXTERNAL_PROFILE.md
+
+no changes added to commit (use "git add" and/or "git commit -a")

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -29,3 +29,4 @@ Expected:
 
 - This repository is evidence-first: claims are backed by reproducible commands.
 - `PROOF_PACK/` is the curated review lane; raw imports and legacy material are not part of the front-door proof path.
+- Phase execution notes: `docs/execution/PHASE_1_COUNT_RECON.md`, `docs/execution/PHASE4_RESUME_ATS_TXT_ENDPOINT.md`, `docs/execution/PHASE_5_DEFERRED_EXTERNAL_PROFILE.md`

--- a/docs/deferred/PHASE_5_EXTERNAL_PROFILE.md
+++ b/docs/deferred/PHASE_5_EXTERNAL_PROFILE.md
@@ -1,0 +1,28 @@
+# PHASE 5 EXTERNAL PROFILE (DEFERRED)
+
+This phase is documentation only; no external profile edits performed.
+
+## Verbatim Phase 5 Tasks (Preserved)
+
+```text
+#### PHASE 5: LinkedIn Optimization
+
+* **LinkedIn upgrades deferred to next prompt.**
+```
+
+```text
+Phase 5 — Deferred External Profile Work
+Create a repo doc that preserves the Phase 5 tasks from proxmox.txt (verbatim) without executing them: docs/deferred/PHASE_5_EXTERNAL_PROFILE.md
+Gate: this phase produces documentation only.
+DoD:
+Deferred doc exists
+No external edits performed in this run
+```
+
+## DEFERRED Checklist (Future Execution)
+
+- [ ] DEFERRED: Confirm external profile execution scope from proxmox source before any action.
+- [ ] DEFERRED: Perform LinkedIn optimization tasks externally (not in this repo).
+- [ ] DEFERRED: Record externally executed changes in a new follow-up evidence run.
+- [ ] DEFERRED: Re-validate that no secrets/internal identifiers are introduced into repo artifacts.
+

--- a/docs/execution/PHASE_5_DEFERRED_EXTERNAL_PROFILE.md
+++ b/docs/execution/PHASE_5_DEFERRED_EXTERNAL_PROFILE.md
@@ -1,0 +1,19 @@
+# PHASE 5 Deferred External Profile Execution Note
+
+## Summary
+
+- Created `docs/deferred/PHASE_5_EXTERNAL_PROFILE.md`.
+- Preserved the available Phase 5 text verbatim in that file.
+- Added a clearly marked `DEFERRED` checklist for future external execution.
+
+## Why This Exists
+
+Phase 5 is explicitly documentation-only in this run. The purpose is to preserve external profile work instructions without executing LinkedIn/GitHub/resume/external-system changes from this repository workflow.
+
+## Scope Guardrails Applied
+
+- No LinkedIn edits performed.
+- No GitHub profile edits performed.
+- No resume content edits performed.
+- No external systems accessed or changed.
+


### PR DESCRIPTION
## Summary
This PR is **documentation only** for Phase 5 (Deferred External Profile Work).

### Added
- docs/deferred/PHASE_5_EXTERNAL_PROFILE.md
- docs/execution/PHASE_5_DEFERRED_EXTERNAL_PROFILE.md
- PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/RESULTS.md
- PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/evidence/logs/git-status.txt
- PROOF_PACK/features/phase5-external-profile-doc/run_02-14-2026_004705/evidence/logs/file-tree-snippet.txt

### Explicitly NOT done
- LinkedIn profile edits
- GitHub profile edits
- Resume content edits
- Any external-system changes

### Validation
- Deferred doc and execution summary doc created
- DEFERRED checklist included
- Evidence artifacts captured under the requested proof-pack path
- Docs-only changes; repo build/deploy behavior unchanged