### PR TITLE
docs: Phase 6A lab infra validation scaffolding (repo-first, redacted)

### DIFF
--- a/PROOF_PACK/PROOF_INDEX.md
+++ b/PROOF_PACK/PROOF_INDEX.md
@@ -7,6 +7,7 @@ Curated reviewer lane for this repository.
 - `PROOF_PACK/VERIFIED_COUNTS.md`
 - `PROOF_PACK/ARCHITECTURE.md`
 - `PROOF_PACK/EVIDENCE_CHECKLIST.md`
+- `PROOF_PACK/REDACTION_RULES.md`
 - `PROOF_PACK/SAMPLES/`
 - `PROOF_PACK/EVIDENCE/`
 
@@ -21,3 +22,4 @@ Curated reviewer lane for this repository.
 ## Additional Evidence Sets
 
 - `PROOF_PACK/EVIDENCE/openclaw_docker_vm102_2026-02-11/`
+- `PROOF_PACK/features/phase6a-infra-validation-doc/`

--- a/PROOF_PACK/REDACTION_RULES.md
+++ b/PROOF_PACK/REDACTION_RULES.md
@@ -1,0 +1,62 @@
+# Redaction Rules
+
+Use these rules for any file, screenshot, log, or diagram committed as evidence.
+
+## Redact These Values
+
+- Internal IP addresses (IPv4/IPv6)
+- Internal hostnames and FQDNs
+- Email addresses
+- Real user names and account IDs
+- API keys, bearer tokens, passwords, secrets
+- SSH keys and certificates
+- Device serial numbers and asset tags
+- VM IDs tied to internal inventory
+- Repository or service URLs containing private tenant/project names
+
+## Replacement Patterns
+
+- Secrets: `[REDACTED]`
+- Internal infrastructure identifiers: `[REDACTED_INTERNAL]`
+- Example domains: `example.local`
+- Example addresses: `10.0.0.10`, `10.0.0.20` only if synthetic and documented as synthetic
+- Example users: `analyst01`, `admin01`
+
+## Examples
+
+### Logs
+
+- Before: `ssh admin@host.internal.local`
+- After: `ssh admin01@[REDACTED_INTERNAL_HOST]`
+
+- Before: `token=ghp_xxxxxxxxxxxxxxxxxxxx`
+- After: `token=[REDACTED]`
+
+### Screenshots
+
+- Blur or mask:
+  - Browser address bar
+  - Sidebar host inventory names
+  - IP columns
+  - User profile/email elements
+
+### Config Files
+
+- Before:
+  - `api_url = "https://tenant.internal.local"`
+  - `api_key = "abc123..."`
+- After:
+  - `api_url = "https://[REDACTED_INTERNAL]"`
+  - `api_key = "[REDACTED]"`
+
+## Verification Command Examples
+
+Run from repo root before commit:
+
+```powershell
+rg -n -i "(password|token|secret|api[_-]?key|client[_-]?secret|bearer\\s+[A-Za-z0-9._-]+)" .
+rg -n -i "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}" .
+rg -n -i "(\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b)" .
+```
+
+If a result is not clearly synthetic, redact before push.

--- a/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/RESULTS.md
+++ b/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/RESULTS.md
@@ -1,0 +1,18 @@
+# Phase 6A Infra Validation Doc Run Results
+
+Run: run_02-14-2026_010351
+Date: 2026-02-14 01:03:51
+
+## Acceptance Criteria Checks
+
+- [PASS] AC1: `projects/lab/README.md` exists with sanitized inventory structure and no internal identifiers.
+- [PASS] AC2: Explicit redaction rules exist in `PROOF_PACK/REDACTION_RULES.md` and are referenced from `projects/lab/README.md`.
+- [PASS] AC3: `docs/execution/PHASE_6A_INFRA_VALIDATION.md` exists and states doc-only execution with non-executed actions.
+- [PASS] AC4: Evidence folder exists with `RESULTS.md`, `evidence/logs/git-status.txt`, and `evidence/logs/file-tree-snippet.txt`.
+- [PASS] AC5: Changes are repo-safe and documentation/scaffolding only; no secrets or unredacted screenshots committed.
+
+## Truthful Status
+
+- Phase 6A in this run is documentation and scaffolding only.
+- No infrastructure actions were executed.
+- No external system changes were made.

--- a/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/evidence/logs/file-tree-snippet.txt
+++ b/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/evidence/logs/file-tree-snippet.txt
@@ -1,0 +1,5 @@
+
+FullName
+--------
+C:\RH\OPS\PUBLISH\GITHUB\repos\HawkinsOperations\projects\lab\README.md
+

--- a/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/evidence/logs/git-status.txt
+++ b/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/evidence/logs/git-status.txt
@@ -1,0 +1,16 @@
+On branch phase6a-infra-validation-doc
+Your branch is up to date with 'origin/main'.
+
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   PROOF_PACK/PROOF_INDEX.md
+	modified:   START_HERE.md
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	PROOF_PACK/REDACTION_RULES.md
+	docs/execution/PHASE_6A_INFRA_VALIDATION.md
+	projects/lab/
+
+no changes added to commit (use "git add" and/or "git commit -a")

--- a/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/evidence/screenshots/README.md
+++ b/PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/evidence/screenshots/README.md
@@ -1,0 +1,4 @@
+# Screenshots (Redacted Only)
+
+Store only sanitized screenshots in this folder.
+If no screenshots were captured for a doc-only run, keep this file as a placeholder.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -29,3 +29,4 @@ Expected:
 
 - This repository is evidence-first: claims are backed by reproducible commands.
 - `PROOF_PACK/` is the curated review lane; raw imports and legacy material are not part of the front-door proof path.
