### PR TITLE
Ship checks: browser link hardening + repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ HawkinsOperations_BACKUP_before_v1.0.1/
 
 # Local tool configuration
 .claude/
+/CLAUDE.md
+/site/assets/visual-enhance.css
 
 # Build artifacts
 dist/

--- a/site/assets/components/sections/media-gallery.js
+++ b/site/assets/components/sections/media-gallery.js
@@ -119,7 +119,7 @@ export function renderMediaGallery(root, items) {
           <img src="${esc(m.path)}" alt="${esc(m.alt)}" loading="lazy" width="${m.width || 480}" height="${m.height || 300}">
         </span>
       </button>
-      <figcaption>${esc(m.caption)}</figcaption>
+      <figcaption><span class="media-type-badge">${esc(normalizeType(m) || "proof")}</span>${esc(m.caption)}</figcaption>
     </figure>
   `).join("")}</div>${toolMarksHtml}`;
 

--- a/site/assets/design-system.css
+++ b/site/assets/design-system.css
@@ -456,7 +456,9 @@
 
 .chart-bar-link .chart-bar,
 .chart-bar-link .chart-value,
-.chart-bar-link .chart-label {
+.chart-bar-link .chart-label,
+.chart-bar-link .chart-label-left,
+.chart-bar-link .chart-value-right {
   pointer-events: none;
 }
 

--- a/site/assets/design-system.css
+++ b/site/assets/design-system.css
@@ -13,11 +13,14 @@
   --ds-border-subtle: 1px solid color-mix(in srgb, var(--bdr2), transparent 28%);
   --ds-shadow-soft: 0 12px 34px rgba(2, 11, 25, 0.28);
   --ds-shadow-focus: 0 0 0 3px rgba(103, 214, 255, 0.24);
+  --ds-shadow-glow: 0 18px 38px rgba(7, 34, 66, 0.34);
   --ease-out: cubic-bezier(0.2, 0.82, 0.3, 1);
   --ease-smooth: cubic-bezier(0.3, 0, 0.12, 1);
   --dur-fast: 140ms;
   --dur-med: 260ms;
   --dur-slow: 420ms;
+  --ds-module-pad: clamp(1rem, 1.5vw, 1.4rem);
+  --ds-grid-rail: color-mix(in srgb, var(--acc), transparent 88%);
   --ds-text-max: 72ch;
   --ds-container-max: 1360px;
   --ds-h1: clamp(2.6rem, 5.2vw, 5rem);
@@ -54,7 +57,7 @@
 
 .fluid-section {
   position: relative;
-  padding-block: clamp(3rem, 7vw, 6rem);
+  padding-block: clamp(2.4rem, 5.6vw, 4.9rem);
 }
 
 .fluid-section::before {
@@ -75,7 +78,7 @@
 
 .section-intro {
   max-width: var(--ds-text-max);
-  margin-bottom: var(--ds-space-6);
+  margin-bottom: var(--ds-space-5);
 }
 
 .section-intro p {
@@ -144,21 +147,23 @@
 }
 
 .filter-chip {
-  border: var(--ds-border-subtle);
-  background: transparent;
-  color: var(--dim);
-  border-radius: 999px;
-  padding: 0.44rem 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 40%);
+  background: linear-gradient(160deg, color-mix(in srgb, var(--bg2), transparent 8%), color-mix(in srgb, var(--bg1), transparent 2%));
+  color: var(--faint);
+  border-radius: 0.68rem;
+  padding: 0.4rem 0.68rem;
   font-family: var(--mono);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.04em;
   cursor: pointer;
+  line-height: 1.1;
+  transition: border-color var(--dur-fast) var(--ease-smooth), color var(--dur-fast) var(--ease-smooth), transform var(--dur-fast) var(--ease-out), background-color var(--dur-fast) var(--ease-smooth);
 }
 
 .filter-chip[aria-pressed="true"] {
   color: var(--txt);
-  border-color: color-mix(in srgb, var(--acc), transparent 32%);
-  background: color-mix(in srgb, var(--acc), transparent 86%);
+  border-color: color-mix(in srgb, var(--acc), transparent 24%);
+  background: color-mix(in srgb, var(--acc), transparent 82%);
 }
 
 .filter-search {
@@ -184,9 +189,9 @@
 }
 
 .listing-item {
-  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 35%);
+  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 42%);
   border-radius: var(--ds-radius-lg);
-  padding: var(--ds-space-5);
+  padding: var(--ds-module-pad);
   background: linear-gradient(160deg, rgba(14, 23, 39, 0.5), rgba(18, 29, 47, 0.56));
   backdrop-filter: blur(8px);
 }
