### PR TITLE
Home: premium operator console theme (home-only)

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -1,59 +1,146 @@
-/* Home-only visual polish. Loaded only by site/index.html */
-body.home-page {
-  --home-accent: #ff69b4;
-  --home-accent-soft: rgba(255, 105, 180, 0.22);
-  --home-glass-border: rgba(245, 247, 255, 0.16);
-  --home-surface: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(12, 16, 26, 0.58));
-  --home-shadow: 0 22px 44px rgba(2, 6, 14, 0.45);
-  --acc: var(--home-accent);
-  --acc2: #a8b6ff;
-  --heading: #f5f7ff;
-  background:
-    radial-gradient(900px 420px at 84% -10%, rgba(255, 105, 180, 0.14), transparent 72%),
-    radial-gradient(860px 420px at -12% 114%, rgba(168, 182, 255, 0.12), transparent 72%),
-    linear-gradient(180deg, #04060c 0%, #080c15 56%, #0a0f1a 100%);
+/* Home-only operator-console theme. Loaded only by site/index.html */
+body.home-page,
+html[data-theme="dark"] body.home-page {
+  --bg0: #060409;
+  --bg1: #0d0913;
+  --bg2: #18101f;
+  --text: #f7f3fa;
+  --muted: #c3b8cb;
+  --border: rgba(255, 228, 242, 0.19);
+  --glass: linear-gradient(160deg, rgba(255, 255, 255, 0.06), rgba(21, 14, 28, 0.78));
+  --shadow: 0 20px 44px rgba(4, 0, 8, 0.52);
+  --accent: #e873ac;
+  --accentSoft: rgba(232, 115, 172, 0.2);
+  --grid: rgba(255, 255, 255, 0.04);
+  --fog: rgba(255, 245, 251, 0.08);
+  --stars: rgba(255, 255, 255, 0.2);
+
+  --acc: var(--accent);
+  --acc2: #c95f90;
+  --acc-d: rgba(232, 115, 172, 0.18);
+  --acc-g: rgba(232, 115, 172, 0.26);
+  --heading: var(--text);
+  --dim: var(--muted);
+  --faint: #9b8ca6;
+  --link: #f2abd0;
+  --link-hover: #ffe1ef;
+  --hero-mark: rgba(255, 218, 238, 0.56);
+  --hero-mark-opacity: 0.72;
+  --nav-bg: rgba(9, 7, 12, 0.9);
+  --nav-hover-bg: rgba(232, 115, 172, 0.15);
+  --nav-active-bg: rgba(232, 115, 172, 0.22);
+  --nav-active-border: rgba(255, 192, 226, 0.52);
+  --nav-active-shadow: inset 0 -1px 0 rgba(255, 209, 235, 0.54);
+  --page-bg:
+    radial-gradient(1040px 560px at 88% -10%, rgba(95, 44, 90, 0.32), transparent 74%),
+    radial-gradient(900px 500px at -16% 112%, rgba(62, 30, 74, 0.26), transparent 72%),
+    linear-gradient(180deg, var(--bg0) 0%, #08050b 47%, #0b0710 100%);
+  background: var(--page-bg);
+  color: var(--text);
 }
 
 html[data-theme="light"] body.home-page {
-  --home-accent: #d65b95;
-  --home-accent-soft: rgba(214, 91, 149, 0.16);
-  --home-glass-border: rgba(26, 34, 52, 0.12);
-  --home-surface: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(247, 249, 255, 0.84));
-  --home-shadow: 0 16px 30px rgba(30, 36, 56, 0.1);
-  --acc: var(--home-accent);
-  --acc2: #778ad9;
-  --heading: #151b2b;
-  color: #1c2437;
-  background:
-    radial-gradient(920px 420px at 84% -10%, rgba(214, 91, 149, 0.12), transparent 72%),
-    radial-gradient(860px 420px at -12% 114%, rgba(119, 138, 217, 0.08), transparent 72%),
-    linear-gradient(180deg, #fcfdff 0%, #f5f7fc 56%, #edf1f8 100%);
+  --bg0: #f7f4f7;
+  --bg1: #fefbfc;
+  --bg2: #f1eaf0;
+  --text: #18131a;
+  --muted: #574d59;
+  --border: rgba(53, 34, 48, 0.18);
+  --glass: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(245, 236, 242, 0.82));
+  --shadow: 0 14px 30px rgba(58, 42, 55, 0.14);
+  --accent: #ba4e81;
+  --accentSoft: rgba(186, 78, 129, 0.14);
+  --grid: rgba(38, 24, 35, 0.05);
+  --fog: rgba(255, 255, 255, 0.74);
+  --stars: rgba(97, 72, 90, 0.2);
+
+  --acc: var(--accent);
+  --acc2: #9b3f6c;
+  --acc-d: rgba(186, 78, 129, 0.14);
+  --acc-g: rgba(186, 78, 129, 0.2);
+  --heading: var(--text);
+  --dim: var(--muted);
+  --faint: #6d5f71;
+  --link: #9b3f6c;
+  --link-hover: #7f3157;
+  --hero-mark: rgba(186, 78, 129, 0.35);
+  --hero-mark-opacity: 0.7;
+  --nav-bg: rgba(252, 248, 251, 0.9);
+  --nav-hover-bg: rgba(186, 78, 129, 0.11);
+  --nav-active-bg: rgba(186, 78, 129, 0.17);
+  --nav-active-border: rgba(155, 63, 108, 0.4);
+  --nav-active-shadow: inset 0 -1px 0 rgba(155, 63, 108, 0.34);
+  --page-bg:
+    radial-gradient(940px 460px at 86% -8%, rgba(205, 139, 174, 0.2), transparent 74%),
+    radial-gradient(860px 430px at -14% 108%, rgba(163, 132, 163, 0.16), transparent 72%),
+    linear-gradient(180deg, #fdfbfc 0%, #f7f2f6 55%, #f0eaf0 100%);
+  background: var(--page-bg);
 }
 
 body.home-page::before {
+  content: "";
   background:
-    linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
-  background-size: 62px 62px;
-}
-
-html[data-theme="light"] body.home-page::before {
-  background:
-    linear-gradient(rgba(18, 26, 44, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(18, 26, 44, 0.04) 1px, transparent 1px);
-  background-size: 62px 62px;
+    linear-gradient(var(--grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+  background-size: 56px 56px;
 }
 
 body.home-page::after {
-  opacity: 0.22;
+  content: "";
+  background-image:
+    radial-gradient(circle at 10% 16%, var(--stars) 0 1px, transparent 1.8px),
+    radial-gradient(circle at 78% 30%, var(--stars) 0 1.1px, transparent 1.8px),
+    radial-gradient(circle at 58% 80%, rgba(255, 216, 237, 0.16) 0 1px, transparent 1.7px),
+    radial-gradient(circle at 30% 70%, var(--stars) 0 1.2px, transparent 2px);
+  opacity: 0.28;
+}
+
+.home-page a:focus-visible,
+.home-page button:focus-visible,
+.home-page .btn:focus-visible,
+.home-page .media-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(232, 115, 172, 0.24);
+}
+
+.home-page .theme-btn:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(232, 115, 172, 0.2);
+}
+
+.home-page .mob-menu {
+  background: rgba(11, 8, 14, 0.95);
+  border-bottom-color: var(--border);
+}
+
+html[data-theme="light"] .home-page .mob-menu {
+  background: rgba(252, 248, 251, 0.96);
+}
+
+.home-page .mob-menu a:hover {
+  color: var(--text);
+  background: var(--accentSoft);
+}
+
+.home-page .mob-menu a.act,
+.home-page .mob-menu a[aria-current="page"] {
+  background: var(--accentSoft);
+  border-left-color: var(--accent);
 }
 
 .home-page .home-hero {
-  min-height: 64vh;
-  padding-top: 68px;
-  padding-bottom: 22px;
+  min-height: 58vh;
+  padding-top: 70px;
+  padding-bottom: 8px;
   align-items: flex-end;
   isolation: isolate;
+}
+
+.home-page .hero-layout {
+  grid-template-columns: minmax(0, 1.18fr) minmax(300px, 0.82fr);
+  gap: 1rem;
+  align-items: stretch;
 }
 
 .home-page .home-hero-cosmos,
@@ -66,89 +153,367 @@ body.home-page::after {
 
 .home-page .home-hero-cosmos {
   background:
-    radial-gradient(circle at 16% 20%, rgba(255, 255, 255, 0.2) 0 1px, transparent 2px),
-    radial-gradient(circle at 76% 32%, rgba(255, 255, 255, 0.16) 0 1px, transparent 2px),
-    radial-gradient(circle at 58% 84%, rgba(255, 255, 255, 0.12) 0 1px, transparent 2px),
-    linear-gradient(120deg, rgba(255, 105, 180, 0.12), rgba(168, 182, 255, 0.08) 44%, transparent 74%);
-  animation: home-drift 28s ease-in-out infinite;
+    radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.18) 0 1px, transparent 2px),
+    radial-gradient(circle at 74% 32%, rgba(255, 255, 255, 0.14) 0 1px, transparent 2px),
+    radial-gradient(circle at 56% 84%, rgba(255, 255, 255, 0.11) 0 1px, transparent 2px),
+    linear-gradient(118deg, rgba(232, 115, 172, 0.15), rgba(116, 60, 108, 0.12) 48%, transparent 76%);
+  opacity: 0.95;
+  animation: home-drift 30s ease-in-out infinite;
 }
 
 .home-page .home-hero-fog {
   background:
-    radial-gradient(1200px 260px at 34% 16%, rgba(255, 255, 255, 0.1), transparent 72%),
-    radial-gradient(900px 220px at 72% 78%, rgba(255, 255, 255, 0.08), transparent 72%);
+    radial-gradient(1200px 240px at 34% 14%, var(--fog), transparent 72%),
+    radial-gradient(940px 220px at 72% 78%, rgba(255, 232, 244, 0.06), transparent 72%);
   mix-blend-mode: screen;
   animation: home-fog 24s ease-in-out infinite;
 }
 
 html[data-theme="light"] .home-page .home-hero-cosmos {
-  opacity: 0.3;
+  opacity: 0.5;
 }
 
 html[data-theme="light"] .home-page .home-hero-fog {
   mix-blend-mode: normal;
-  opacity: 0.7;
+  opacity: 0.86;
+}
+
+.home-page .hero-glow {
+  background: radial-gradient(circle, rgba(232, 115, 172, 0.2) 0%, transparent 74%);
 }
 
 .home-page .hero-panel,
 .home-page .hero-proof,
 .home-page .panel-glass {
-  background: var(--home-surface);
-  border-color: var(--home-glass-border);
-  box-shadow: var(--home-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border);
+  border-radius: 1.1rem;
+  background: var(--glass);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.1), inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(6px);
+}
+
+.home-page .panel-glass::before {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 28%);
+}
+
+.home-page .proof-dashboard-wrap::before {
+  background: radial-gradient(960px 320px at 8% -10%, rgba(232, 115, 172, 0.15), transparent 72%);
 }
 
 .home-page .hero-panel {
-  padding: 28px 30px 24px;
+  max-width: 100%;
+  padding: 1.45rem 1.45rem 1.15rem;
 }
 