+- Phase 6A docs: `projects/lab/README.md`, `docs/execution/PHASE_6A_INFRA_VALIDATION.md`, `PROOF_PACK/REDACTION_RULES.md`

--- a/docs/execution/PHASE_6A_INFRA_VALIDATION.md
+++ b/docs/execution/PHASE_6A_INFRA_VALIDATION.md
@@ -1,0 +1,33 @@
+# Phase 6A Infra Validation (Doc-Only)
+
+## Summary
+
+Phase 6A was implemented as repo-first documentation and scaffolding only.
+
+Created:
+
+- `projects/lab/README.md`
+- `PROOF_PACK/REDACTION_RULES.md`
+- `PROOF_PACK/features/phase6a-infra-validation-doc/run_MM-DD-YYYY_HHMMSS/` run evidence
+
+## What Was Not Executed
+
+- No hypervisor changes
+- No VM create/update/delete actions
+- No Terraform apply/destroy
+- No agent enrollment or endpoint config changes
+- No external system updates
+
+## Evidence Produced
+
+- Run results file with acceptance criteria checks
+- Git status log
+- File tree snippet
+- Screenshot folder scaffold restricted to redacted artifacts only
+
+## Safety and Redaction
+
+All Phase 6A artifacts are sanitized and must follow:
+
+- `PROOF_PACK/REDACTION_RULES.md`
+- `PROOF_PACK/EVIDENCE_CHECKLIST.md`

--- a/projects/lab/README.md
+++ b/projects/lab/README.md
@@ -1,0 +1,70 @@
+# Lab Automation and Detection Validation (Phase 6A)
+
+## Scope
+
+This document is repo-first scaffolding for Phase 6A infra validation.
+It inventories the lab at a sanitized level only and does not execute infra changes.
+
+## Redaction Requirement
+
+Before publishing any evidence for this lab, apply:
+
+- `PROOF_PACK/REDACTION_RULES.md`
+- `PROOF_PACK/EVIDENCE_CHECKLIST.md`
+
+## Sanitized Environment Inventory
+
+Use this structure for evidence and runbooks. Keep all identifiers redacted.
+
+### Control Plane
+
+- Hypervisor platform: `[REDACTED_INTERNAL_PLATFORM]`
+- Management node label: `[REDACTED_INTERNAL_HOST]`
+- Access model: VPN + SSH + web UI (all identifiers redacted)
+- Admin account references: role-based labels only (`analyst`, `admin`, `operator`)
+
+### Workload Plane
+
+- Linux validation VM: `[REDACTED_INTERNAL_VM_LINUX]`
+- Windows validation VM: `[REDACTED_INTERNAL_VM_WINDOWS]`
+- Detection test VM: `[REDACTED_INTERNAL_VM_TEST]`
+- Optional GPU-enabled VM: `[REDACTED_INTERNAL_VM_GPU]`
+
+### Tooling Inventory
+
+- SIEM/EDR stack: `[REDACTED_INTERNAL_SIEM]`
+- Rule source directories: repo paths only
+- Automation stack:
+  - IaC: `projects/lab/iac/` (templates only)
+  - Test harness: `projects/lab/testing/` (scaffold only)
+  - Evidence outputs: `PROOF_PACK/features/`
+
+### Network and Identity Rules
+
+- Never publish:
+  - IP addresses
+  - Hostnames
+  - Domain names
+  - Email addresses
+  - Usernames tied to real identity
+  - Serial numbers, asset tags, license keys
+  - Tokens, keys, secrets
+- Use placeholders:
+  - `[REDACTED_INTERNAL]`
+  - `[REDACTED]`
+  - `example.local`
+  - `10.0.0.0/24` only when clearly synthetic
+
+## What Exists in Phase 6A
+
+- Sanitized inventory and documentation scaffolding in this file
+- Redaction policy in `PROOF_PACK/REDACTION_RULES.md`
+- Execution note in `docs/execution/PHASE_6A_INFRA_VALIDATION.md`
+- Evidence run folder under `PROOF_PACK/features/phase6a-infra-validation-doc/`
+
+## What Is Not Executed in Phase 6A
+
+- No VM creation or modification
+- No Terraform apply/destroy
+- No endpoint enrollment changes
+- No external system configuration changes


### PR DESCRIPTION
## Summary
Implements **Phase 6A only** as repo-first, redacted documentation and scaffolding.

## Included in this PR
- projects/lab/README.md (sanitized lab inventory structure, no internal identifiers)
- PROOF_PACK/REDACTION_RULES.md (explicit redaction rules + examples)
- docs/execution/PHASE_6A_INFRA_VALIDATION.md (doc-only execution note)
- PROOF_PACK/features/phase6a-infra-validation-doc/run_02-14-2026_010351/
  - RESULTS.md
  - vidence/logs/git-status.txt
  - vidence/logs/file-tree-snippet.txt
  - vidence/screenshots/README.md (redacted-only placeholder)
- Link updates:
  - PROOF_PACK/PROOF_INDEX.md
  - START_HERE.md

## Acceptance Criteria Status
1. projects/lab/README.md exists with sanitized inventory and no internal identifiers: **PASS**
2. Redaction rules exist, explicit, and referenced from README: **PASS**
3. Phase 6A execution note exists and states doc-only behavior: **PASS**
4. Evidence folder exists with RESULTS.md, git-status log, and file-tree snippet: **PASS**
5. Repo-safe only changes; no secrets or unredacted screenshots: **PASS**

## Not Executed (truthful status)
- No hypervisor/VM infra actions
- No Terraform apply/destroy
- No external system modifications
- No endpoint enrollment/config changes

This PR is documentation/scaffolding only for Phase 6A.