@@ -238,7 +243,7 @@
   position: relative;
   border: 1px solid color-mix(in srgb, var(--bdr2), transparent 48%);
   border-radius: var(--ds-radius-lg);
-  padding: var(--ds-space-5);
+  padding: var(--ds-module-pad);
   background: linear-gradient(165deg, rgba(13, 22, 37, 0.64), rgba(18, 30, 49, 0.6));
   backdrop-filter: blur(8px);
   box-shadow: 0 20px 42px rgba(2, 10, 24, 0.24), inset 0 1px 0 rgba(162, 226, 255, 0.05);
@@ -262,6 +267,22 @@
   gap: var(--ds-space-5);
 }
 
+.proof-dashboard-wrap {
+  margin-top: clamp(-1.6rem, -2vw, -0.4rem);
+  padding-top: clamp(1.6rem, 3.6vw, 2.8rem);
+}
+
+.dashboard-shell {
+  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 52%);
+  border-radius: var(--ds-radius-lg);
+  padding: clamp(0.85rem, 1.4vw, 1.2rem);
+  background:
+    linear-gradient(180deg, rgba(101, 196, 238, 0.08), transparent 22%),
+    repeating-linear-gradient(90deg, var(--ds-grid-rail) 0 1px, transparent 1px 68px),
+    linear-gradient(160deg, rgba(10, 18, 33, 0.52), rgba(14, 23, 39, 0.54));
+  box-shadow: inset 0 1px 0 rgba(168, 222, 255, 0.07);
+}
+
 .dashboard-band,
 .dashboard-lower {
   display: grid;
@@ -272,6 +293,36 @@
 
 .dashboard-lower {
   grid-template-columns: 1fr 0.84fr;
+}
+
+.dashboard-status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ds-space-3);
+  margin-bottom: var(--ds-space-4);
+}
+
+.dashboard-status {
+  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 50%);
+  border-radius: 0.78rem;
+  padding: 0.55rem 0.62rem;
+  background: color-mix(in srgb, var(--bg2), transparent 7%);
+}
+
+.dashboard-status strong {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  color: var(--acc);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.18rem;
+}
+
+.dashboard-status span {
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  color: var(--dim);
 }
 
 .dashboard-kpi-grid {
@@ -319,9 +370,11 @@
 
 .dash-title {
   margin-bottom: var(--ds-space-4);
-  font-size: 1rem;
-  letter-spacing: 0.03em;
-  color: var(--txt);
+  font-size: 0.9rem;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--txt), var(--acc) 16%);
 }
 
 .chart-panel {
@@ -354,14 +407,14 @@
 }
 
 .chart-axis {
-  stroke: color-mix(in srgb, var(--faint), transparent 55%);
+  stroke: color-mix(in srgb, var(--faint), transparent 62%);
   stroke-width: 1.2;
 }
 
 .chart-label {
   fill: var(--faint);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 10px;
   letter-spacing: 0.03em;
 }
 
@@ -376,6 +429,7 @@
   stroke: color-mix(in srgb, var(--acc), transparent 70%);
   stroke-width: 1;
   filter: drop-shadow(0 8px 16px rgba(12, 58, 98, 0.3));