-.home-page .hero-proof-hd {
-  background: var(--home-accent-soft);
+.home-page .hero-proof {
+  padding: 0.95rem;
 }
 
-.home-page .htitle,
-.home-page .stitle {
-  color: var(--heading);
-}
-
-.home-page .htitle .hl {
-  background: linear-gradient(130deg, var(--home-accent), #ff97c8);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.home-page .htag,
+.home-page .hero-proof-label,
+.home-page .dash-title,
 .home-page .kicker,
-.home-page .dash-title {
-  color: color-mix(in srgb, var(--home-accent), var(--txt) 26%);
+.home-page .htag,
+.home-page .slbl {
+  color: var(--accent);
 }
 
 .home-page .htag::before {
-  background: color-mix(in srgb, var(--home-accent), white 22%);
+  background: rgba(255, 211, 234, 0.78);
+}
+
+.home-page .hero-proof-hd {
+  border-bottom-color: var(--border);
+  background: var(--accentSoft);
+}
+
+.home-page .hero-proof-hd span {
+  background: rgba(255, 207, 233, 0.72);
+}
+
+html[data-theme="light"] .home-page .hero-proof-hd span {
+  background: rgba(186, 78, 129, 0.45);
+}
+
+.home-page .hero-proof-shot {
+  border-color: var(--border);
+  background: linear-gradient(180deg, rgba(12, 9, 16, 0.95), rgba(9, 7, 13, 0.98));
+}
+
+html[data-theme="light"] .home-page .hero-proof-shot {
+  background: linear-gradient(180deg, rgba(255, 254, 255, 0.9), rgba(245, 237, 243, 0.92));
+}
+
+.home-page .hero-proof pre {
+  color: #f6edf4;
+}
+
+html[data-theme="light"] .home-page .hero-proof pre {
+  color: #2e2231;
+}
+
+.home-page .htitle {
+  max-width: 18ch;
+  margin-bottom: 0.65rem;
+  font-size: clamp(3.05rem, 7vw, 5.4rem);
+  line-height: 0.97;
+  letter-spacing: -0.04em;
+  color: var(--text);
+  text-wrap: balance;
+}
+
+.home-page .htitle .hl {
+  color: var(--accent);
+  background: none;
+  -webkit-background-clip: border-box;
+  -webkit-text-fill-color: currentColor;
+  background-clip: border-box;
+}
+
+.home-page .hsub {
+  max-width: 58ch;
+  margin-bottom: 0.85rem;
+  color: var(--muted);
+}
+
+.home-page .hproof {
+  margin-bottom: 0.85rem;
+  padding: 0.6rem 0.7rem 0.68rem;
+  border: 1px solid rgba(255, 212, 233, 0.24);
+  border-radius: 0.7rem;
+  background: rgba(232, 115, 172, 0.08);
+}
+
+html[data-theme="light"] .home-page .hproof {
+  background: rgba(186, 78, 129, 0.08);
+  border-color: rgba(186, 78, 129, 0.2);
+}
+
+.home-page .hproof p {
+  margin: 0 0 0.25rem;
+  color: var(--text);
+}
+
+.home-page .hproof b {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.home-page .hproof-steps {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.16rem;
+  color: var(--muted);
+}
+
+.home-page .hproof-steps li {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  line-height: 1.6;
+}
+
+.home-page .roles {
+  margin-bottom: 0.85rem;
+}
+
+.home-page .rtag {
+  border-color: rgba(255, 207, 232, 0.2);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.home-page .rtag.on {
+  border-color: rgba(255, 182, 221, 0.5);
+  background: rgba(232, 115, 172, 0.18);
+  color: #ffd9ee;
+}
+
+html[data-theme="light"] .home-page .rtag.on {
+  color: #6a2448;
+}
+
+.home-page .hctas {
+  margin-bottom: 0.9rem;
+}
+
+.home-page .btn-p {
+  color: #fff;
+  background: linear-gradient(128deg, #e873ac 0%, #cc5b8f 100%);
+  box-shadow: 0 10px 22px rgba(99, 27, 62, 0.38);
+}
+
+.home-page .btn-p:hover {
+  box-shadow: 0 0 0 3px rgba(232, 115, 172, 0.24), 0 12px 24px rgba(99, 27, 62, 0.42);
+}
+
+.home-page .btn-g {
+  border-color: var(--border);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.home-page .btn-g:hover {
+  border-color: rgba(255, 211, 234, 0.62);
+  color: #ffe5f2;
+}
+
+html[data-theme="light"] .home-page .btn-g:hover {
+  color: #7f3157;
+}
+
+.home-page .sbadge {
+  color: #ffdff0;
+  border-color: rgba(255, 189, 224, 0.34);
+  background: rgba(232, 115, 172, 0.14);
+}
+
+html[data-theme="light"] .home-page .sbadge {
+  color: #6e274b;
+}
+
+.home-page .sdot {
+  background: #ffc3e3;
+}
+
+.home-page main > section,
+.home-page .fluid-section {
+  padding: 3.3rem 0;
 }
 
 .home-page .proof-dashboard-wrap {
-  margin-top: clamp(-1.1rem, -1.8vw, -0.2rem);
+  margin-top: clamp(-1.6rem, -2.2vw, -0.5rem);
 }
 
-.home-page .dashboard-shell {
-  border-color: rgba(245, 247, 255, 0.14);
-  background:
-    linear-gradient(180deg, rgba(245, 247, 255, 0.05), transparent 24%),
-    repeating-linear-gradient(90deg, rgba(245, 247, 255, 0.04) 0 1px, transparent 1px 58px),
-    linear-gradient(160deg, rgba(8, 12, 22, 0.72), rgba(12, 17, 30, 0.78));
+.home-page .section-intro {
+  margin-bottom: 1rem;
 }
 
-html[data-theme="light"] .home-page .dashboard-shell {
-  border-color: rgba(24, 32, 52, 0.16);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(249, 250, 255, 0.8)),
-    repeating-linear-gradient(90deg, rgba(24, 32, 52, 0.05) 0 1px, transparent 1px 58px);
+.home-page .dashboard-band,
+.home-page .dashboard-lower {
+  gap: 0.95rem;
+}
+
+.home-page .dashboard-kpi-grid {
+  gap: 0.55rem;
+}
+
+.home-page .kpi-badge {
+  border-color: rgba(255, 217, 237, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0.78rem;
 }
 
 .home-page .kpi-badge strong {
-  font-size: 1.34rem;
+  color: #fff5fb;
+  font-size: 1.3rem;
+}
+
+html[data-theme="light"] .home-page .kpi-badge strong {
+  color: #211820;
+}
+
+.home-page .dash-title {
+  margin-bottom: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+}
+
+.home-page .dashboard-cta-list li {
+  border-bottom-color: rgba(255, 217, 237, 0.28);
+}
+
+.home-page .chart-shell {
+  border-radius: 0.9rem;
+}
+
+.home-page .chart-axis {
+  stroke: rgba(255, 222, 239, 0.38);
+}
+
+html[data-theme="light"] .home-page .chart-axis {
+  stroke: rgba(72, 48, 69, 0.26);
+}
+
+.home-page .chart-bar {
+  stroke: rgba(255, 182, 221, 0.46);
+  filter: drop-shadow(0 8px 14px rgba(90, 27, 59, 0.3));
+}
+
+.home-page .chart-bar-link:focus-visible .chart-bar {
+  stroke: var(--accent);
+}
+
+.home-page .chart-tooltip {
+  border-color: var(--border);
+  background: linear-gradient(160deg, rgba(14, 9, 20, 0.92), rgba(20, 13, 26, 0.94));
+}
+
+html[data-theme="light"] .home-page .chart-tooltip {
+  background: linear-gradient(160deg, rgba(253, 249, 252, 0.95), rgba(244, 235, 241, 0.96));
+  color: var(--text);
+}
+
+.home-page .chart-fallback-list {
+  gap: 0.52rem;
+}
+
+.home-page .chart-fallback-list li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: baseline;
+  gap: 0.48rem;
+  font-family: var(--mono);
+}
+
+.home-page .chart-fallback-list strong {
+  color: #ffd3ea;
+}
+
+html[data-theme="light"] .home-page .chart-fallback-list strong {
+  color: #7f3157;
+}
+
+.home-page .fallback-sep {
+  display: inline-flex;
+  margin: 0 0.1rem;
+  color: var(--muted);
+  opacity: 0.86;
+}
+
+.home-page .tag-chart-skeleton {
+  display: grid;
+  gap: 0.52rem;
+  padding: 0.1rem 0;
+}
+
+.home-page .tag-chart-skeleton .lupd {
+  margin: 0 0 0.1rem;
+  color: var(--muted);
+}
+
+.home-page .tag-skeleton-row {
+  position: relative;
+  height: 0.72rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+html[data-theme="light"] .home-page .tag-skeleton-row {
+  background: rgba(64, 42, 60, 0.1);
+}
+
+.home-page .tag-skeleton-row::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 10%, rgba(255, 217, 238, 0.54) 50%, transparent 90%);
+  transform: translateX(-100%);
+  animation: home-shimmer 1.7s ease-in-out infinite;
+}
+
+html[data-theme="light"] .home-page .tag-skeleton-row::before {
+  background: linear-gradient(100deg, transparent 10%, rgba(186, 78, 129, 0.28) 50%, transparent 90%);
 }
 
 .home-page .home-action-row {
@@ -157,81 +522,141 @@ html[data-theme="light"] .home-page .dashboard-shell {
   gap: 0.56rem;
 }
 
-.home-page .btn-p {
-  background: linear-gradient(120deg, #ff7fc4, #db5b99);
-  color: #fff;
-  box-shadow: 0 10px 22px rgba(130, 24, 79, 0.36);
+.home-page .home-proof-strip .home-gallery-compact,
+.home-page .home-proof-strip #proof-gallery-strip {
+  margin-top: 0.16rem;
 }
 
-.home-page .btn-g {
-  border-color: color-mix(in srgb, var(--home-accent), transparent 62%);
-}
-
-.home-page .fallback-sep {
-  font-family: var(--mono);
-  color: var(--faint);
-  margin-inline: 0.2rem;
-}
-
-.home-page .tag-chart-skeleton {
-  display: grid;
+.home-page .home-proof-strip .media-grid {
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
   gap: 0.48rem;
 }
 
-.home-page .tag-skeleton-row {
-  height: 0.86rem;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.08));
-  background-size: 180% 100%;
-  animation: home-skeleton 1.8s ease-in-out infinite;
+.home-page .home-proof-strip .media-item {
+  border-color: rgba(255, 217, 237, 0.24);
+  border-radius: 0.7rem;
+  background: rgba(255, 255, 255, 0.03);
 }
 
-html[data-theme="light"] .home-page .tag-skeleton-row {
-  background: linear-gradient(90deg, rgba(24, 32, 52, 0.08), rgba(24, 32, 52, 0.14), rgba(24, 32, 52, 0.08));
-  background-size: 180% 100%;
+.home-page .home-proof-strip .media-thumb {
+  aspect-ratio: 4 / 3;
+  max-height: 96px;
+  background: rgba(17, 11, 23, 0.84);
+}
+
+html[data-theme="light"] .home-page .home-proof-strip .media-thumb {
+  background: rgba(245, 236, 242, 0.95);
+}
+
+.home-page .home-proof-strip .media-btn img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.home-page .home-proof-strip figcaption {
+  font-size: 0.6rem;
+  line-height: 1.3;
+  padding: 0.38rem 0.46rem 0.46rem;
+  word-break: break-word;
 }
 
 .home-page .home-proof-strip .tool-marks {
-  gap: 0.4rem;
+  gap: 0.38rem;
 }
 
 .home-page .home-proof-strip .tool-mark {
-  padding: 0.28rem 0.52rem;
-  font-size: 0.62rem;
-  border-color: color-mix(in srgb, var(--home-accent), transparent 70%);
-  background: color-mix(in srgb, var(--bg2), transparent 12%);
+  border-color: rgba(255, 217, 237, 0.3);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.28rem 0.5rem;
+  font-size: 0.61rem;
 }
 
 .home-page .home-proof-strip .tool-mark img {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 @keyframes home-drift {
-  0%, 100% { transform: translate3d(0, 0, 0); }
-  50% { transform: translate3d(-1.1%, 0.7%, 0); }
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(-0.9%, 0.7%, 0);
+  }
 }
 
 @keyframes home-fog {
-  0%, 100% { transform: translate3d(0, 0, 0); opacity: 0.9; }
-  50% { transform: translate3d(1%, -0.5%, 0); opacity: 1; }
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+    opacity: 0.88;
+  }
+  50% {
+    transform: translate3d(0.8%, -0.4%, 0);
+    opacity: 1;
+  }
 }
 
-@keyframes home-skeleton {
-  0% { background-position: 100% 0; }
-  100% { background-position: -80% 0; }
+@keyframes home-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (max-width: 1120px) {
+  .home-page .hero-layout {
+    grid-template-columns: 1fr;
+    gap: 0.86rem;
+  }
+
+  .home-page .home-hero {
+    min-height: auto;
+    padding-bottom: 0;
+  }
+
+  .home-page .proof-dashboard-wrap {
+    margin-top: 0.35rem;
+  }
 }
 
 @media (max-width: 980px) {
   .home-page .hero-panel {
-    padding: 22px 20px 18px;
+    padding: 1.1rem 1rem 0.9rem;
+  }
+
+  .home-page .dashboard-band,
+  .home-page .dashboard-lower {
+    grid-template-columns: 1fr;
+  }
+
+  .home-page main > section,
+  .home-page .fluid-section {
+    padding: 2.85rem 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-page .htitle {
+    font-size: clamp(2.25rem, 11vw, 3.1rem);
+  }
+
+  .home-page .hctas .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .home-page .home-proof-strip .media-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  body.home-page::after,
   .home-page .home-hero-cosmos,
   .home-page .home-hero-fog,
-  .home-page .tag-skeleton-row {
+  .home-page .tag-skeleton-row::before {
     animation: none !important;
   }
 }

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -250,6 +250,8 @@ html[data-theme="light"] .home-page .listing-item {
 
 .home-page .hero-proof {
   padding: 0.95rem;
+  display: grid;
+  gap: 0.6rem;
 }
 
 .home-page .hero-proof-label,
@@ -278,8 +280,19 @@ html[data-theme="light"] .home-page .hero-proof-hd span {
 }
 
 .home-page .hero-proof-shot {
+  position: relative;
   border-color: var(--border);
   background: linear-gradient(180deg, rgba(12, 9, 16, 0.95), rgba(9, 7, 13, 0.98));
+  overflow: hidden;
+}
+
+.home-page .hero-proof-shot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(180deg, rgba(255, 255, 255, 0.045) 0 1px, transparent 1px 3px);
+  opacity: 0.22;
 }
 
 html[data-theme="light"] .home-page .hero-proof-shot {
@@ -292,6 +305,43 @@ html[data-theme="light"] .home-page .hero-proof-shot {
 
 html[data-theme="light"] .home-page .hero-proof pre {
   color: #2e2231;
+}
+
+.home-page .console-lane {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.34rem;
+}
+
+.home-page .console-lane li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 0.61rem;
+  color: var(--muted);
+  border-bottom: 1px dashed color-mix(in srgb, var(--accent), transparent 72%);
+  padding-bottom: 0.28rem;
+}
+
+.home-page .console-lane li:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.home-page .console-lane span {
+  color: color-mix(in srgb, var(--text), var(--muted) 70%);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.home-page .console-lane strong {
+  color: color-mix(in srgb, var(--text), var(--accent) 18%);
+  font-weight: 600;
+  text-align: right;
 }
 
 .home-page .htitle {

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -35,6 +35,9 @@ html[data-theme="dark"] body.home-page {
     radial-gradient(1040px 560px at 88% -10%, rgba(95, 44, 90, 0.32), transparent 74%),
     radial-gradient(900px 500px at -16% 112%, rgba(62, 30, 74, 0.26), transparent 72%),
     linear-gradient(180deg, var(--bg0) 0%, #08050b 47%, #0b0710 100%);
+  --home-dur-fast: 170ms;
+  --home-dur-med: 260ms;
+  --home-ease: cubic-bezier(0.23, 0.82, 0.34, 1);
   background: var(--page-bg);
   color: var(--text);
 }
@@ -74,6 +77,9 @@ html[data-theme="light"] body.home-page {
     radial-gradient(940px 460px at 86% -8%, rgba(205, 139, 174, 0.2), transparent 74%),
     radial-gradient(860px 430px at -14% 108%, rgba(163, 132, 163, 0.16), transparent 72%),
     linear-gradient(180deg, #fdfbfc 0%, #f7f2f6 55%, #f0eaf0 100%);
+  --home-dur-fast: 170ms;
+  --home-dur-med: 260ms;
+  --home-ease: cubic-bezier(0.23, 0.82, 0.34, 1);
   background: var(--page-bg);
 }
 
@@ -96,6 +102,20 @@ body.home-page::after {
   animation: none;
 }
 
+.home-page a,
+.home-page a:visited {
+  color: var(--link);
+}
+
+.home-page a:hover {
+  color: var(--link-hover);
+}
+
+body.home-page .skip-link {
+  background: var(--accent);
+  color: #170f17;
+}
+
 .home-page a:focus-visible,
 .home-page button:focus-visible,
 .home-page .btn:focus-visible,
@@ -114,6 +134,35 @@ body.home-page::after {
   background: var(--accent);
   color: #231821;
   box-shadow: 0 0 0 1px rgba(255, 213, 235, 0.26);
+}
+
+.home-page .logo b {
+  color: var(--accent);
+}
+
+.home-page .nav-l a {
+  color: var(--muted);
+  border-color: transparent;
+}
+
+.home-page .nav-l a:hover {
+  color: var(--text);
+  background: var(--nav-hover-bg);
+  border-color: color-mix(in srgb, var(--accent), transparent 64%);
+}
+
+.home-page .nav-l a.act,
+.home-page .nav-l a[aria-current="page"] {
+  color: var(--text);
+  background: var(--nav-active-bg);
+  border-color: var(--nav-active-border);
+  box-shadow: var(--nav-active-shadow);
+}
+
+.home-page .theme-btn {
+  background: color-mix(in srgb, var(--bg2), transparent 8%);
+  color: var(--text);
+  border-color: var(--border);
 }
 
 .home-page .mob-menu {
@@ -209,7 +258,7 @@ html[data-theme="light"] .home-page .home-hero-fog {
 .home-page .hero-proof,
 .home-page .panel-glass {
   border: 1px solid var(--border);
-  border-radius: 1.1rem;
+  border-radius: 0.96rem;
   background: var(--glass);
   box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.1), inset 0 0 0 1px rgba(255, 255, 255, 0.03);
   backdrop-filter: blur(6px);
@@ -239,6 +288,7 @@ html[data-theme="light"] .home-page .listing-item {
 .home-page .listing-item:hover,
 .home-page .listing-item:focus-within {
   border-color: color-mix(in srgb, var(--accent), transparent 35%);
+  transform: translateY(-2px);
 }
 
 .home-page .signal-list li {
@@ -434,6 +484,32 @@ html[data-theme="light"] .home-page .rtag.on {
   margin-bottom: 0.9rem;
 }
 
+.home-page .btn,
+.home-page .rtag,
+.home-page .kpi-badge,
+.home-page .panel-glass,
+.home-page .hero-panel,
+.home-page .hero-proof,
+.home-page .listing-item,
+.home-page .home-proof-strip .media-item,
+.home-page .home-proof-strip .tool-mark {
+  transition:
+    transform var(--home-dur-fast) var(--home-ease),
+    border-color var(--home-dur-fast) var(--home-ease),
+    box-shadow var(--home-dur-med) var(--home-ease),
+    background-color var(--home-dur-fast) var(--home-ease),
+    color var(--home-dur-fast) var(--home-ease);
+}
+
+.home-page .panel-glass:hover,
+.home-page .panel-glass:focus-within,
+.home-page .hero-panel:hover,
+.home-page .hero-proof:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--accent), transparent 44%);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 10px 24px rgba(58, 15, 44, 0.26);
+}
+
 .home-page .btn-p {
   color: #fff;
   background: linear-gradient(128deg, #e873ac 0%, #cc5b8f 100%);
@@ -441,6 +517,7 @@ html[data-theme="light"] .home-page .rtag.on {
 }
 
 .home-page .btn-p:hover {
+  transform: translateY(-2px);
   box-shadow: 0 0 0 3px rgba(232, 115, 172, 0.24), 0 12px 24px rgba(99, 27, 62, 0.42);
 }
 
@@ -451,6 +528,7 @@ html[data-theme="light"] .home-page .rtag.on {
 }
 
 .home-page .btn-g:hover {
+  transform: translateY(-2px);
   border-color: rgba(255, 211, 234, 0.62);
   color: #ffe5f2;
 }
@@ -501,6 +579,11 @@ html[data-theme="light"] .home-page .sbadge {
   border-radius: 0.78rem;
 }
 
+.home-page .kpi-badge:hover {
+  border-color: color-mix(in srgb, var(--accent), transparent 48%);
+  transform: translateY(-2px);
+}
+
 .home-page .kpi-badge strong {
   color: #fff5fb;
   font-size: 1.3rem;
@@ -523,6 +606,9 @@ html[data-theme="light"] .home-page .kpi-badge strong {
 
 .home-page .chart-shell {
   border-radius: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--accent), transparent 72%);
+  background: color-mix(in srgb, var(--bg1), transparent 4%);
+  padding: 0.6rem;
 }
 
 .home-page .chart-axis {
@@ -655,6 +741,12 @@ html[data-theme="light"] .home-page .tag-skeleton-row::before {
   background: rgba(255, 255, 255, 0.025);
 }
 
+.home-page .home-proof-strip .media-item:hover,
+.home-page .home-proof-strip .media-item:focus-within {
+  transform: translateY(-2px);
+  border-color: rgba(255, 196, 225, 0.54);
+}
+
 .home-page .home-proof-strip .media-thumb {
   aspect-ratio: 16 / 10;
   max-height: 74px;
@@ -699,6 +791,7 @@ html[data-theme="light"] .home-page .home-proof-strip .media-thumb {
 .home-page .home-proof-strip .tool-mark:focus-within,
 .home-page .home-proof-strip .tool-mark:hover {
   border-color: rgba(255, 196, 225, 0.52);
+  transform: translateY(-1px);
 }
 
 .home-page .home-proof-strip .tool-mark img {
@@ -785,7 +878,18 @@ html[data-theme="light"] .home-page .home-proof-strip .media-thumb {
   body.home-page::after,
   .home-page .home-hero-cosmos,
   .home-page .home-hero-fog,
-  .home-page .tag-skeleton-row::before {
+  .home-page .tag-skeleton-row::before,
+  .home-page .btn,
+  .home-page .rtag,
+  .home-page .kpi-badge,
+  .home-page .panel-glass,
+  .home-page .hero-panel,
+  .home-page .hero-proof,
+  .home-page .listing-item,
+  .home-page .home-proof-strip .media-item,
+  .home-page .home-proof-strip .tool-mark {
     animation: none !important;
+    transition: none !important;
+    transform: none !important;
   }
 }

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -1,0 +1,237 @@
+/* Home-only visual polish. Loaded only by site/index.html */
+body.home-page {
+  --home-accent: #ff69b4;
+  --home-accent-soft: rgba(255, 105, 180, 0.22);
+  --home-glass-border: rgba(245, 247, 255, 0.16);
+  --home-surface: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(12, 16, 26, 0.58));
+  --home-shadow: 0 22px 44px rgba(2, 6, 14, 0.45);
+  --acc: var(--home-accent);
+  --acc2: #a8b6ff;
+  --heading: #f5f7ff;
+  background:
+    radial-gradient(900px 420px at 84% -10%, rgba(255, 105, 180, 0.14), transparent 72%),
+    radial-gradient(860px 420px at -12% 114%, rgba(168, 182, 255, 0.12), transparent 72%),
+    linear-gradient(180deg, #04060c 0%, #080c15 56%, #0a0f1a 100%);
+}
+
+html[data-theme="light"] body.home-page {
+  --home-accent: #d65b95;
+  --home-accent-soft: rgba(214, 91, 149, 0.16);
+  --home-glass-border: rgba(26, 34, 52, 0.12);
+  --home-surface: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(247, 249, 255, 0.84));
+  --home-shadow: 0 16px 30px rgba(30, 36, 56, 0.1);
+  --acc: var(--home-accent);
+  --acc2: #778ad9;
+  --heading: #151b2b;
+  color: #1c2437;
+  background:
+    radial-gradient(920px 420px at 84% -10%, rgba(214, 91, 149, 0.12), transparent 72%),
+    radial-gradient(860px 420px at -12% 114%, rgba(119, 138, 217, 0.08), transparent 72%),
+    linear-gradient(180deg, #fcfdff 0%, #f5f7fc 56%, #edf1f8 100%);
+}
+
+body.home-page::before {
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+  background-size: 62px 62px;
+}
+
+html[data-theme="light"] body.home-page::before {
+  background:
+    linear-gradient(rgba(18, 26, 44, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(18, 26, 44, 0.04) 1px, transparent 1px);
+  background-size: 62px 62px;
+}
+
+body.home-page::after {
+  opacity: 0.22;
+}
+
+.home-page .home-hero {
+  min-height: 64vh;
+  padding-top: 68px;
+  padding-bottom: 22px;
+  align-items: flex-end;
+  isolation: isolate;
+}
+
+.home-page .home-hero-cosmos,
+.home-page .home-hero-fog {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.home-page .home-hero-cosmos {
+  background:
+    radial-gradient(circle at 16% 20%, rgba(255, 255, 255, 0.2) 0 1px, transparent 2px),
+    radial-gradient(circle at 76% 32%, rgba(255, 255, 255, 0.16) 0 1px, transparent 2px),
+    radial-gradient(circle at 58% 84%, rgba(255, 255, 255, 0.12) 0 1px, transparent 2px),
+    linear-gradient(120deg, rgba(255, 105, 180, 0.12), rgba(168, 182, 255, 0.08) 44%, transparent 74%);
+  animation: home-drift 28s ease-in-out infinite;
+}
+
+.home-page .home-hero-fog {
+  background:
+    radial-gradient(1200px 260px at 34% 16%, rgba(255, 255, 255, 0.1), transparent 72%),
+    radial-gradient(900px 220px at 72% 78%, rgba(255, 255, 255, 0.08), transparent 72%);
+  mix-blend-mode: screen;
+  animation: home-fog 24s ease-in-out infinite;
+}
+
+html[data-theme="light"] .home-page .home-hero-cosmos {
+  opacity: 0.3;
+}
+
+html[data-theme="light"] .home-page .home-hero-fog {
+  mix-blend-mode: normal;
+  opacity: 0.7;
+}
+
+.home-page .hero-panel,
+.home-page .hero-proof,
+.home-page .panel-glass {
+  background: var(--home-surface);
+  border-color: var(--home-glass-border);
+  box-shadow: var(--home-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.home-page .hero-panel {
+  padding: 28px 30px 24px;
+}
+
+.home-page .hero-proof-hd {
+  background: var(--home-accent-soft);
+}
+
+.home-page .htitle,
+.home-page .stitle {
+  color: var(--heading);
+}
+
+.home-page .htitle .hl {
+  background: linear-gradient(130deg, var(--home-accent), #ff97c8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.home-page .htag,
+.home-page .kicker,
+.home-page .dash-title {
+  color: color-mix(in srgb, var(--home-accent), var(--txt) 26%);
+}
+
+.home-page .htag::before {
+  background: color-mix(in srgb, var(--home-accent), white 22%);
+}
+
+.home-page .proof-dashboard-wrap {
+  margin-top: clamp(-1.1rem, -1.8vw, -0.2rem);
+}
+
+.home-page .dashboard-shell {
+  border-color: rgba(245, 247, 255, 0.14);
+  background:
+    linear-gradient(180deg, rgba(245, 247, 255, 0.05), transparent 24%),
+    repeating-linear-gradient(90deg, rgba(245, 247, 255, 0.04) 0 1px, transparent 1px 58px),
+    linear-gradient(160deg, rgba(8, 12, 22, 0.72), rgba(12, 17, 30, 0.78));
+}
+
+html[data-theme="light"] .home-page .dashboard-shell {
+  border-color: rgba(24, 32, 52, 0.16);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(249, 250, 255, 0.8)),
+    repeating-linear-gradient(90deg, rgba(24, 32, 52, 0.05) 0 1px, transparent 1px 58px);
+}
+
+.home-page .kpi-badge strong {
+  font-size: 1.34rem;
+}
+
+.home-page .home-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.56rem;
+}
+
+.home-page .btn-p {
+  background: linear-gradient(120deg, #ff7fc4, #db5b99);
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(130, 24, 79, 0.36);
+}
+
+.home-page .btn-g {
+  border-color: color-mix(in srgb, var(--home-accent), transparent 62%);
+}
+
+.home-page .fallback-sep {
+  font-family: var(--mono);
+  color: var(--faint);
+  margin-inline: 0.2rem;
+}
+
+.home-page .tag-chart-skeleton {
+  display: grid;
+  gap: 0.48rem;
+}
+
+.home-page .tag-skeleton-row {
+  height: 0.86rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.08));
+  background-size: 180% 100%;
+  animation: home-skeleton 1.8s ease-in-out infinite;
+}
+
+html[data-theme="light"] .home-page .tag-skeleton-row {
+  background: linear-gradient(90deg, rgba(24, 32, 52, 0.08), rgba(24, 32, 52, 0.14), rgba(24, 32, 52, 0.08));
+  background-size: 180% 100%;
+}
+
+.home-page .home-proof-strip .tool-marks {
+  gap: 0.4rem;
+}
+
+.home-page .home-proof-strip .tool-mark {
+  padding: 0.28rem 0.52rem;
+  font-size: 0.62rem;
+  border-color: color-mix(in srgb, var(--home-accent), transparent 70%);
+  background: color-mix(in srgb, var(--bg2), transparent 12%);
+}
+
+.home-page .home-proof-strip .tool-mark img {
+  width: 16px;
+  height: 16px;
+}
+
+@keyframes home-drift {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50% { transform: translate3d(-1.1%, 0.7%, 0); }
+}
+
+@keyframes home-fog {
+  0%, 100% { transform: translate3d(0, 0, 0); opacity: 0.9; }
+  50% { transform: translate3d(1%, -0.5%, 0); opacity: 1; }
+}
+
+@keyframes home-skeleton {
+  0% { background-position: 100% 0; }
+  100% { background-position: -80% 0; }
+}
+
+@media (max-width: 980px) {
+  .home-page .hero-panel {
+    padding: 22px 20px 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-page .home-hero-cosmos,
+  .home-page .home-hero-fog,
+  .home-page .tag-skeleton-row {
+    animation: none !important;
+  }
+}

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -110,6 +110,12 @@ body.home-page::after {
   box-shadow: 0 0 0 3px rgba(232, 115, 172, 0.2);
 }
 
+.home-page .logo-monogram {
+  background: var(--accent);
+  color: #231821;
+  box-shadow: 0 0 0 1px rgba(255, 213, 235, 0.26);
+}
+
 .home-page .mob-menu {
   background: rgba(11, 8, 14, 0.95);
   border-bottom-color: var(--border);
@@ -532,8 +538,10 @@ html[data-theme="light"] .home-page .chart-axis {
   filter: drop-shadow(0 8px 14px rgba(90, 27, 59, 0.3));
 }
 
+.home-page .chart-bar:hover,
 .home-page .chart-bar-link:focus-visible .chart-bar {
   stroke: var(--accent);
+  filter: drop-shadow(0 10px 18px rgba(90, 27, 59, 0.36));
 }
 
 .home-page .chart-tooltip {
@@ -544,6 +552,16 @@ html[data-theme="light"] .home-page .chart-axis {
 html[data-theme="light"] .home-page .chart-tooltip {
   background: linear-gradient(160deg, rgba(253, 249, 252, 0.95), rgba(244, 235, 241, 0.96));
   color: var(--text);
+}
+
+.home-page .chart-data-source a,
+.home-page .listing a {
+  color: color-mix(in srgb, var(--accent), white 22%);
+}
+
+.home-page .chart-data-source a:hover,
+.home-page .listing a:hover {
+  color: var(--link-hover);
 }
 
 .home-page .chart-fallback-list {

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -92,7 +92,8 @@ body.home-page::after {
     radial-gradient(circle at 78% 30%, var(--stars) 0 1.1px, transparent 1.8px),
     radial-gradient(circle at 58% 80%, rgba(255, 216, 237, 0.16) 0 1px, transparent 1.7px),
     radial-gradient(circle at 30% 70%, var(--stars) 0 1.2px, transparent 2px);
-  opacity: 0.28;
+  opacity: 0.26;
+  animation: none;
 }
 
 .home-page a:focus-visible,
@@ -129,10 +130,26 @@ html[data-theme="light"] .home-page .mob-menu {
   border-left-color: var(--accent);
 }
 
+.home-page .fluid-section::before {
+  background: radial-gradient(920px 360px at 12% -20%, rgba(232, 115, 172, 0.11), transparent 72%);
+}
+
+.home-page .fluid-section::after {
+  background: radial-gradient(1240px 500px at 96% 108%, rgba(139, 84, 132, 0.1), transparent 72%);
+}
+
+html[data-theme="light"] .home-page .fluid-section::before {
+  background: radial-gradient(920px 360px at 12% -20%, rgba(186, 78, 129, 0.08), transparent 72%);
+}
+
+html[data-theme="light"] .home-page .fluid-section::after {
+  background: radial-gradient(1240px 500px at 96% 108%, rgba(163, 132, 163, 0.09), transparent 72%);
+}
+
 .home-page .home-hero {
-  min-height: 58vh;
+  min-height: 54vh;
   padding-top: 70px;
-  padding-bottom: 8px;
+  padding-bottom: 4px;
   align-items: flex-end;
   isolation: isolate;
 }
@@ -198,6 +215,32 @@ html[data-theme="light"] .home-page .home-hero-fog {
 
 .home-page .proof-dashboard-wrap::before {
   background: radial-gradient(960px 320px at 8% -10%, rgba(232, 115, 172, 0.15), transparent 72%);
+}
+
+.home-page .timeline li,
+.home-page .listing-item {
+  border: 1px solid var(--border);
+  border-radius: 1.05rem;
+  background: linear-gradient(160deg, rgba(16, 10, 24, 0.74), rgba(19, 12, 29, 0.76));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+html[data-theme="light"] .home-page .timeline li,
+html[data-theme="light"] .home-page .listing-item {
+  background: linear-gradient(160deg, rgba(255, 251, 255, 0.92), rgba(244, 235, 241, 0.9));
+}
+
+.home-page .listing-item:hover,
+.home-page .listing-item:focus-within {
+  border-color: color-mix(in srgb, var(--accent), transparent 35%);
+}
+
+.home-page .signal-list li {
+  border-left-color: color-mix(in srgb, var(--accent), transparent 40%);
+}
+
+.home-page .operator-console {
+  border-color: color-mix(in srgb, var(--accent), transparent 50%);
 }
 
 .home-page .hero-panel {
@@ -376,7 +419,7 @@ html[data-theme="light"] .home-page .sbadge {
 
 .home-page main > section,
 .home-page .fluid-section {
-  padding: 3.3rem 0;
+  padding: 2.9rem 0;
 }
 
 .home-page .proof-dashboard-wrap {
@@ -384,7 +427,7 @@ html[data-theme="light"] .home-page .sbadge {
 }
 
 .home-page .section-intro {
-  margin-bottom: 1rem;
+  margin-bottom: 0.85rem;
 }
 
 .home-page .dashboard-band,
@@ -458,10 +501,10 @@ html[data-theme="light"] .home-page .chart-tooltip {
 }
 
 .home-page .chart-fallback-list li {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
+  display: flex;
+  justify-content: space-between;
   align-items: baseline;
-  gap: 0.48rem;
+  gap: 0.62rem;
   font-family: var(--mono);
 }
 
@@ -469,12 +512,18 @@ html[data-theme="light"] .home-page .chart-tooltip {
   color: #ffd3ea;
 }
 
+.home-page .chart-fallback-list li:not(.has-sep) strong::before {
+  content: "\2014";
+  color: var(--muted);
+  margin-right: 0.42rem;
+}
+
 html[data-theme="light"] .home-page .chart-fallback-list strong {
   color: #7f3157;
 }
 
 .home-page .fallback-sep {
-  display: inline-flex;
+  display: none;
   margin: 0 0.1rem;
   color: var(--muted);
   opacity: 0.86;
@@ -528,19 +577,19 @@ html[data-theme="light"] .home-page .tag-skeleton-row::before {
 }
 
 .home-page .home-proof-strip .media-grid {
-  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-  gap: 0.48rem;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 0.44rem;
 }
 
 .home-page .home-proof-strip .media-item {
   border-color: rgba(255, 217, 237, 0.24);
-  border-radius: 0.7rem;
-  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0.62rem;
+  background: rgba(255, 255, 255, 0.025);
 }
 
 .home-page .home-proof-strip .media-thumb {
-  aspect-ratio: 4 / 3;
-  max-height: 96px;
+  aspect-ratio: 16 / 10;
+  max-height: 74px;
   background: rgba(17, 11, 23, 0.84);
 }
 
@@ -554,11 +603,18 @@ html[data-theme="light"] .home-page .home-proof-strip .media-thumb {
   object-fit: cover;
 }
 
+.home-page .home-proof-strip .media-btn img[src$=".svg"] {
+  object-fit: contain;
+  padding: 0.35rem;
+}
+
 .home-page .home-proof-strip figcaption {
   font-size: 0.6rem;
-  line-height: 1.3;
-  padding: 0.38rem 0.46rem 0.46rem;
-  word-break: break-word;
+  line-height: 1.2;
+  padding: 0.32rem 0.42rem 0.4rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .home-page .home-proof-strip .tool-marks {
@@ -570,6 +626,11 @@ html[data-theme="light"] .home-page .home-proof-strip .media-thumb {
   background: rgba(255, 255, 255, 0.03);
   padding: 0.28rem 0.5rem;
   font-size: 0.61rem;
+}
+
+.home-page .home-proof-strip .tool-mark:focus-within,
+.home-page .home-proof-strip .tool-mark:hover {
+  border-color: rgba(255, 196, 225, 0.52);
 }
 
 .home-page .home-proof-strip .tool-mark img {

--- a/site/index.html
+++ b/site/index.html
@@ -67,10 +67,10 @@
       <div class="hero-c">
         <div class="hero-panel" data-reveal>
           <div class="htag">EVIDENCE-FIRST SECURITY PORTFOLIO</div>
-          <h1 class="htitle">Detection content that <span class="hl">survives verification</span>, mapping, and deployment.</h1>
+          <h1 class="htitle">Detection content that <span class="hl">survives verification</span>, mapping, and production review.</h1>
           <p class="hsub">
-            Sigma, Wazuh, and Splunk detections plus IR playbooks and triage flows.
-            Every claim is traceable to a public artifact.
+            Sigma, Wazuh, and Splunk detections plus IR playbooks and triage lanes.
+            Every public claim resolves to a reproducible artifact.
           </p>
 
           <div class="hproof" aria-label="Verification steps">
@@ -101,17 +101,17 @@
           </div>
 
           <div class="hctas">
-            <a class="btn btn-p" href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">Clone the repo</a>
+            <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">Clone the repo</a>
             <a class="btn btn-g" href="proof.html">See the proof pack</a>
             <a class="btn btn-g" href="/assets/Raylee_Hawkins_Resume.pdf" target="_blank" rel="noreferrer">Download resume</a>
           </div>
 
           <div class="sbadge"><span class="sdot"></span> Huntsville-adjacent • North Alabama</div>
-          <div class="lupd">Counts and links align to <code>raylee-ops/HawkinsOperations</code> (verified, reproducible today).</div>
+          <div class="lupd">Counts and links align to <code>raylee-hawkins/HawkinsOperations</code> (verified, reproducible today).</div>
         </div>
       </div>
 
-      <aside class="hero-proof" aria-label="Proof pack visual preview" data-reveal data-reveal-delay="60ms">
+      <aside class="hero-proof operator-console" aria-label="Proof pack visual preview" data-reveal data-reveal-delay="60ms">
         <div class="hero-proof-label">Verification console</div>
         <div class="hero-proof-shot">
           <div class="hero-proof-hd">
@@ -167,18 +167,18 @@ IR playbooks ...  10</code></pre>
             <span>Verified on date</span>
           </div>
         </div>
-        <p class="lupd" style="margin-top:0.75rem">Source: <a id="verified-source" href="https://github.com/raylee-ops/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noreferrer">PROOF_PACK/VERIFIED_COUNTS.md</a>.</p>
+        <p class="lupd" style="margin-top:0.75rem">Source: <a id="verified-source" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noreferrer">PROOF_PACK/VERIFIED_COUNTS.md</a>.</p>
       </article>
 
       <article class="panel-glass chart-panel home-coverage-panel" data-reveal data-reveal-delay="70ms">
         <h3 class="dash-title">Coverage overview</h3>
         <div id="coverage-chart" class="chart-shell">
           <ul class="chart-fallback-list">
-            <li><span>Detections</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>142</strong></li>
-            <li><span>Sigma Rules</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>105</strong></li>
-            <li><span>Wazuh Blocks</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>29</strong></li>
-            <li><span>Splunk Queries</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>8</strong></li>
-            <li><span>Playbooks</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>10</strong></li>
+            <li class="has-sep"><span>Detections &mdash;</span><strong>142</strong></li>
+            <li class="has-sep"><span>Sigma Rules &mdash;</span><strong>105</strong></li>
+            <li class="has-sep"><span>Wazuh Blocks &mdash;</span><strong>29</strong></li>
+            <li class="has-sep"><span>Splunk Queries &mdash;</span><strong>8</strong></li>
+            <li class="has-sep"><span>Playbooks &mdash;</span><strong>10</strong></li>
           </ul>
         </div>
         <p class="chart-data-source">Data source: <a href="/assets/verified-counts.json">/assets/verified-counts.json</a></p>
@@ -217,7 +217,7 @@ IR playbooks ...  10</code></pre>
     <article class="panel-glass home-proof-strip" data-reveal>
       <h3 class="dash-title">Proof in action</h3>
       <p class="lupd">Only safe assets are rendered. Home keeps this lane compact with tool marks, never oversized logo tiles.</p>
-      <div id="proof-gallery-strip" class="home-gallery-compact" data-home-gallery="compact" data-media-gallery data-tags="sigma,wazuh,splunk,automation" data-limit="6"></div>
+      <div id="proof-gallery-strip" class="home-gallery-compact" data-home-gallery="compact" data-media-gallery data-tags="sigma,wazuh,splunk,automation" data-limit="6" aria-label="Compact proof strip"></div>
     </article>
   </div>
 </section>
@@ -291,7 +291,7 @@ IR playbooks ...  10</code></pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -67,17 +67,19 @@
       <div class="hero-c">
         <div class="hero-panel" data-reveal>
           <div class="htag">EVIDENCE-FIRST SECURITY PORTFOLIO</div>
-          <h1 class="htitle">Detection content that is <span class="hl">tested</span>, mapped, and deployable.</h1>
+          <h1 class="htitle">Detection content that <span class="hl">survives verification</span>, mapping, and deployment.</h1>
           <p class="hsub">
-            Sigma, Wazuh, and Splunk detections plus IR playbooks and a triage simulator.
-            Everything is auditable in GitHub.
+            Sigma, Wazuh, and Splunk detections plus IR playbooks and triage flows.
+            Every claim is traceable to a public artifact.
           </p>
 
-          <div class="hproof">
-            <b>Proof</b> over vibes:
-            <br>• Clone the repo
-            <br>• Run the verify commands
-            <br>• Match the counts
+          <div class="hproof" aria-label="Verification steps">
+            <p><b>Proof path</b></p>
+            <ol class="hproof-steps">
+              <li>Clone the repository lane.</li>
+              <li>Run verification commands.</li>
+              <li>Match public counts and artifacts.</li>
+            </ol>
           </div>
           <div class="hero-icons" aria-label="Proof highlights">
             <span class="ico-chip">
@@ -110,7 +112,7 @@
       </div>
 
       <aside class="hero-proof" aria-label="Proof pack visual preview" data-reveal data-reveal-delay="60ms">
-        <div class="hero-proof-label">Reproducible artifacts</div>
+        <div class="hero-proof-label">Verification console</div>
         <div class="hero-proof-shot">
           <div class="hero-proof-hd">
             <span></span><span></span><span></span>
@@ -172,11 +174,11 @@ IR playbooks ...  10</code></pre>
         <h3 class="dash-title">Coverage overview</h3>
         <div id="coverage-chart" class="chart-shell">
           <ul class="chart-fallback-list">
-            <li><span>Detections</span><span class="fallback-sep" aria-hidden="true">-</span><strong>142</strong></li>
-            <li><span>Sigma Rules</span><span class="fallback-sep" aria-hidden="true">-</span><strong>105</strong></li>
-            <li><span>Wazuh Blocks</span><span class="fallback-sep" aria-hidden="true">-</span><strong>29</strong></li>
-            <li><span>Splunk Queries</span><span class="fallback-sep" aria-hidden="true">-</span><strong>8</strong></li>
-            <li><span>Playbooks</span><span class="fallback-sep" aria-hidden="true">-</span><strong>10</strong></li>
+            <li><span>Detections</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>142</strong></li>
+            <li><span>Sigma Rules</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>105</strong></li>
+            <li><span>Wazuh Blocks</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>29</strong></li>
+            <li><span>Splunk Queries</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>8</strong></li>
+            <li><span>Playbooks</span><span class="fallback-sep" aria-hidden="true">&mdash;</span><strong>10</strong></li>
           </ul>
         </div>
         <p class="chart-data-source">Data source: <a href="/assets/verified-counts.json">/assets/verified-counts.json</a></p>
@@ -188,7 +190,7 @@ IR playbooks ...  10</code></pre>
         <h3 class="dash-title">Detections by tag</h3>
         <div id="detections-tag-chart" class="chart-shell">
           <div class="tag-chart-skeleton" role="status" aria-live="polite">
-            <p class="lupd">Loading tag coverage from detections manifest...</p>
+            <p class="lupd">Loading tag coverage from detection manifests...</p>
             <div class="tag-skeleton-row"></div>
             <div class="tag-skeleton-row"></div>
             <div class="tag-skeleton-row"></div>
@@ -215,7 +217,7 @@ IR playbooks ...  10</code></pre>
     <article class="panel-glass home-proof-strip" data-reveal>
       <h3 class="dash-title">Proof in action</h3>
       <p class="lupd">Only safe assets are rendered. Home keeps this lane compact with tool marks, never oversized logo tiles.</p>
-      <div id="proof-gallery-strip" data-media-gallery data-tags="sigma,wazuh,splunk,automation" data-limit="8"></div>
+      <div id="proof-gallery-strip" class="home-gallery-compact" data-home-gallery="compact" data-media-gallery data-tags="sigma,wazuh,splunk,automation" data-limit="6"></div>
     </article>
   </div>
 </section>

--- a/site/index.html
+++ b/site/index.html
@@ -125,6 +125,11 @@ Wazuh blocks ...  29
 IR playbooks ...  10</code></pre>
         </div>
         <p>Single-command verification mapped to public proof artifacts.</p>
+        <ul class="console-lane" aria-label="Verification lane signals">
+          <li><span>Pipeline</span><strong>Repository -> verify -> evidence</strong></li>
+          <li><span>Claim policy</span><strong>Only verifiable public claims</strong></li>
+          <li><span>Reviewer speed</span><strong>Ten-minute technical pass</strong></li>
+        </ul>
       </aside>
     </div>
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -27,8 +27,9 @@
 </script>
 <link rel="stylesheet" href="assets/styles.css">
 <link rel="stylesheet" href="assets/design-system.css">
+<link rel="stylesheet" href="assets/home.css">
 </head>
-<body>
+<body class="home-page">
 <a class="skip-link" href="#main-content">Skip to main content</a>
 <nav>
   <div class="nav-i">
@@ -57,7 +58,9 @@
 </div>
 
 <main id="main-content">
-<header class="hero">
+<header class="hero home-hero">
+  <div class="home-hero-cosmos" aria-hidden="true"></div>
+  <div class="home-hero-fog" aria-hidden="true"></div>
   <div class="hero-glow"></div>
   <div class="ctr">
     <div class="hero-layout">
@@ -134,7 +137,7 @@ IR playbooks ...  10</code></pre>
     </div>
 
     <div class="dashboard-band">
-      <article class="panel-glass" data-reveal>
+      <article class="panel-glass home-kpi-panel" data-reveal>
         <h3 class="dash-title">KPI lane</h3>
         <div class="dashboard-kpi-grid">
           <div class="kpi-badge">
@@ -165,15 +168,15 @@ IR playbooks ...  10</code></pre>
         <p class="lupd" style="margin-top:0.75rem">Source: <a id="verified-source" href="https://github.com/raylee-ops/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noreferrer">PROOF_PACK/VERIFIED_COUNTS.md</a>.</p>
       </article>
 
-      <article class="panel-glass chart-panel" data-reveal data-reveal-delay="70ms">
+      <article class="panel-glass chart-panel home-coverage-panel" data-reveal data-reveal-delay="70ms">
         <h3 class="dash-title">Coverage overview</h3>
         <div id="coverage-chart" class="chart-shell">
           <ul class="chart-fallback-list">
-            <li><span>Detections</span><strong>142</strong></li>
-            <li><span>Sigma Rules</span><strong>105</strong></li>
-            <li><span>Wazuh Blocks</span><strong>29</strong></li>
-            <li><span>Splunk Queries</span><strong>8</strong></li>
-            <li><span>Playbooks</span><strong>10</strong></li>
+            <li><span>Detections</span><span class="fallback-sep" aria-hidden="true">-</span><strong>142</strong></li>
+            <li><span>Sigma Rules</span><span class="fallback-sep" aria-hidden="true">-</span><strong>105</strong></li>
+            <li><span>Wazuh Blocks</span><span class="fallback-sep" aria-hidden="true">-</span><strong>29</strong></li>
+            <li><span>Splunk Queries</span><span class="fallback-sep" aria-hidden="true">-</span><strong>8</strong></li>
+            <li><span>Playbooks</span><span class="fallback-sep" aria-hidden="true">-</span><strong>10</strong></li>
           </ul>
         </div>
         <p class="chart-data-source">Data source: <a href="/assets/verified-counts.json">/assets/verified-counts.json</a></p>
@@ -184,27 +187,35 @@ IR playbooks ...  10</code></pre>
       <article class="panel-glass chart-panel" data-reveal>
         <h3 class="dash-title">Detections by tag</h3>
         <div id="detections-tag-chart" class="chart-shell">
-          <p class="lupd">Loading tag coverage from detections manifest...</p>
+          <div class="tag-chart-skeleton" role="status" aria-live="polite">
+            <p class="lupd">Loading tag coverage from detections manifest...</p>
+            <div class="tag-skeleton-row"></div>
+            <div class="tag-skeleton-row"></div>
+            <div class="tag-skeleton-row"></div>
+          </div>
         </div>
         <p class="chart-data-source">Data source: <a href="/assets/data/detections.json">/assets/data/detections.json</a></p>
       </article>
 
-      <aside class="panel-glass" data-reveal data-reveal-delay="90ms">
+      <aside class="panel-glass home-actions-panel" data-reveal data-reveal-delay="90ms">
         <h3 class="dash-title">Inventory actions</h3>
         <ul class="dashboard-cta-list">
           <li>Inspect every detection record with platform and evidence links.</li>
           <li>Filter by tag and map results to proof-ready artifacts.</li>
           <li>Use command-level verify lanes before reviewing claims.</li>
         </ul>
-        <a class="btn btn-p" href="security.html#detection-inventory">View inventory</a>
+        <div class="home-action-row">
+          <a class="btn btn-p" href="security.html#detection-inventory">View inventory</a>
+          <a class="btn btn-g" href="proof.html#verified-lane">Open proof workflow</a>
+        </div>
         <p class="lupd" style="margin-top:0.75rem">Verify lane: <code>pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</code></p>
       </aside>
     </div>
 
-    <article class="panel-glass" data-reveal>
+    <article class="panel-glass home-proof-strip" data-reveal>
       <h3 class="dash-title">Proof in action</h3>
-      <p class="lupd">Only safe assets are rendered. Screenshot/dashboard/diagram artifacts are prioritized; logos are shown as compact tool marks if no proof screenshots exist.</p>
-      <div id="proof-gallery-strip" data-media-gallery data-tags="proof,dashboard,detection,diagram" data-limit="6"></div>
+      <p class="lupd">Only safe assets are rendered. Home keeps this lane compact with tool marks, never oversized logo tiles.</p>
+      <div id="proof-gallery-strip" data-media-gallery data-tags="sigma,wazuh,splunk,automation" data-limit="8"></div>
     </article>
   </div>
 </section>

--- a/site/index.html
+++ b/site/index.html
@@ -126,9 +126,10 @@ IR playbooks ...  10</code></pre>
         </div>
         <p>Single-command verification mapped to public proof artifacts.</p>
         <ul class="console-lane" aria-label="Verification lane signals">
-          <li><span>Pipeline</span><strong>Repository -> verify -> evidence</strong></li>
-          <li><span>Claim policy</span><strong>Only verifiable public claims</strong></li>
-          <li><span>Reviewer speed</span><strong>Ten-minute technical pass</strong></li>
+          <li><span>Host target</span><strong>Cloudflare Pages (production lane)</strong></li>
+          <li><span>Safety gate</span><strong>Safe media only (privacy_review = ok)</strong></li>
+          <li><span>Reviewer path</span><strong>Home -> Proof -> Security inventory</strong></li>
+          <li><span>Data sources</span><strong>verified-counts.json + detections.json</strong></li>
         </ul>
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- Home-only redesign to operator-console intimidation style with dark/light theme parity.
- Removed blue/cyan presentation on Home by overriding shared section/card tints with near-black/plum + controlled pink accents.
- Tightened Home rhythm so KPI/dashboard modules surface earlier.
- Hardened Home fallback readability for coverage rows with visible separators.
- Kept proof strip compact and chip-first on Home (no oversized logo tile presentation).

## Scope
- site/index.html
- site/assets/home.css

## Verification
- node scripts/verify/no-netlify.js
- pwsh -NoProfile -File scripts/verify/verify-counts.ps1