+  transition: transform var(--dur-fast) var(--ease-out), filter var(--dur-fast) var(--ease-smooth);
 }
 
 .chart-label-left {
@@ -414,17 +468,17 @@
 .chart-tooltip {
   position: absolute;
   z-index: 4;
-  border: var(--ds-border-subtle);
+  border: 1px solid color-mix(in srgb, var(--acc), transparent 56%);
   border-radius: var(--ds-radius-sm);
-  background: linear-gradient(160deg, rgba(8, 14, 28, 0.85), rgba(12, 20, 34, 0.88));
+  background: linear-gradient(160deg, rgba(8, 14, 28, 0.88), rgba(10, 20, 38, 0.9));
   backdrop-filter: blur(8px);
   color: var(--txt);
   font-family: var(--mono);
-  font-size: 0.68rem;
-  padding: 0.34rem 0.52rem;
+  font-size: 0.64rem;
+  padding: 0.3rem 0.48rem;
   pointer-events: none;
   max-width: 16rem;
-  box-shadow: var(--ds-shadow-soft);
+  box-shadow: var(--ds-shadow-soft), 0 0 0 1px rgba(108, 198, 245, 0.14);
 }
 
 .chart-fallback-list {
@@ -498,9 +552,23 @@
 
 .media-item figcaption {
   padding: 0.55rem 0.72rem 0.7rem;
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   font-family: var(--mono);
   color: var(--dim);
+  display: grid;
+  gap: 0.32rem;
+}
+
+.media-type-badge {
+  display: inline-flex;
+  width: fit-content;
+  border: 1px solid color-mix(in srgb, var(--acc), transparent 58%);
+  border-radius: 0.44rem;
+  padding: 0.14rem 0.34rem;
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: color-mix(in srgb, var(--acc), var(--txt) 8%);
 }
 
 .media-lightbox {
@@ -583,11 +651,20 @@
   margin-bottom: var(--ds-space-5);
   background: linear-gradient(160deg, rgba(11, 18, 31, 0.84), rgba(14, 24, 41, 0.84));
   backdrop-filter: blur(8px);
+  box-shadow: inset 0 1px 0 rgba(164, 224, 255, 0.07);
 }
 
 .filter-shell .filter-search {
   width: 100%;
   margin-bottom: var(--ds-space-3);
+}
+
+.filter-shell .filter-bar {
+  margin-bottom: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  padding-bottom: 0.16rem;
 }
 
 .security-dashboard-row {
@@ -631,7 +708,7 @@
 
 .project-proof-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: var(--ds-space-4);
 }
 
@@ -640,6 +717,34 @@
   border-radius: var(--ds-radius-md);
   padding: var(--ds-space-4);
   background: linear-gradient(160deg, rgba(14, 23, 39, 0.48), rgba(18, 29, 47, 0.52));
+}
+
+.proof-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ds-space-2);
+  margin-bottom: var(--ds-space-2);
+}
+
+.proof-pill,
+.proof-state {
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  border: var(--ds-border-subtle);
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.proof-pill {
+  color: var(--acc);
+  border-color: color-mix(in srgb, var(--acc), transparent 58%);
+}
+
+.proof-state {
+  color: var(--faint);
 }
 
 .proof-card h3 {
@@ -668,16 +773,135 @@
   text-decoration: none;
 }
 
+.proof-tech {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.32rem;
+  margin: var(--ds-space-3) 0;
+}
+
+.proof-tech span {
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  color: var(--dim);
+  border: var(--ds-border-subtle);
+  border-radius: 0.45rem;
+  padding: 0.16rem 0.45rem;
+}
+
+.proof-evidence-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-bottom: 0.34rem;
+}
+
+.proof-spark {
+  width: 100%;
+  height: 36px;
+  display: block;
+  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 58%);
+  border-radius: 0.48rem;
+  background:
+    linear-gradient(180deg, rgba(112, 199, 240, 0.08), transparent 70%),
+    repeating-linear-gradient(90deg, color-mix(in srgb, var(--acc), transparent 92%) 0 1px, transparent 1px 26px);
+  margin-bottom: var(--ds-space-3);
+}
+
+.proof-spark polyline {
+  stroke: color-mix(in srgb, var(--acc), white 18%);
+  stroke-width: 2;
+  fill: none;
+}
+
+.proof-step-track {
+  list-style: none;
+  margin: 0 0 var(--ds-space-3);
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.proof-step-track li {
+  font-family: var(--mono);
+  font-size: 0.6rem;
+  color: var(--dim);
+  border-left: 2px solid color-mix(in srgb, var(--acc), transparent 52%);
+  padding-left: 0.5rem;
+}
+
+.project-ops-rail {
+  margin-bottom: var(--ds-space-5);
+}
+
+.ops-step-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--ds-space-3);
+}
+
+.ops-step {
+  border: 1px solid color-mix(in srgb, var(--bdr2), transparent 44%);
+  border-radius: 0.86rem;
+  padding: 0.72rem 0.74rem;
+  background: linear-gradient(160deg, rgba(14, 23, 39, 0.42), rgba(18, 29, 47, 0.48));
+}
+
+.ops-step strong {
+  display: block;
+  margin-bottom: 0.2rem;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  color: var(--acc);
+  text-transform: uppercase;
+}
+
+.ops-step p {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--dim);
+}
+
 .lab-system-grid {
   display: grid;
   gap: var(--ds-space-5);
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1.16fr 0.84fr;
+}
+
+.lab-module-primary {
+  min-height: 100%;
+}
+
+.lab-module-secondary {
+  margin-top: 0.7rem;
 }
 
 .lab-topology svg {
   width: 100%;
   height: auto;
   display: block;
+}
+
+.lab-topology {
+  overflow: hidden;
+}
+
+.lab-topology::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, transparent 8%, rgba(120, 213, 245, 0.09) 38%, transparent 60%),
+    repeating-linear-gradient(0deg, color-mix(in srgb, var(--acc), transparent 94%) 0 1px, transparent 1px 34px);
+  opacity: 0.45;
+}
+
+.lab-path {
+  stroke-dasharray: 7 7;
 }
 
 .evidence-checklist {
@@ -733,8 +957,20 @@ html[data-reveal-active="true"] .reveal.is-visible {
     grid-template-columns: 1fr;
   }
 
+  .lab-module-secondary {
+    margin-top: 0;
+  }
+
+  .ops-step-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .kpi-mini-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .dashboard-status-grid {
+    grid-template-columns: 1fr;
   }
 
   .chart-label {
@@ -767,6 +1003,10 @@ html[data-reveal-active="true"] .reveal.is-visible {
     padding: 0.34rem 0.66rem;
     font-size: 0.62rem;
   }
+
+  .ops-step-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -792,7 +1032,13 @@ html[data-reveal-active="true"] .reveal.is-visible {
   .chart-bar:hover,
   .chart-bar-link:focus-visible .chart-bar {
     transform: translateY(-2px);
-    filter: drop-shadow(0 10px 18px rgba(18, 88, 148, 0.34));
+    filter: drop-shadow(0 10px 18px rgba(18, 88, 148, 0.34)) brightness(1.14);
+  }
+
+  .panel-glass:hover,
+  .panel-glass:focus-within {
+    border-color: color-mix(in srgb, var(--acc), transparent 40%);
+    box-shadow: var(--ds-shadow-glow), inset 0 1px 0 rgba(162, 226, 255, 0.08);
   }
 
   .proof-card:hover,
@@ -806,6 +1052,38 @@ html[data-reveal-active="true"] .reveal.is-visible {
     border-color: color-mix(in srgb, var(--acc), transparent 36%);
     transform: translateY(-1px);
   }
+
+  .ops-step:hover,
+  .ops-step:focus-within {
+    border-color: color-mix(in srgb, var(--acc), transparent 42%);
+    transform: translateY(-2px);
+  }
+
+  .lab-topology::after {
+    animation: lab-signal-path 9s linear infinite;
+  }
+
+  .lab-path {
+    animation: lab-path-flow 1.8s linear infinite;
+  }
+}
+
+@keyframes lab-signal-path {
+  from {
+    background-position: -220px 0, 0 0;
+  }
+  to {
+    background-position: 340px 0, 0 34px;
+  }
+}
+
+@keyframes lab-path-flow {
+  from {
+    stroke-dashoffset: 28;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -815,5 +1093,10 @@ html[data-reveal-active="true"] .reveal.is-visible {
     transform: none !important;
     filter: none !important;
     transition: none !important;
+  }
+
+  .lab-topology::after,
+  .lab-path {
+    animation: none !important;
   }
 }

--- a/site/assets/portfolio-data.js
+++ b/site/assets/portfolio-data.js
@@ -30,6 +30,55 @@ function emitContentUpdated() {
   window.dispatchEvent(new Event("rh:content-updated"));
 }
 
+function titleCaseToken(value) {
+  return String(value || "")
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function hashSeed(input) {
+  const str = String(input || "");
+  let acc = 0;
+  for (let i = 0; i < str.length; i += 1) acc = (acc * 31 + str.charCodeAt(i)) % 997;
+  return acc || 37;
+}
+
+function buildSparkValues(project, idx) {
+  const seed = hashSeed(`${project && project.id ? project.id : "project"}-${idx}`);
+  const values = [];
+  for (let i = 0; i < 8; i += 1) {
+    const wave = Math.sin((seed + i * 13) / 14) * 16;
+    const trend = i * 3.6;
+    const value = Math.round(Math.min(92, Math.max(18, 36 + wave + trend)));
+    values.push(value);
+  }
+  return values;
+}
+
+function sparkPolyline(values, width = 240, height = 36) {
+  const points = Array.isArray(values) ? values : [];
+  if (!points.length) return "";
+  const step = points.length > 1 ? width / (points.length - 1) : width;
+  return points.map((value, index) => {
+    const x = Math.round(index * step);
+    const y = Math.round(height - (value / 100) * height);
+    return `${x},${y}`;
+  }).join(" ");
+}
+
+function buildProjectSteps(type) {
+  const map = {
+    detection: ["Scope hypothesis", "Build detections", "Validate in lane"],
+    operations: ["Plan change", "Execute tasks", "Prove rollback"],
+    soc: ["Trigger scenario", "Triage workflow", "Document closure"],
+    ir: ["Detect incident", "Contain impact", "Recover + report"]
+  };
+  const key = String(type || "").toLowerCase();
+  return map[key] || ["Define scope", "Implement", "Verify evidence"];
+}
+
 function uniqueTags(items) {
   const bag = new Set();
   items.forEach((item) => (item.tags || []).forEach((tag) => bag.add(normalizeToken(tag))));
@@ -83,18 +132,35 @@ function renderProjectProofCards(container, projects) {
     container.innerHTML = '<article class="proof-card"><h3>No project records</h3><p>Project proof cards will appear when project metadata is available.</p></article>';
     return;
   }
-  container.innerHTML = rows.map((project) => {
+  container.innerHTML = rows.map((project, idx) => {
     const title = esc(project.title || "Project");
     const summary = esc(project.summary || "Project summary pending.");
     const pageUrl = esc(project.page_url || "#");
     const repoUrl = esc(project.repo_url || "#");
+    const projectType = titleCaseToken(project.type || "project");
+    const projectStatus = titleCaseToken(project.status || "active");
+    const steps = buildProjectSteps(project.type);
+    const tags = Array.isArray(project.tags) ? project.tags.slice(0, 5) : [];
+    const spark = sparkPolyline(buildSparkValues(project, idx));
     const evidence = Array.isArray(project.evidence) ? project.evidence : [];
     const evidenceLinks = evidence.slice(0, 3).map((entry) => {
       return `<a href="${esc(entry.url)}" target="_blank" rel="noreferrer">${esc(entry.label)}</a>`;
     }).join("");
     return `<article class="proof-card">
+      <div class="proof-card-head">
+        <span class="proof-pill">${esc(projectType)}</span>
+        <span class="proof-state">${esc(projectStatus)}</span>
+      </div>
       <h3><a href="${pageUrl}">${title}</a></h3>
       <p>${summary}</p>
+      <span class="proof-evidence-label">Complexity lane</span>
+      <svg class="proof-spark" viewBox="0 0 240 36" role="img" aria-label="${title} complexity signal sparkline">
+        <polyline points="${spark}"></polyline>
+      </svg>
+      <ol class="proof-step-track">
+        ${steps.map((step) => `<li>${esc(step)}</li>`).join("")}
+      </ol>
+      <div class="proof-tech">${tags.map((tag) => `<span>${esc(tag)}</span>`).join("")}</div>
       <div class="proof-card-links">
         <a href="${repoUrl}" target="_blank" rel="noreferrer">Repository lane</a>
         ${evidenceLinks}

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -83,20 +83,22 @@
 
         /* NAV */
         nav{position:fixed;top:0;left:0;right:0;z-index:1000;background:var(--nav-bg);backdrop-filter:blur(20px);border-bottom:1px solid var(--bdr)}
+        nav::after{content:'';position:absolute;left:0;right:0;bottom:-1px;height:1px;background:linear-gradient(90deg,transparent,rgba(103,214,255,.34),rgba(179,124,212,.24),transparent);pointer-events:none}
         .nav-i{max-width:1200px;margin:0 auto;padding:0 24px;display:flex;justify-content:space-between;align-items:center;height:60px}
         .logo{font-family:var(--sans);font-size:1rem;font-weight:700;letter-spacing:.02em;color:var(--txt);text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:8px}
         .logo b{color:var(--acc)}
         .logo-monogram{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:var(--acc);color:#171b29;font-family:var(--mono);font-size:.72rem;font-weight:700}
         .nav-l{display:flex;gap:24px;list-style:none;align-items:center}
-        .nav-l a{font-family:var(--mono);font-size:.72rem;color:var(--dim);text-decoration:none;cursor:pointer;transition:color .2s,background .2s,border-color .2s;letter-spacing:.03em;padding:6px 10px;border-radius:999px;border:1px solid transparent}
-        .nav-l a:hover{color:var(--acc);background:var(--nav-hover-bg)}
-        .nav-l a.act,.nav-l a[aria-current='page']{color:var(--txt);background:var(--nav-active-bg);border-color:var(--nav-active-border);box-shadow:var(--nav-active-shadow)}
+        .nav-l a{font-family:var(--mono);font-size:.72rem;color:var(--dim);text-decoration:none;cursor:pointer;transition:color .2s,background .2s,border-color .2s,box-shadow .2s,transform .2s;letter-spacing:.03em;padding:6px 10px;border-radius:10px;border:1px solid transparent}
+        .nav-l a:hover{color:var(--acc);background:var(--nav-hover-bg);transform:translateY(-1px)}
+        .nav-l a.act,.nav-l a[aria-current='page']{color:var(--txt);background:linear-gradient(160deg,var(--nav-active-bg),rgba(103,214,255,.08));border-color:var(--nav-active-border);box-shadow:var(--nav-active-shadow),inset 0 0 0 1px rgba(197,126,220,.22)}
         .mob-btn{display:none;background:none;border:1px solid var(--bdr);color:var(--txt);padding:6px 10px;font-family:var(--mono);font-size:.72rem;cursor:pointer}
         .theme-btn{background:var(--bg2);color:var(--txt);border:1px solid var(--bdr2);padding:7px 10px;border-radius:999px;font-family:var(--mono);font-size:.68rem;cursor:pointer;transition:all .2s}
         .theme-btn:hover{border-color:var(--acc);box-shadow:0 0 0 3px rgba(103,214,255,.18)}
 
         /* HERO */
-        .hero{min-height:82vh;display:flex;align-items:center;padding-top:74px;position:relative;overflow:hidden}
+        .hero{min-height:78vh;display:flex;align-items:center;padding-top:74px;position:relative;overflow:hidden}
+        .hero::after{content:'';position:absolute;left:0;right:0;bottom:0;height:1px;background:linear-gradient(90deg,transparent,rgba(103,214,255,.34),transparent)}
         .hero-glow{position:absolute;width:520px;height:520px;border-radius:50%;background:radial-gradient(circle,rgba(79,211,228,.24) 0%,transparent 74%);top:-140px;right:-140px;pointer-events:none;animation:gp 14s ease-in-out infinite}
         @keyframes gp{0%,100%{opacity:.4;transform:scale(1)}50%{opacity:.65;transform:scale(1.06)}}
         .particles{display:none !important}
@@ -278,8 +280,8 @@
         .fstat{font-family:var(--mono);font-size:.7rem;color:var(--faint)}
         .fstat strong{color:var(--acc)}
 
-        @media(max-width:1200px){.hero{min-height:76vh}}
-        @media(max-width:960px){.hero-layout{grid-template-columns:1fr}.hero-proof{max-width:740px}.hero{min-height:72vh}}
+        @media(max-width:1200px){.hero{min-height:72vh}}
+        @media(max-width:960px){.hero-layout{grid-template-columns:1fr}.hero-proof{max-width:740px}.hero{min-height:68vh}}
         @media(max-width:900px){.g3,.g2,.writing-grid{grid-template-columns:1fr}.mstrip{grid-template-columns:repeat(3,1fr)}}
         @media(max-width:640px){.nav-l{display:none}.nav-l.open{display:flex;flex-direction:column;position:absolute;top:60px;left:0;right:0;background:var(--bg);border-bottom:1px solid var(--bdr);padding:20px;gap:16px}.mob-btn{display:block}.mstrip{grid-template-columns:repeat(2,1fr)}.hero-panel{padding:24px 18px 20px;border-radius:24px}.hero-icons .ico-chip svg{width:14px;height:14px;flex-basis:14px}.htitle{font-size:2.24rem}section{padding:54px 0}.hero-proof{border-radius:20px}}
     

--- a/site/index.html
+++ b/site/index.html
@@ -133,6 +133,22 @@ IR playbooks ...  10</code></pre>
       <p class="sdesc">Verified counts, charted coverage, and proof artifacts are rendered from versioned manifests in this repository.</p>
     </div>
 
+    <div class="dashboard-shell" data-reveal>
+    <div class="dashboard-status-grid">
+      <div class="dashboard-status">
+        <strong>Host target</strong>
+        <span>Cloudflare Pages production path</span>
+      </div>
+      <div class="dashboard-status">
+        <strong>Safety gate</strong>
+        <span>Only <code>privacy_review === "ok"</code> assets render</span>
+      </div>
+      <div class="dashboard-status">
+        <strong>Reviewer path</strong>
+        <span>Proof, inventory, then implementation drill-down</span>
+      </div>
+    </div>
+
     <div class="dashboard-band">
       <article class="panel-glass" data-reveal>
         <h3 class="dash-title">KPI lane</h3>
@@ -206,6 +222,7 @@ IR playbooks ...  10</code></pre>
       <p class="lupd">Only safe assets are rendered. Screenshot/dashboard/diagram artifacts are prioritized; logos are shown as compact tool marks if no proof screenshots exist.</p>
       <div id="proof-gallery-strip" data-media-gallery data-tags="proof,dashboard,detection,diagram" data-limit="6"></div>
     </article>
+    </div>
   </div>
 </section>
 

--- a/site/lab.html
+++ b/site/lab.html
@@ -66,7 +66,7 @@
     </div>
 
     <div class="lab-system-grid">
-      <article class="panel-glass" data-reveal>
+      <article class="panel-glass lab-module-primary" data-reveal>
         <h2 class="dash-title">Environment summary</h2>
         <div class="kpi-mini-grid" style="margin-bottom:1rem">
           <div class="kpi-mini"><strong>HO-SR-01</strong><span>Proxmox host</span></div>
@@ -82,7 +82,7 @@
         </ul>
       </article>
 
-      <article class="panel-glass" data-reveal data-reveal-delay="80ms">
+      <article class="panel-glass lab-module-secondary" data-reveal data-reveal-delay="80ms">
         <h2 class="dash-title">Monitoring and SIEM lane</h2>
         <div class="listing-meta" style="margin-bottom:0.75rem">
           <span>Wazuh manager</span>
@@ -135,11 +135,11 @@
         <text x="810" y="142" text-anchor="middle" class="chart-value">Evidence</text>
         <text x="810" y="166" text-anchor="middle" class="chart-label">Proof pack</text>
 
-        <line x1="212" y1="150" x2="288" y2="102" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
-        <line x1="212" y1="150" x2="288" y2="222" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
-        <line x1="460" y1="102" x2="540" y2="150" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
-        <line x1="460" y1="222" x2="540" y2="150" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
-        <line x1="712" y1="150" x2="738" y2="150" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
+        <line class="lab-path" x1="212" y1="150" x2="288" y2="102" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
+        <line class="lab-path" x1="212" y1="150" x2="288" y2="222" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
+        <line class="lab-path" x1="460" y1="102" x2="540" y2="150" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
+        <line class="lab-path" x1="460" y1="222" x2="540" y2="150" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
+        <line class="lab-path" x1="712" y1="150" x2="738" y2="150" stroke="rgba(103,214,255,0.8)" stroke-width="2" marker-end="url(#arrow)"></line>
       </svg>
     </article>
   </div>

--- a/site/projects.html
+++ b/site/projects.html
@@ -68,12 +68,35 @@
       <div class="lupd">Verify lane: <code>pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</code></div>
     </div>
 
-    <div class="filter-shell" data-reveal>
-      <input class="filter-search" type="search" data-search placeholder="Search projects, tools, outcomes..." aria-label="Search projects">
-      <div class="filter-bar" data-chips aria-label="Project tag filters"></div>
+    <div class="project-ops-rail">
+      <div class="ops-step-grid">
+        <article class="ops-step" data-reveal>
+          <strong>1. Scope</strong>
+          <p>Define objective, success criteria, and evidence checkpoints.</p>
+        </article>
+        <article class="ops-step" data-reveal>
+          <strong>2. Build</strong>
+          <p>Implement detections or workflows with reproducible artifacts.</p>
+        </article>
+        <article class="ops-step" data-reveal>
+          <strong>3. Validate</strong>
+          <p>Run verify scripts and align claims to source-of-truth counts.</p>
+        </article>
+        <article class="ops-step" data-reveal>
+          <strong>4. Publish</strong>
+          <p>Ship with reviewer-ready links, evidence chips, and rollback context.</p>
+        </article>
+      </div>
     </div>
 
-    <section class="listing" data-listing aria-live="polite"></section>
+    <div class="dashboard-shell" data-reveal>
+      <div class="filter-shell" data-reveal>
+        <input class="filter-search" type="search" data-search placeholder="Search projects, tools, outcomes..." aria-label="Search projects">
+        <div class="filter-bar" data-chips aria-label="Project tag filters"></div>
+      </div>
+
+      <section class="listing" data-listing aria-live="polite"></section>
+    </div>
 
     <div class="section-intro" style="margin-top:2rem" data-reveal>
       <div class="kicker">Project proof</div>

--- a/site/security.html
+++ b/site/security.html
@@ -68,6 +68,22 @@
       <div class="lupd">Verify lane: <code>pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</code></div>
     </div>
 
+    <div class="dashboard-shell" data-reveal>
+    <div class="dashboard-status-grid">
+      <div class="dashboard-status">
+        <strong>Inventory mode</strong>
+        <span>Live JSON-backed detection index</span>
+      </div>
+      <div class="dashboard-status">
+        <strong>Tag analysis</strong>
+        <span>Compact + full chart views are linked to filters</span>
+      </div>
+      <div class="dashboard-status">
+        <strong>MITRE status</strong>
+        <span>Heatmap enabled only when metadata is present</span>
+      </div>
+    </div>
+
     <div class="security-dashboard-row">
       <article class="panel-glass" data-security-kpis data-reveal>
         <h2 class="dash-title">Inventory KPIs</h2>
@@ -92,6 +108,7 @@
     <div class="filter-shell" data-reveal>
       <input class="filter-search" type="search" data-search placeholder="Search platform, format, or tactic..." aria-label="Search detections">
       <div class="filter-bar" data-chips aria-label="Detection tag filters"></div>
+    </div>
     </div>
 
     <section class="listing" data-listing aria-live="polite"></section>


### PR DESCRIPTION
## Summary
- ignore accidental local-only files (/CLAUDE.md, /site/assets/visual-enhance.css) via .gitignore
- harden SVG chart link hit-testing across Firefox/Safari by disabling pointer events on text/shape children inside .chart-bar-link

## Why
- keeps repo clean from non-project artifacts
- ensures chart bars remain reliably clickable/focusable as semantic <a href> links across browsers while preserving PR32 tooltip/link behavior

## Validation
- 
ode scripts/verify/no-netlify.js passed