### PR TITLE
fix: stop static-site deploy degradation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,6 +32,11 @@ jobs:
         run: |
           node .\scripts\verify\no-netlify.js
 
+      - name: Static site diagnosis gate
+        shell: pwsh
+        run: |
+          node .\scripts\diagnose-site.js --fail-on-issues
+
       - name: Generate verified counts markdown
         shell: pwsh
         run: |

--- a/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.json
+++ b/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.json
@@ -1,0 +1,1122 @@
+{
+  "generatedAt": "2026-02-18T00:17:53.397Z",
+  "environment": {
+    "cwd": "C:\\RH\\OPS\\PUBLISH\\GITHUB\\repos\\HawkinsOperations",
+    "siteDir": "site"
+  },
+  "coverage": {
+    "htmlFilesScanned": 10,
+    "jsFilesScanned": 8,
+    "fetchCallsFound": 0
+  },
+  "checks": {
+    "assetPathAudit": {
+      "siteConvention": "absolute_root",
+      "absoluteTotal": 53,
+      "relativeTotal": 0,
+      "homepageAbsoluteInnerRelativePattern": false,
+      "pagesDifferingFromConvention": [],
+      "perPage": [
+        {
+          "page": "site/404.html",
+          "canonicalHref": "https://hawkinsops.com/404",
+          "localAbsoluteCount": 3,
+          "localRelativeCount": 0,
+          "externalCount": 1,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/blog-python2-to-python3.html",
+          "canonicalHref": "https://hawkinsops.com/blog-python2-to-python3",
+          "localAbsoluteCount": 5,
+          "localRelativeCount": 0,
+          "externalCount": 4,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/case-study.html",
+          "canonicalHref": "https://hawkinsops.com/case-study",
+          "localAbsoluteCount": 5,
+          "localRelativeCount": 0,
+          "externalCount": 4,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/index.html",
+          "canonicalHref": "https://hawkinsops.com/",
+          "localAbsoluteCount": 5,
+          "localRelativeCount": 0,
+          "externalCount": 1,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/lab.html",
+          "canonicalHref": "https://hawkinsops.com/lab",
+          "localAbsoluteCount": 6,
+          "localRelativeCount": 0,
+          "externalCount": 1,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/projects.html",
+          "canonicalHref": "https://hawkinsops.com/projects",
+          "localAbsoluteCount": 7,
+          "localRelativeCount": 0,
+          "externalCount": 1,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/proof.html",
+          "canonicalHref": "https://hawkinsops.com/proof",
+          "localAbsoluteCount": 5,
+          "localRelativeCount": 0,
+          "externalCount": 4,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/resume.html",
+          "canonicalHref": "https://hawkinsops.com/resume",
+          "localAbsoluteCount": 5,
+          "localRelativeCount": 0,
+          "externalCount": 4,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/security.html",
+          "canonicalHref": "https://hawkinsops.com/security",
+          "localAbsoluteCount": 7,
+          "localRelativeCount": 0,
+          "externalCount": 1,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        },
+        {
+          "page": "site/triage.html",
+          "canonicalHref": "https://hawkinsops.com/triage",
+          "localAbsoluteCount": 5,
+          "localRelativeCount": 0,
+          "externalCount": 4,
+          "specialCount": 0,
+          "mixedLocalAssetStrategy": false,
+          "duplicateIds": []
+        }
+      ]
+    },
+    "canonicalization": {
+      "redirectsFilePresent": true,
+      "headersFilePresent": true,
+      "redirectsPreview": [
+        "# Cloudflare Pages serves extensionless routes for matching .html files.",
+        "# Keep this file for canonical file-path redirects only.",
+        "/security/ /security 301",
+        "/projects/ /projects 301",
+        "/lab/ /lab 301",
+        "/proof/ /proof 301",
+        "/Raylee_Hawkins_Resume.pdf /assets/Raylee_Hawkins_Resume.pdf 301",
+        "/assets/raylee_hawkins_resume.pdf /assets/Raylee_Hawkins_Resume.pdf 301",
+        ""
+      ],
+      "headersPreview": [
+        "/*",
+        "  X-Content-Type-Options: nosniff",
+        "  Referrer-Policy: strict-origin-when-cross-origin",
+        "  X-Frame-Options: DENY",
+        "  Permissions-Policy: camera=(), microphone=(), geolocation=()",
+        "  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+        "",
+        "/resume.txt",
+        "  Content-Type: text/plain; charset=utf-8",
+        ""
+      ],
+      "canonicalKinds": {
+        "file": 0,
+        "pretty_no_slash": 9,
+        "pretty_with_slash": 0,
+        "root": 1,
+        "other": 0
+      },
+      "canonicalizationIntent": "pretty_no_slash",
+      "trailingSlashHazards": []
+    },
+    "localResolver": {
+      "localAssetMissingReferences": []
+    },
+    "fetchAudit": {
+      "inconsistentLocalFetchStrategies": false,
+      "timeoutRiskFiles": [],
+      "fetchEntries": [],
+      "suspiciousFetches": []
+    },
+    "dataArtifacts": {
+      "expectedArtifacts": [
+        {
+          "file": "site/assets/verified-counts.json",
+          "exists": true
+        },
+        {
+          "file": "site/assets/data/detections.json",
+          "exists": true
+        },
+        {
+          "file": "site/assets/data/media.json",
+          "exists": true
+        },
+        {
+          "file": "site/assets/data/projects.json",
+          "exists": true
+        }
+      ],
+      "referencedJsonUrls": [],
+      "generatorScriptEvidence": [
+        {
+          "file": "scripts/diagnose-site.js",
+          "line": 16,
+          "text": "  \"site/assets/verified-counts.json\","
+        },
+        {
+          "file": "scripts/diagnose-site.js",
+          "line": 17,
+          "text": "  \"site/assets/data/detections.json\","
+        },
+        {
+          "file": "scripts/diagnose-site.js",
+          "line": 18,
+          "text": "  \"site/assets/data/media.json\","
+        },
+        {
+          "file": "scripts/diagnose-site.js",
+          "line": 19,
+          "text": "  \"site/assets/data/projects.json\""
+        },
+        {
+          "file": "scripts/diagnose-site.js",
+          "line": 586,
+          "text": "      \"Check Cloudflare build logs for generation script execution and verify deployed files under /assets/data and /assets/verified-counts.json.\","
+        },
+        {
+          "file": "scripts/generate-site-data.js",
+          "line": 8,
+          "text": "const outPath = path.join(root, \"site\", \"assets\", \"verified-counts.json\");"
+        },
+        {
+          "file": "scripts/smoke-production.js",
+          "line": 9,
+          "text": "  `${baseUrl}/assets/data/detections.json`,"
+        },
+        {
+          "file": "scripts/smoke-production.js",
+          "line": 10,
+          "text": "  `${baseUrl}/assets/data/media.json`,"
+        },
+        {
+          "file": "scripts/smoke-production.js",
+          "line": 11,
+          "text": "  `${baseUrl}/assets/verified-counts.json`"
+        },
+        {
+          "file": "scripts/smoke-production.js",
+          "line": 15,
+          "text": "  `${baseUrl}/assets/data/detections.json`,"
+        },
+        {
+          "file": "scripts/smoke-production.js",
+          "line": 16,
+          "text": "  `${baseUrl}/assets/data/media.json`,"
+        },
+        {
+          "file": "scripts/smoke-production.js",
+          "line": 17,
+          "text": "  `${baseUrl}/assets/verified-counts.json`"
+        },
+        {
+          "file": "scripts/smoke-production.ps1",
+          "line": 106,
+          "text": "  \"$BaseUrl/assets/data/detections.json\","
+        },
+        {
+          "file": "scripts/smoke-production.ps1",
+          "line": 107,
+          "text": "  \"$BaseUrl/assets/data/media.json\","
+        },
+        {
+          "file": "scripts/smoke-production.ps1",
+          "line": 108,
+          "text": "  \"$BaseUrl/assets/verified-counts.json\""
+        },
+        {
+          "file": "scripts/smoke-production.ps1",
+          "line": 122,
+          "text": "  \"$BaseUrl/assets/data/detections.json\","
+        },
+        {
+          "file": "scripts/smoke-production.ps1",
+          "line": 123,
+          "text": "  \"$BaseUrl/assets/data/media.json\","
+        },
+        {
+          "file": "scripts/smoke-production.ps1",
+          "line": 124,
+          "text": "  \"$BaseUrl/assets/verified-counts.json\""
+        }
+      ],
+      "cloudflareOutputEvidence": [
+        {
+          "file": "README.md",
+          "line": 95,
+          "text": "| `site/` | static portfolio site source | published recruiter-facing web content |"
+        },
+        {
+          "file": "README.md",
+          "line": 114,
+          "text": "      |-- generate-site-content.js      -> site/assets/data/*.json"
+        },
+        {
+          "file": "README.md",
+          "line": 139,
+          "text": "- Runtime remains static HTML/CSS/JS under `site/` (no framework lock-in)."
+        },
+        {
+          "file": "README.md",
+          "line": 140,
+          "text": "- Design tokens and fluid layout primitives: `site/assets/design-system.css`."
+        },
+        {
+          "file": "README.md",
+          "line": 142,
+          "text": "  - `site/projects.html` reads `site/assets/data/projects.json`."
+        },
+        {
+          "file": "README.md",
+          "line": 143,
+          "text": "  - `site/security.html` reads `site/assets/data/detections.json`."
+        },
+        {
+          "file": "README.md",
+          "line": 152,
+          "text": "Cloudflare Pages production build:"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 15,
+          "text": "- Primary production hosting: **Cloudflare Pages**"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 16,
+          "text": "- Publish directory: `site/`"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 18,
+          "text": "- Cloudflare Pages build command:"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 35,
+          "text": "- `site/assets/verified-counts.json`"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 36,
+          "text": "- `site/assets/data/projects.json`"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 37,
+          "text": "- `site/assets/data/detections.json`"
+        },
+        {
+          "file": "docs/hosting/CLOUDFLARE_PAGES.md",
+          "line": 1,
+          "text": "# Cloudflare Pages Production Settings"
+        },
+        {
+          "file": "docs/hosting/CLOUDFLARE_PAGES.md",
+          "line": 3,
+          "text": "This repository is a static site deployment from `site/`."
+        },
+        {
+          "file": "docs/hosting/CLOUDFLARE_PAGES.md",
+          "line": 7,
+          "text": "- Why: pages are static HTML/CSS/JS in `site/`, and data artifacts are generated by Node scripts before publish."
+        },
+        {
+          "file": "docs/hosting/CLOUDFLARE_PAGES.md",
+          "line": 9,
+          "text": "## Exact Cloudflare Pages UI settings"
+        },
+        {
+          "file": "docs/hosting/CLOUDFLARE_PAGES.md",
+          "line": 14,
+          "text": "- Build output directory: `site`"
+        },
+        {
+          "file": "docs/execution/HOSTING_TRANSFER_PROOF_PACK.md",
+          "line": 4,
+          "text": "Docs-only execution checklist for Cloudflare Pages hosting validation."
+        },
+        {
+          "file": "docs/execution/HOSTING_TRANSFER_PROOF_PACK.md",
+          "line": 7,
+          "text": "- Cloudflare Pages = production primary"
+        },
+        {
+          "file": "docs/execution/HOSTING_TRANSFER_PROOF_PACK.md",
+          "line": 15,
+          "text": "   - build command, publish directory (`site/`), branch mapping, environment notes"
+        },
+        {
+          "file": "docs/execution/HOSTING_TRANSFER_PROOF_PACK.md",
+          "line": 33,
+          "text": "- [ ] Cloudflare Pages production deploy screenshot/log link."
+        },
+        {
+          "file": "docs/execution/HOSTING_TRANSFER_PROOF_PACK.md",
+          "line": 34,
+          "text": "- [ ] Cloudflare Pages preview deploy screenshot/log link."
+        }
+      ]
+    },
+    "renameRegression": {
+      "currentOwner": "raylee-hawkins",
+      "legacyOwnerTokens": [
+        "raylee-ops",
+        "raylee_ops",
+        "rayleeops"
+      ],
+      "legacyOwnerHits": [
+        {
+          "token": "raylee-ops",
+          "file": ".github/ISSUE_TEMPLATE/config.yml",
+          "line": 4,
+          "text": "    url: https://github.com/raylee-ops/HawkinsOperations/blob/main/docs/VERIFY_COMMANDS_POWERSHELL.md"
+        },
+        {
+          "token": "raylee-ops",
+          "file": ".github/ISSUE_TEMPLATE/config.yml",
+          "line": 7,
+          "text": "    url: https://github.com/raylee-ops/HawkinsOperations/blob/main/SECURITY.md"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/migration-rh/PROOF_PACK/PROOF_INDEX.md",
+          "line": 7,
+          "text": "- Standalone release receipt: [`v0.9.0`](https://github.com/raylee-ops/RH_MIGRATION_2026_V2/releases/tag/v0.9.0)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/migration-rh/PROOF_PACK/PROOF_INDEX.md",
+          "line": 8,
+          "text": "- Standalone source repository: [`raylee-ops/RH_MIGRATION_2026_V2`](https://github.com/raylee-ops/RH_MIGRATION_2026_V2)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/migration-rh/PROOF_PACK/VERIFICATION.md",
+          "line": 19,
+          "text": "- https://github.com/raylee-ops/RH_MIGRATION_2026_V2/releases/tag/v0.9.0"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/migration-rh/README.md",
+          "line": 20,
+          "text": "- Repo: `raylee-ops/RH_MIGRATION_2026_V2`"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/migration-rh/README.md",
+          "line": 21,
+          "text": "- Release: [`v0.9.0` — Phase 08 complete (100% core phases)](https://github.com/raylee-ops/RH_MIGRATION_2026_V2/releases/tag/v0.9.0)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/migration-rh/SRC/reference/imports/README.md",
+          "line": 16,
+          "text": "**Source:** raylee-ops/RH_MIGRATION_2026_V2 (private, active project)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 5,
+          "text": "**PR:** https://github.com/raylee-ops/HawkinsOperations/pull/2"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 22,
+          "text": "- **URL:** https://github.com/raylee-ops/hawkinsops-framework"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 29,
+          "text": "- **URL:** https://github.com/raylee-ops/hawkins_ops"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 36,
+          "text": "- **URL:** https://github.com/raylee-ops/hawkinsops-site"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 43,
+          "text": "- **URL:** https://github.com/raylee-ops/RH_MIGRATION_2026_V2 (private)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 50,
+          "text": "- **URL:** https://github.com/raylee-ops/hawkinsops-soc-content (already archived)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 191,
+          "text": "gh repo archive raylee-ops/hawkinsops-framework --yes"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 192,
+          "text": "gh repo archive raylee-ops/hawkins_ops --yes"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 193,
+          "text": "gh repo archive raylee-ops/hawkinsops-site --yes"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 194,
+          "text": "gh repo archive raylee-ops/RH_MIGRATION_2026_V2 --yes"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/CONSOLIDATION_MAP.md",
+          "line": 250,
+          "text": "- **Pull Request:** https://github.com/raylee-ops/HawkinsOperations/pull/2"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 30,
+          "text": "git clone https://github.com/raylee-ops/hawkinsops-framework.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 37,
+          "text": "git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 52,
+          "text": "git clone https://github.com/raylee-ops/hawkins_ops.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 59,
+          "text": "git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 74,
+          "text": "git clone https://github.com/raylee-ops/hawkinsops-site.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 81,
+          "text": "git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 95,
+          "text": "git clone https://github.com/raylee-ops/RH_MIGRATION_2026_V2.git  # Private repo"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 102,
+          "text": "git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 141,
+          "text": "    run: git clone https://github.com/raylee-ops/hawkinsops-framework.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 144,
+          "text": "    run: git clone https://github.com/raylee-ops/hawkins_ops.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 151,
+          "text": "    run: git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 168,
+          "text": "See [hawkinsops-framework](https://github.com/raylee-ops/hawkinsops-framework)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 171,
+          "text": "See [HawkinsOperations/tools](https://github.com/raylee-ops/HawkinsOperations/tree/main/tools)"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 177,
+          "text": "git clone https://github.com/raylee-ops/hawkins_ops.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 180,
+          "text": "git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 190,
+          "text": "git clone https://github.com/raylee-ops/HawkinsOperations.git"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md",
+          "line": 229,
+          "text": "- **Issues:** Report at https://github.com/raylee-ops/HawkinsOperations/issues"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "projects/repo-history/RELEASE_NOTES_v1.1.0.md",
+          "line": 185,
+          "text": "**Repository:** https://github.com/raylee-ops/HawkinsOperations"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "PROOF_PACK/features/resume-ats-txt-endpoint/run_02-14-2026_000051/evidence/logs/local_headers_resume_html_02-14-2026.txt",
+          "line": 94,
+          "text": "          <a href=\"https://github.com/raylee-ops\" target=\"_blank\" rel=\"noreferrer\">GitHub</a> |"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "PROOF_PACK/features/resume-ats-txt-endpoint/run_02-14-2026_000051/evidence/logs/local_headers_resume_html_02-14-2026.txt",
+          "line": 173,
+          "text": "      <a href=\"https://github.com/raylee-ops/HawkinsOperations\" target=\"_blank\" rel=\"noreferrer\">GitHub</a>"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "PROOF_PACK/features/resume-ats-txt-endpoint/run_02-14-2026_000051/evidence/logs/local_headers_resume_txt_02-14-2026.txt",
+          "line": 13,
+          "text": "GitHub: https://github.com/raylee-ops"
+        },
+        {
+          "token": "raylee-ops",
+          "file": "README.md",
+          "line": 5,
+          "text": "[![Verification](https://img.shields.io/github/actions/workflow/status/raylee-ops/HawkinsOperations/verify.yml?branch=main&label=verify)](https://github.com/raylee-ops/HawkinsOperations/actions/workflows/verify.yml)"
+        }
+      ],
+      "rawGithubHits": [],
+      "netlifyHits": [
+        {
+          "file": ".github/workflows/verify.yml",
+          "line": 33,
+          "text": "          node .\\scripts\\verify\\no-netlify.js"
+        },
+        {
+          "file": "docs/hosting/CLOUDFLARE_PAGES.md",
+          "line": 13,
+          "text": "- Build command: `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`"
+        },
+        {
+          "file": "docs/ui/REFRACTOR_PR_PLAN.md",
+          "line": 7,
+          "text": "- Add `scripts/verify/no-netlify.js` and wire it into verification workflow."
+        },
+        {
+          "file": "PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt",
+          "line": 2,
+          "text": "Legacy provider target reference (Netlify hostname): hawkinsoperations.netlify.app"
+        },
+        {
+          "file": "PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt",
+          "line": 4,
+          "text": "=== nslookup hawkinsoperations.netlify.app 8.8.8.8 ==="
+        },
+        {
+          "file": "PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt",
+          "line": 8,
+          "text": "Name:    hawkinsoperations.netlify.app"
+        },
+        {
+          "file": "README.md",
+          "line": 73,
+          "text": "node .\\scripts\\verify\\no-netlify.js"
+        },
+        {
+          "file": "README.md",
+          "line": 153,
+          "text": "- `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`"
+        },
+        {
+          "file": "scripts/verify/no-netlify.js",
+          "line": 32,
+          "text": "  path.join(\"scripts\", \"verify\", \"no-netlify.js\").replaceAll(\"\\\\\", \"/\"),"
+        },
+        {
+          "file": "scripts/verify/no-netlify.js",
+          "line": 57,
+          "text": "    .replaceAll(\"scripts/verify/no-netlify.js\", \"scripts/verify/no-hosting-check.js\")"
+        },
+        {
+          "file": "scripts/verify/no-netlify.js",
+          "line": 58,
+          "text": "    .replaceAll(\".\\\\scripts\\\\verify\\\\no-netlify.js\", \".\\\\scripts\\\\verify\\\\no-hosting-check.js\");"
+        },
+        {
+          "file": "scripts/verify/README.md",
+          "line": 5,
+          "text": "- `no-netlify.js` enforces Cloudflare-only hosting consistency."
+        },
+        {
+          "file": "scripts/verify/README.md",
+          "line": 18,
+          "text": "node .\\scripts\\verify\\no-netlify.js"
+        },
+        {
+          "file": "site/README_DEPLOY.md",
+          "line": 19,
+          "text": "  - `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`"
+        }
+      ],
+      "legacyOwnersDetected": [
+        "alessandroz",
+        "gentilkiwi",
+        "raylee-ops",
+        "sigmahq",
+        "swiftonsecurity",
+        "your-username"
+      ]
+    },
+    "domMounts": {
+      "duplicateIds": [],
+      "scriptMountReferences": [
+        {
+          "script": "site/assets/app.js",
+          "id": "verified-date",
+          "line": 303,
+          "col": 31,
+          "loadedByPages": [
+            "site/blog-python2-to-python3.html",
+            "site/case-study.html",
+            "site/lab.html",
+            "site/projects.html",
+            "site/proof.html",
+            "site/resume.html",
+            "site/security.html",
+            "site/triage.html"
+          ],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "id": "verified-source",
+          "line": 308,
+          "col": 33,
+          "loadedByPages": [
+            "site/blog-python2-to-python3.html",
+            "site/case-study.html",
+            "site/lab.html",
+            "site/projects.html",
+            "site/proof.html",
+            "site/resume.html",
+            "site/security.html",
+            "site/triage.html"
+          ],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/components/sections/media-gallery.js",
+          "id": "mediaLightbox",
+          "line": 66,
+          "col": 21,
+          "loadedByPages": [],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "id": "detectionsChart",
+          "line": 264,
+          "col": 30,
+          "loadedByPages": [
+            "site/projects.html",
+            "site/security.html"
+          ],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "id": "securityTagMiniChart",
+          "line": 266,
+          "col": 33,
+          "loadedByPages": [
+            "site/projects.html",
+            "site/security.html"
+          ],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "id": "mitre-coverage-status",
+          "line": 269,
+          "col": 38,
+          "loadedByPages": [
+            "site/projects.html",
+            "site/security.html"
+          ],
+          "guarded": false
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "id": "coverage-chart",
+          "line": 273,
+          "col": 33,
+          "loadedByPages": [
+            "site/projects.html",
+            "site/security.html"
+          ],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "id": "detections-tag-chart",
+          "line": 274,
+          "col": 28,
+          "loadedByPages": [
+            "site/projects.html",
+            "site/security.html"
+          ],
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "id": "proof-gallery-strip",
+          "line": 275,
+          "col": 32,
+          "loadedByPages": [
+            "site/projects.html",
+            "site/security.html"
+          ],
+          "guarded": false
+        }
+      ],
+      "missingMountsByPage": [
+        {
+          "script": "site/assets/app.js",
+          "page": "site/blog-python2-to-python3.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/case-study.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/lab.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/projects.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/proof.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/resume.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/security.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/triage.html",
+          "id": "verified-date",
+          "scriptLine": 303,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/blog-python2-to-python3.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/case-study.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/lab.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/projects.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/proof.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/resume.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/security.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/app.js",
+          "page": "site/triage.html",
+          "id": "verified-source",
+          "scriptLine": 308,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/projects.html",
+          "id": "detectionsChart",
+          "scriptLine": 264,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/projects.html",
+          "id": "securityTagMiniChart",
+          "scriptLine": 266,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/projects.html",
+          "id": "mitre-coverage-status",
+          "scriptLine": 269,
+          "guarded": false
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/projects.html",
+          "id": "coverage-chart",
+          "scriptLine": 273,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/security.html",
+          "id": "coverage-chart",
+          "scriptLine": 273,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/projects.html",
+          "id": "detections-tag-chart",
+          "scriptLine": 274,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/security.html",
+          "id": "detections-tag-chart",
+          "scriptLine": 274,
+          "guarded": true
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/projects.html",
+          "id": "proof-gallery-strip",
+          "scriptLine": 275,
+          "guarded": false
+        },
+        {
+          "script": "site/assets/portfolio-data.js",
+          "page": "site/security.html",
+          "id": "proof-gallery-strip",
+          "scriptLine": 275,
+          "guarded": false
+        }
+      ]
+    },
+    "rootCauseRanking": [
+      {
+        "rank": 1,
+        "title": "Mixed local asset path strategies + trailing slash route variance",
+        "whyIntermittent": "Relative asset URLs can resolve differently for /page versus /page/, so different canonicalization outcomes produce different asset paths per deploy and cache state.",
+        "evidence": {
+          "siteConvention": "absolute_root",
+          "homepageAbsoluteInnerRelativePattern": false,
+          "trailingHazardCount": 0,
+          "missingAssetCount": 0
+        },
+        "howToConfirm": "In DevTools Network, compare requests for /security and /security/. Look for /security/assets/... 404s versus /assets/... 200s.",
+        "minimalFix": "Standardize local asset references to root-absolute paths (/assets/...) across all HTML pages."
+      },
+      {
+        "rank": 2,
+        "title": "Fetch URL inconsistency and missing timeout/fallback behavior",
+        "whyIntermittent": "Relative fetch URLs are document-URL dependent and can fail under slash variants; fetches without timeout/fallback can leave permanent loading placeholders.",
+        "evidence": {
+          "inconsistentStrategies": false,
+          "timeoutRiskFiles": [],
+          "suspiciousFetches": 0
+        },
+        "howToConfirm": "Use DevTools Network + Console on live pages and force slow/offline mode. Failed JSON requests without UI fallback indicate hanging lanes.",
+        "minimalFix": "Use root-absolute fetch URLs (/assets/data/...) and enforce a 1.5-2.0s timeout with fallback rendering."
+      },
+      {
+        "rank": 3,
+        "title": "Generated artifacts can drift from deployment inputs",
+        "whyIntermittent": "If generated JSON artifacts are not consistently present (or generated from stale content), deploy output can differ even when source HTML appears unchanged.",
+        "evidence": {
+          "artifacts": [
+            {
+              "file": "site/assets/verified-counts.json",
+              "exists": true
+            },
+            {
+              "file": "site/assets/data/detections.json",
+              "exists": true
+            },
+            {
+              "file": "site/assets/data/media.json",
+              "exists": true
+            },
+            {
+              "file": "site/assets/data/projects.json",
+              "exists": true
+            }
+          ]
+        },
+        "howToConfirm": "Check Cloudflare build logs for generation script execution and verify deployed files under /assets/data and /assets/verified-counts.json.",
+        "minimalFix": "Guarantee generation step in build command and add CI assertion that required artifacts exist before deploy."
+      },
+      {
+        "rank": 4,
+        "title": "Edge/browser cache mixing old HTML with newer JS/CSS payloads",
+        "whyIntermittent": "A stale HTML shell can reference outdated script paths or mount contracts while newer assets are cached separately, causing progressive inconsistent behavior.",
+        "evidence": {
+          "cloudflareEvidenceCount": 23
+        },
+        "howToConfirm": "Hard refresh + cache-disabled devtools test. Compare response headers and ETags for HTML vs JS assets across affected and unaffected sessions.",
+        "minimalFix": "Set short cache for HTML and immutable cache strategy for fingerprinted assets; purge cache on critical routing/path changes."
+      },
+      {
+        "rank": 5,
+        "title": "Repository/owner rename leftovers and external raw URL dependencies",
+        "whyIntermittent": "Old owner URLs may redirect unpredictably across mirrors/caches; raw.githubusercontent dependencies are sensitive to owner/repo/path changes.",
+        "evidence": {
+          "legacyOwnerHits": 41,
+          "rawGithubHits": 0,
+          "netlifyHits": 14
+        },
+        "howToConfirm": "Search deployed source for raylee-ops and raw.githubusercontent.com, then test those links directly for redirects or 404s.",
+        "minimalFix": "Replace old owner references with raylee-hawkins and prefer same-origin packaged assets over raw external URLs."
+      }
+    ]
+  },
+  "fixPlan": {
+    "recommendedConvention": "Use root-absolute local asset URLs: /assets/...",
+    "recommendedPatchSections": {
+      "htmlAssetPathRewrites": [],
+      "jsFetchPathRewrites": [],
+      "redirectsCanonicalSuggestions": [],
+      "ciSanityCheckSuggestion": {
+        "command": "node scripts/diagnose-site.js --fail-on-issues",
+        "description": "Fail CI if relative local asset references, slash-hazard paths, or unresolved local assets are detected."
+      }
+    }
+  },
+  "runInstructions": {
+    "node": "node scripts/diagnose-site.js",
+    "nodeFailOnIssues": "node scripts/diagnose-site.js --fail-on-issues",
+    "localServer": [
+      "python -m http.server --directory site 8000",
+      "Open http://127.0.0.1:8000/ in a browser.",
+      "Test both /security and /security/ to validate relative-path behavior."
+    ]
+  }
+}

--- a/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.json
+++ b/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-02-18T00:17:53.397Z",
+  "generatedAt": "2026-02-18T00:25:33.941Z",
   "environment": {
     "cwd": "C:\\RH\\OPS\\PUBLISH\\GITHUB\\repos\\HawkinsOperations",
     "siteDir": "site"
@@ -693,17 +693,17 @@
         },
         {
           "file": "scripts/verify/no-netlify.js",
-          "line": 32,
+          "line": 35,
           "text": "  path.join(\"scripts\", \"verify\", \"no-netlify.js\").replaceAll(\"\\\\\", \"/\"),"
         },
         {
           "file": "scripts/verify/no-netlify.js",
-          "line": 57,
+          "line": 69,
           "text": "    .replaceAll(\"scripts/verify/no-netlify.js\", \"scripts/verify/no-hosting-check.js\")"
         },
         {
           "file": "scripts/verify/no-netlify.js",
-          "line": 58,
+          "line": 70,
           "text": "    .replaceAll(\".\\\\scripts\\\\verify\\\\no-netlify.js\", \".\\\\scripts\\\\verify\\\\no-hosting-check.js\");"
         },
         {

--- a/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.md
+++ b/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.md
@@ -1,0 +1,257 @@
+# Static Site Diagnosis Report
+
+Generated: `2026-02-18T00:17:53.397Z`
+Root: `C:\RH\OPS\PUBLISH\GITHUB\repos\HawkinsOperations`
+Site directory: `site`
+
+## Scope
+- HTML asset path consistency audit across all `site/*.html` pages
+- Trailing slash and canonicalization hazard analysis
+- Static-host URL resolution simulation for local assets
+- JS fetch/XHR URL audit
+- Generated data artifact and hosting build expectations
+- Rename regression checks (`raylee-ops`, `netlify`, raw GitHub URLs)
+- DOM mount contract checks (JS selectors vs page IDs)
+
+## Sample Run Output
+```text
+HTML files scanned: 10
+JS files scanned: 8
+Fetch calls found: 0
+Trailing-slash hazards: 0
+Missing local asset resolutions: 0
+Legacy owner hits: 41
+Netlify hits: 14
+```
+
+## A) Asset Path Consistency Audit (HTML)
+Site-wide local asset convention inferred: `absolute_root`
+Homepage absolute + inner-page relative pattern detected: `false`
+
+| Page | Absolute Local | Relative Local | External | Mixed | Canonical |
+| --- | --- | --- | --- | --- | --- |
+| `site/404.html` | 3 | 0 | 1 | no | `https://hawkinsops.com/404` |
+| `site/blog-python2-to-python3.html` | 5 | 0 | 4 | no | `https://hawkinsops.com/blog-python2-to-python3` |
+| `site/case-study.html` | 5 | 0 | 4 | no | `https://hawkinsops.com/case-study` |
+| `site/index.html` | 5 | 0 | 1 | no | `https://hawkinsops.com/` |
+| `site/lab.html` | 6 | 0 | 1 | no | `https://hawkinsops.com/lab` |
+| `site/projects.html` | 7 | 0 | 1 | no | `https://hawkinsops.com/projects` |
+| `site/proof.html` | 5 | 0 | 4 | no | `https://hawkinsops.com/proof` |
+| `site/resume.html` | 5 | 0 | 4 | no | `https://hawkinsops.com/resume` |
+| `site/security.html` | 7 | 0 | 1 | no | `https://hawkinsops.com/security` |
+| `site/triage.html` | 5 | 0 | 4 | no | `https://hawkinsops.com/triage` |
+
+## B) Trailing Slash + Canonicalization Hazards
+Canonicalization intent inferred: `pretty_no_slash`
+- `site/_redirects` present: `true`
+- `site/_headers` present: `true`
+
+Trailing-slash hazard examples:
+- No relative-asset slash hazards detected.
+
+## C) Local Static-Serve Fetch/Path Simulation
+- `python -m http.server --directory site 8000`
+- `Open http://127.0.0.1:8000/ in a browser.`
+- `Test both /security and /security/ to validate relative-path behavior.`
+- Missing local asset resolutions: 0
+
+## D) JS Runtime Fetch Audit
+- Inconsistent local fetch strategy: `false`
+- Files with fetch but no timeout primitives: 0
+| Fetch Site | URL | Class | Loaded By | Local Check |
+| --- | --- | --- | --- | --- |
+Suspicious fetch URLs:
+- None
+
+## E) Data Artifact Presence + Generation Expectations
+- `site/assets/verified-counts.json` -> present
+- `site/assets/data/detections.json` -> present
+- `site/assets/data/media.json` -> present
+- `site/assets/data/projects.json` -> present
+Generation script evidence:
+- `scripts/diagnose-site.js:16` "site/assets/verified-counts.json",
+- `scripts/diagnose-site.js:17` "site/assets/data/detections.json",
+- `scripts/diagnose-site.js:18` "site/assets/data/media.json",
+- `scripts/diagnose-site.js:19` "site/assets/data/projects.json"
+- `scripts/diagnose-site.js:586` "Check Cloudflare build logs for generation script execution and verify deployed files under /assets/data and /assets/verified-counts.json.",
+- `scripts/generate-site-data.js:8` const outPath = path.join(root, "site", "assets", "verified-counts.json");
+- `scripts/smoke-production.js:9` `${baseUrl}/assets/data/detections.json`,
+- `scripts/smoke-production.js:10` `${baseUrl}/assets/data/media.json`,
+- `scripts/smoke-production.js:11` `${baseUrl}/assets/verified-counts.json`
+- `scripts/smoke-production.js:15` `${baseUrl}/assets/data/detections.json`,
+- `scripts/smoke-production.js:16` `${baseUrl}/assets/data/media.json`,
+- `scripts/smoke-production.js:17` `${baseUrl}/assets/verified-counts.json`
+- `scripts/smoke-production.ps1:106` "$BaseUrl/assets/data/detections.json",
+- `scripts/smoke-production.ps1:107` "$BaseUrl/assets/data/media.json",
+- `scripts/smoke-production.ps1:108` "$BaseUrl/assets/verified-counts.json"
+- `scripts/smoke-production.ps1:122` "$BaseUrl/assets/data/detections.json",
+- `scripts/smoke-production.ps1:123` "$BaseUrl/assets/data/media.json",
+- `scripts/smoke-production.ps1:124` "$BaseUrl/assets/verified-counts.json"
+Cloudflare output evidence:
+- `README.md:95` \| `site/` \| static portfolio site source \| published recruiter-facing web content \|
+- `README.md:114` \|-- generate-site-content.js      -> site/assets/data/*.json
+- `README.md:139` - Runtime remains static HTML/CSS/JS under `site/` (no framework lock-in).
+- `README.md:140` - Design tokens and fluid layout primitives: `site/assets/design-system.css`.
+- `README.md:142` - `site/projects.html` reads `site/assets/data/projects.json`.
+- `README.md:143` - `site/security.html` reads `site/assets/data/detections.json`.
+- `README.md:152` Cloudflare Pages production build:
+- `site/README_DEPLOY.md:15` - Primary production hosting: **Cloudflare Pages**
+- `site/README_DEPLOY.md:16` - Publish directory: `site/`
+- `site/README_DEPLOY.md:18` - Cloudflare Pages build command:
+- `site/README_DEPLOY.md:35` - `site/assets/verified-counts.json`
+- `site/README_DEPLOY.md:36` - `site/assets/data/projects.json`
+- `site/README_DEPLOY.md:37` - `site/assets/data/detections.json`
+- `docs/hosting/CLOUDFLARE_PAGES.md:1` # Cloudflare Pages Production Settings
+- `docs/hosting/CLOUDFLARE_PAGES.md:3` This repository is a static site deployment from `site/`.
+- `docs/hosting/CLOUDFLARE_PAGES.md:7` - Why: pages are static HTML/CSS/JS in `site/`, and data artifacts are generated by Node scripts before publish.
+- `docs/hosting/CLOUDFLARE_PAGES.md:9` ## Exact Cloudflare Pages UI settings
+- `docs/hosting/CLOUDFLARE_PAGES.md:14` - Build output directory: `site`
+- `docs/execution/HOSTING_TRANSFER_PROOF_PACK.md:4` Docs-only execution checklist for Cloudflare Pages hosting validation.
+- `docs/execution/HOSTING_TRANSFER_PROOF_PACK.md:7` - Cloudflare Pages = production primary
+- `docs/execution/HOSTING_TRANSFER_PROOF_PACK.md:15` - build command, publish directory (`site/`), branch mapping, environment notes
+- `docs/execution/HOSTING_TRANSFER_PROOF_PACK.md:33` - [ ] Cloudflare Pages production deploy screenshot/log link.
+- `docs/execution/HOSTING_TRANSFER_PROOF_PACK.md:34` - [ ] Cloudflare Pages preview deploy screenshot/log link.
+
+## F) Old Identifier / Rename Regression Checks
+Current owner baseline: `raylee-hawkins`
+Legacy owners detected: `alessandroz`, `gentilkiwi`, `raylee-ops`, `sigmahq`, `swiftonsecurity`, `your-username`
+
+raylee-ops/old owner hits:
+- `.github/ISSUE_TEMPLATE/config.yml:4` [raylee-ops] url: https://github.com/raylee-ops/HawkinsOperations/blob/main/docs/VERIFY_COMMANDS_POWERSHELL.md
+- `.github/ISSUE_TEMPLATE/config.yml:7` [raylee-ops] url: https://github.com/raylee-ops/HawkinsOperations/blob/main/SECURITY.md
+- `projects/migration-rh/PROOF_PACK/PROOF_INDEX.md:7` [raylee-ops] - Standalone release receipt: [`v0.9.0`](https://github.com/raylee-ops/RH_MIGRATION_2026_V2/releases/tag/v0.9.0)
+- `projects/migration-rh/PROOF_PACK/PROOF_INDEX.md:8` [raylee-ops] - Standalone source repository: [`raylee-ops/RH_MIGRATION_2026_V2`](https://github.com/raylee-ops/RH_MIGRATION_2026_V2)
+- `projects/migration-rh/PROOF_PACK/VERIFICATION.md:19` [raylee-ops] - https://github.com/raylee-ops/RH_MIGRATION_2026_V2/releases/tag/v0.9.0
+- `projects/migration-rh/README.md:20` [raylee-ops] - Repo: `raylee-ops/RH_MIGRATION_2026_V2`
+- `projects/migration-rh/README.md:21` [raylee-ops] - Release: [`v0.9.0` — Phase 08 complete (100% core phases)](https://github.com/raylee-ops/RH_MIGRATION_2026_V2/releases/tag/v0.9.0)
+- `projects/migration-rh/SRC/reference/imports/README.md:16` [raylee-ops] **Source:** raylee-ops/RH_MIGRATION_2026_V2 (private, active project)
+- `projects/repo-history/CONSOLIDATION_MAP.md:5` [raylee-ops] **PR:** https://github.com/raylee-ops/HawkinsOperations/pull/2
+- `projects/repo-history/CONSOLIDATION_MAP.md:22` [raylee-ops] - **URL:** https://github.com/raylee-ops/hawkinsops-framework
+- `projects/repo-history/CONSOLIDATION_MAP.md:29` [raylee-ops] - **URL:** https://github.com/raylee-ops/hawkins_ops
+- `projects/repo-history/CONSOLIDATION_MAP.md:36` [raylee-ops] - **URL:** https://github.com/raylee-ops/hawkinsops-site
+- `projects/repo-history/CONSOLIDATION_MAP.md:43` [raylee-ops] - **URL:** https://github.com/raylee-ops/RH_MIGRATION_2026_V2 (private)
+- `projects/repo-history/CONSOLIDATION_MAP.md:50` [raylee-ops] - **URL:** https://github.com/raylee-ops/hawkinsops-soc-content (already archived)
+- `projects/repo-history/CONSOLIDATION_MAP.md:191` [raylee-ops] gh repo archive raylee-ops/hawkinsops-framework --yes
+- `projects/repo-history/CONSOLIDATION_MAP.md:192` [raylee-ops] gh repo archive raylee-ops/hawkins_ops --yes
+- `projects/repo-history/CONSOLIDATION_MAP.md:193` [raylee-ops] gh repo archive raylee-ops/hawkinsops-site --yes
+- `projects/repo-history/CONSOLIDATION_MAP.md:194` [raylee-ops] gh repo archive raylee-ops/RH_MIGRATION_2026_V2 --yes
+- `projects/repo-history/CONSOLIDATION_MAP.md:250` [raylee-ops] - **Pull Request:** https://github.com/raylee-ops/HawkinsOperations/pull/2
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:30` [raylee-ops] git clone https://github.com/raylee-ops/hawkinsops-framework.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:37` [raylee-ops] git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:52` [raylee-ops] git clone https://github.com/raylee-ops/hawkins_ops.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:59` [raylee-ops] git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:74` [raylee-ops] git clone https://github.com/raylee-ops/hawkinsops-site.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:81` [raylee-ops] git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:95` [raylee-ops] git clone https://github.com/raylee-ops/RH_MIGRATION_2026_V2.git  # Private repo
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:102` [raylee-ops] git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:141` [raylee-ops] run: git clone https://github.com/raylee-ops/hawkinsops-framework.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:144` [raylee-ops] run: git clone https://github.com/raylee-ops/hawkins_ops.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:151` [raylee-ops] run: git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:168` [raylee-ops] See [hawkinsops-framework](https://github.com/raylee-ops/hawkinsops-framework)
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:171` [raylee-ops] See [HawkinsOperations/tools](https://github.com/raylee-ops/HawkinsOperations/tree/main/tools)
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:177` [raylee-ops] git clone https://github.com/raylee-ops/hawkins_ops.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:180` [raylee-ops] git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:190` [raylee-ops] git clone https://github.com/raylee-ops/HawkinsOperations.git
+- `projects/repo-history/MIGRATION_GUIDE_FOR_USERS.md:229` [raylee-ops] - **Issues:** Report at https://github.com/raylee-ops/HawkinsOperations/issues
+- `projects/repo-history/RELEASE_NOTES_v1.1.0.md:185` [raylee-ops] **Repository:** https://github.com/raylee-ops/HawkinsOperations
+- `PROOF_PACK/features/resume-ats-txt-endpoint/run_02-14-2026_000051/evidence/logs/local_headers_resume_html_02-14-2026.txt:94` [raylee-ops] <a href="https://github.com/raylee-ops" target="_blank" rel="noreferrer">GitHub</a> \|
+- `PROOF_PACK/features/resume-ats-txt-endpoint/run_02-14-2026_000051/evidence/logs/local_headers_resume_html_02-14-2026.txt:173` [raylee-ops] <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+- `PROOF_PACK/features/resume-ats-txt-endpoint/run_02-14-2026_000051/evidence/logs/local_headers_resume_txt_02-14-2026.txt:13` [raylee-ops] GitHub: https://github.com/raylee-ops
+- `README.md:5` [raylee-ops] [![Verification](https://img.shields.io/github/actions/workflow/status/raylee-ops/HawkinsOperations/verify.yml?branch=main&label=verify)](https://github.com/raylee-ops/HawkinsOperations/actions/workflows/verify.yml)
+raw.githubusercontent.com hits:
+netlify hits:
+- `.github/workflows/verify.yml:33` node .\scripts\verify\no-netlify.js
+- `docs/hosting/CLOUDFLARE_PAGES.md:13` - Build command: `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`
+- `docs/ui/REFRACTOR_PR_PLAN.md:7` - Add `scripts/verify/no-netlify.js` and wire it into verification workflow.
+- `PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt:2` Legacy provider target reference (Netlify hostname): hawkinsoperations.netlify.app
+- `PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt:4` === nslookup hawkinsoperations.netlify.app 8.8.8.8 ===
+- `PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt:8` Name:    hawkinsoperations.netlify.app
+- `README.md:73` node .\scripts\verify\no-netlify.js
+- `README.md:153` - `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`
+- `scripts/verify/no-netlify.js:32` path.join("scripts", "verify", "no-netlify.js").replaceAll("\\", "/"),
+- `scripts/verify/no-netlify.js:57` .replaceAll("scripts/verify/no-netlify.js", "scripts/verify/no-hosting-check.js")
+- `scripts/verify/no-netlify.js:58` .replaceAll(".\\scripts\\verify\\no-netlify.js", ".\\scripts\\verify\\no-hosting-check.js");
+- `scripts/verify/README.md:5` - `no-netlify.js` enforces Cloudflare-only hosting consistency.
+- `scripts/verify/README.md:18` node .\scripts\verify\no-netlify.js
+- `site/README_DEPLOY.md:19` - `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`
+
+## G) Content/DOM Mount Mismatch Checks
+Duplicate ID findings: 0
+Missing script mount IDs by page: 25
+- `site/assets/app.js:303` expects `#verified-date` on `site/blog-python2-to-python3.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/case-study.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/lab.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/projects.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/proof.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/resume.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/security.html` (guarded=true)
+- `site/assets/app.js:303` expects `#verified-date` on `site/triage.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/blog-python2-to-python3.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/case-study.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/lab.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/projects.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/proof.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/resume.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/security.html` (guarded=true)
+- `site/assets/app.js:308` expects `#verified-source` on `site/triage.html` (guarded=true)
+- `site/assets/portfolio-data.js:264` expects `#detectionsChart` on `site/projects.html` (guarded=true)
+- `site/assets/portfolio-data.js:266` expects `#securityTagMiniChart` on `site/projects.html` (guarded=true)
+- `site/assets/portfolio-data.js:269` expects `#mitre-coverage-status` on `site/projects.html` (guarded=false)
+- `site/assets/portfolio-data.js:273` expects `#coverage-chart` on `site/projects.html` (guarded=true)
+- `site/assets/portfolio-data.js:273` expects `#coverage-chart` on `site/security.html` (guarded=true)
+- `site/assets/portfolio-data.js:274` expects `#detections-tag-chart` on `site/projects.html` (guarded=true)
+- `site/assets/portfolio-data.js:274` expects `#detections-tag-chart` on `site/security.html` (guarded=true)
+- `site/assets/portfolio-data.js:275` expects `#proof-gallery-strip` on `site/projects.html` (guarded=false)
+- `site/assets/portfolio-data.js:275` expects `#proof-gallery-strip` on `site/security.html` (guarded=false)
+
+## H) Ranked Top 5 Causes of Progressive Degradation
+### 1. Mixed local asset path strategies + trailing slash route variance
+- Why intermittent: Relative asset URLs can resolve differently for /page versus /page/, so different canonicalization outcomes produce different asset paths per deploy and cache state.
+- How to confirm: In DevTools Network, compare requests for /security and /security/. Look for /security/assets/... 404s versus /assets/... 200s.
+- Minimal fix: Standardize local asset references to root-absolute paths (/assets/...) across all HTML pages.
+- Evidence: `{"siteConvention":"absolute_root","homepageAbsoluteInnerRelativePattern":false,"trailingHazardCount":0,"missingAssetCount":0}`
+
+### 2. Fetch URL inconsistency and missing timeout/fallback behavior
+- Why intermittent: Relative fetch URLs are document-URL dependent and can fail under slash variants; fetches without timeout/fallback can leave permanent loading placeholders.
+- How to confirm: Use DevTools Network + Console on live pages and force slow/offline mode. Failed JSON requests without UI fallback indicate hanging lanes.
+- Minimal fix: Use root-absolute fetch URLs (/assets/data/...) and enforce a 1.5-2.0s timeout with fallback rendering.
+- Evidence: `{"inconsistentStrategies":false,"timeoutRiskFiles":[],"suspiciousFetches":0}`
+
+### 3. Generated artifacts can drift from deployment inputs
+- Why intermittent: If generated JSON artifacts are not consistently present (or generated from stale content), deploy output can differ even when source HTML appears unchanged.
+- How to confirm: Check Cloudflare build logs for generation script execution and verify deployed files under /assets/data and /assets/verified-counts.json.
+- Minimal fix: Guarantee generation step in build command and add CI assertion that required artifacts exist before deploy.
+- Evidence: `{"artifacts":[{"file":"site/assets/verified-counts.json","exists":true},{"file":"site/assets/data/detections.json","exists":true},{"file":"site/assets/data/media.json","exists":true},{"file":"site/assets/data/projects.json","exists":true}]}`
+
+### 4. Edge/browser cache mixing old HTML with newer JS/CSS payloads
+- Why intermittent: A stale HTML shell can reference outdated script paths or mount contracts while newer assets are cached separately, causing progressive inconsistent behavior.
+- How to confirm: Hard refresh + cache-disabled devtools test. Compare response headers and ETags for HTML vs JS assets across affected and unaffected sessions.
+- Minimal fix: Set short cache for HTML and immutable cache strategy for fingerprinted assets; purge cache on critical routing/path changes.
+- Evidence: `{"cloudflareEvidenceCount":23}`
+
+### 5. Repository/owner rename leftovers and external raw URL dependencies
+- Why intermittent: Old owner URLs may redirect unpredictably across mirrors/caches; raw.githubusercontent dependencies are sensitive to owner/repo/path changes.
+- How to confirm: Search deployed source for raylee-ops and raw.githubusercontent.com, then test those links directly for redirects or 404s.
+- Minimal fix: Replace old owner references with raylee-hawkins and prefer same-origin packaged assets over raw external URLs.
+- Evidence: `{"legacyOwnerHits":41,"rawGithubHits":0,"netlifyHits":14}`
+
+## Minimal Safe Fix Plan
+1. Standardize local asset references in HTML to root-absolute `/assets/...`.
+2. Standardize local fetch URLs in JS to root-absolute `/assets/data/...`.
+3. Add canonical slash redirects in `site/_redirects` if pretty-no-slash is canonical.
+4. Enforce timeout + fallback rendering for all async loading lanes.
+5. Add CI sanity gate: `node scripts/diagnose-site.js --fail-on-issues`.
+
+### Recommended Fix Patch Sections
+#### HTML asset path rewrites
+#### JS fetch path rewrites
+#### _redirects canonical suggestions
+- No canonical redirect additions suggested.
+#### CI sanity check
+- Fail CI if relative local asset references, slash-hazard paths, or unresolved local assets are detected.
+- Command: `node scripts/diagnose-site.js --fail-on-issues`
+
+## Re-run Instructions
+- Node only: `node scripts/diagnose-site.js`
+- Fail CI on issues: `node scripts/diagnose-site.js --fail-on-issues`
+- Report outputs: `docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.md`, `docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.json`

--- a/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.md
+++ b/docs/diagnosis/STATIC_SITE_DIAGNOSIS_REPORT.md
@@ -1,6 +1,6 @@
 # Static Site Diagnosis Report
 
-Generated: `2026-02-18T00:17:53.397Z`
+Generated: `2026-02-18T00:25:33.941Z`
 Root: `C:\RH\OPS\PUBLISH\GITHUB\repos\HawkinsOperations`
 Site directory: `site`
 
@@ -168,9 +168,9 @@ netlify hits:
 - `PROOF_PACK/hosting_transfer_cloudflare/run_02-14-2026_031137/evidence/logs/dns_before_after_backfill_02-14-2026.txt:8` Name:    hawkinsoperations.netlify.app
 - `README.md:73` node .\scripts\verify\no-netlify.js
 - `README.md:153` - `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`
-- `scripts/verify/no-netlify.js:32` path.join("scripts", "verify", "no-netlify.js").replaceAll("\\", "/"),
-- `scripts/verify/no-netlify.js:57` .replaceAll("scripts/verify/no-netlify.js", "scripts/verify/no-hosting-check.js")
-- `scripts/verify/no-netlify.js:58` .replaceAll(".\\scripts\\verify\\no-netlify.js", ".\\scripts\\verify\\no-hosting-check.js");
+- `scripts/verify/no-netlify.js:35` path.join("scripts", "verify", "no-netlify.js").replaceAll("\\", "/"),
+- `scripts/verify/no-netlify.js:69` .replaceAll("scripts/verify/no-netlify.js", "scripts/verify/no-hosting-check.js")
+- `scripts/verify/no-netlify.js:70` .replaceAll(".\\scripts\\verify\\no-netlify.js", ".\\scripts\\verify\\no-hosting-check.js");
 - `scripts/verify/README.md:5` - `no-netlify.js` enforces Cloudflare-only hosting consistency.
 - `scripts/verify/README.md:18` node .\scripts\verify\no-netlify.js
 - `site/README_DEPLOY.md:19` - `node scripts/generate-site-data.js && node scripts/generate-site-content.js && node scripts/generate-media-manifest.js && node scripts/verify/no-netlify.js`

--- a/scripts/diagnose-site.js
+++ b/scripts/diagnose-site.js
@@ -1,0 +1,1347 @@
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const rootDir = process.cwd();
+const siteDir = path.join(rootDir, "site");
+const docsDir = path.join(rootDir, "docs", "diagnosis");
+const markdownOut = path.join(docsDir, "STATIC_SITE_DIAGNOSIS_REPORT.md");
+const jsonOut = path.join(docsDir, "STATIC_SITE_DIAGNOSIS_REPORT.json");
+
+const failOnIssues = process.argv.includes("--fail-on-issues");
+
+const CURRENT_GITHUB_OWNER = "raylee-hawkins";
+const OLD_OWNER_PATTERNS = ["raylee-ops", "raylee_ops", "rayleeops"];
+const GENERATED_ARTIFACTS_EXPECTED = [
+  "site/assets/verified-counts.json",
+  "site/assets/data/detections.json",
+  "site/assets/data/media.json",
+  "site/assets/data/projects.json"
+];
+const DIAGNOSTIC_TEXT_EXTENSIONS = new Set([
+  ".md",
+  ".txt",
+  ".html",
+  ".css",
+  ".js",
+  ".json",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".ps1",
+  ".sh",
+  ".svg",
+  ".xml",
+  ".csv",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".gitignore",
+  ".gitattributes"
+]);
+const DIAGNOSTIC_IGNORE_PREFIXES = ["docs/diagnosis/"];
+const DIAGNOSTIC_IGNORE_FILES = new Set(["scripts/diagnose-site.js", "scripts/diagnose-site.ps1"]);
+
+function toPosix(relPath) {
+  return relPath.replaceAll("\\", "/");
+}
+
+function readUtf8(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function walkFiles(dirPath, out, predicate) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(full, out, predicate);
+      continue;
+    }
+    if (!predicate || predicate(full)) out.push(full);
+  }
+}
+
+function getLineStarts(text) {
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "\n") starts.push(i + 1);
+  }
+  return starts;
+}
+
+function indexToLineCol(lineStarts, index) {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (lineStarts[mid] <= index) {
+      if (mid === lineStarts.length - 1 || lineStarts[mid + 1] > index) {
+        return { line: mid + 1, col: index - lineStarts[mid] + 1 };
+      }
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return { line: 1, col: 1 };
+}
+
+function stripQueryHash(urlValue) {
+  return String(urlValue || "").split("#")[0].split("?")[0];
+}
+
+function classifyUrl(urlValue) {
+  const url = String(urlValue || "").trim();
+  if (!url) return "empty";
+  if (url.startsWith("#")) return "anchor";
+  if (/^(mailto:|tel:|javascript:|data:)/i.test(url)) return "special";
+  if (/^https?:\/\//i.test(url) || url.startsWith("//")) return "external";
+  if (url.startsWith("/")) return "absolute_root";
+  return "relative";
+}
+
+function isLocalClass(classification) {
+  return classification === "absolute_root" || classification === "relative";
+}
+
+function parseTagAttributes(tagText) {
+  const attrs = {};
+  const attrRe = /([:@A-Za-z0-9_-]+)\s*=\s*("([^"]*)"|'([^']*)')/g;
+  let match;
+  while ((match = attrRe.exec(tagText)) !== null) {
+    const name = String(match[1] || "").toLowerCase();
+    const value = typeof match[3] === "string" ? match[3] : match[4];
+    attrs[name] = value;
+  }
+  return attrs;
+}
+
+function parseHtmlFile(filePath) {
+  const relPath = toPosix(path.relative(rootDir, filePath));
+  const raw = readUtf8(filePath);
+  const lineStarts = getLineStarts(raw);
+  const refs = [];
+  const pageIds = [];
+  const idCounts = new Map();
+
+  const tagRe = /<(link|script|img|source)\b[^>]*>/gi;
+  let tagMatch;
+  while ((tagMatch = tagRe.exec(raw)) !== null) {
+    const tagName = String(tagMatch[1] || "").toLowerCase();
+    const tagText = tagMatch[0];
+    const attrs = parseTagAttributes(tagText);
+    const where = indexToLineCol(lineStarts, tagMatch.index);
+    const relAttr = String(attrs.rel || "").toLowerCase();
+    const isFavicon = tagName === "link" && /\bicon\b/.test(relAttr);
+
+    function pushRef(attrName, value, extra) {
+      const classification = classifyUrl(value);
+      refs.push({
+        page: relPath,
+        tag: tagName,
+        attr: attrName,
+        value,
+        classification,
+        line: where.line,
+        col: where.col,
+        isFavicon,
+        ...extra
+      });
+    }
+
+    if (tagName === "link" && typeof attrs.href === "string") {
+      pushRef("href", attrs.href, { rel: relAttr || null });
+    }
+
+    if ((tagName === "script" || tagName === "img") && typeof attrs.src === "string") {
+      pushRef("src", attrs.src, {});
+    }
+
+    if (tagName === "source" && typeof attrs.srcset === "string") {
+      const srcsetEntries = attrs.srcset
+        .split(",")
+        .map((part) => String(part || "").trim())
+        .filter(Boolean);
+      if (srcsetEntries.length === 0) {
+        pushRef("srcset", attrs.srcset, { srcsetItem: null });
+      } else {
+        for (const srcsetEntry of srcsetEntries) {
+          const sourceUrl = srcsetEntry.split(/\s+/)[0] || "";
+          pushRef("srcset", sourceUrl, { srcsetItem: srcsetEntry });
+        }
+      }
+    }
+  }
+
+  const canonicalRe = /<link\b[^>]*\brel\s*=\s*("|\')canonical\1[^>]*\bhref\s*=\s*("|\')([^"\']+)\2[^>]*>/i;
+  const canonicalMatch = raw.match(canonicalRe);
+  const canonicalHref = canonicalMatch ? canonicalMatch[3] : null;
+
+  const idRe = /\bid\s*=\s*("([^"]+)"|'([^']+)')/gi;
+  let idMatch;
+  while ((idMatch = idRe.exec(raw)) !== null) {
+    const idValue = typeof idMatch[2] === "string" ? idMatch[2] : idMatch[3];
+    const where = indexToLineCol(lineStarts, idMatch.index);
+    pageIds.push({ id: idValue, line: where.line, col: where.col });
+    idCounts.set(idValue, (idCounts.get(idValue) || 0) + 1);
+  }
+
+  const duplicateIds = Array.from(idCounts.entries())
+    .filter((entry) => entry[1] > 1)
+    .map((entry) => entry[0]);
+
+  return {
+    relPath,
+    absPath: filePath,
+    raw,
+    lineStarts,
+    refs,
+    canonicalHref,
+    pageIds,
+    duplicateIds
+  };
+}
+
+function pageRouteScenarios(pageRelPath) {
+  const siteRel = toPosix(pageRelPath).replace(/^site\//, "");
+  const dir = path.posix.dirname(siteRel);
+  const base = path.posix.basename(siteRel, ".html");
+  const fileRoute = "/" + siteRel;
+
+  if (base === "index") {
+    const rootRoute = dir === "." ? "/" : `/${dir}/`;
+    return [{ kind: "root_or_index", routePath: rootRoute }];
+  }
+
+  const prettyNoSlash = dir === "." ? `/${base}` : `/${dir}/${base}`;
+  const prettyWithSlash = `${prettyNoSlash}/`;
+  return [
+    { kind: "file", routePath: fileRoute },
+    { kind: "pretty_no_slash", routePath: prettyNoSlash },
+    { kind: "pretty_with_slash", routePath: prettyWithSlash }
+  ];
+}
+
+function resolveLocalUrlForScenario(localUrl, scenarioRoutePath) {
+  const base = `https://diagnostic.local${scenarioRoutePath}`;
+  const clean = stripQueryHash(localUrl);
+  try {
+    return new URL(clean, base).pathname;
+  } catch {
+    return null;
+  }
+}
+
+function resolvedPathToFsPath(pathname) {
+  if (!pathname) return null;
+  const clean = pathname.replace(/^\/+/, "");
+  if (!clean) return path.join(siteDir, "index.html");
+  return path.join(siteDir, clean.split("/").join(path.sep));
+}
+
+function fsPathExists(fsPath) {
+  try {
+    return fsPath ? fs.existsSync(fsPath) : false;
+  } catch {
+    return false;
+  }
+}
+
+function collectHtmlFiles() {
+  const files = [];
+  walkFiles(siteDir, files, (full) => full.toLowerCase().endsWith(".html"));
+  return files.sort((a, b) => toPosix(path.relative(rootDir, a)).localeCompare(toPosix(path.relative(rootDir, b))));
+}
+
+function collectJsFilesUnderAssets() {
+  const assetsDir = path.join(siteDir, "assets");
+  const files = [];
+  if (fs.existsSync(assetsDir)) {
+    walkFiles(assetsDir, files, (full) => full.toLowerCase().endsWith(".js"));
+  }
+  return files.sort((a, b) => toPosix(path.relative(rootDir, a)).localeCompare(toPosix(path.relative(rootDir, b))));
+}
+function extractLocalScriptLoads(pageAnalysis) {
+  const scriptLoads = [];
+  for (const page of pageAnalysis) {
+    for (const ref of page.refs) {
+      if (ref.tag !== "script" || ref.attr !== "src") continue;
+      if (!isLocalClass(ref.classification)) continue;
+      const pageRoute = pageRouteScenarios(page.relPath.replace(/^site\//, ""))[0].routePath;
+      const resolved = resolveLocalUrlForScenario(ref.value, pageRoute);
+      const fsPath = resolvedPathToFsPath(resolved);
+      const relResolved = fsPath ? toPosix(path.relative(rootDir, fsPath)) : null;
+      scriptLoads.push({
+        page: page.relPath,
+        line: ref.line,
+        src: ref.value,
+        resolvedPathname: resolved,
+        resolvedRelPath: relResolved
+      });
+    }
+  }
+  return scriptLoads;
+}
+
+function mapScriptsToPages(scriptLoads) {
+  const map = new Map();
+  for (const load of scriptLoads) {
+    if (!load.resolvedRelPath) continue;
+    if (!map.has(load.resolvedRelPath)) map.set(load.resolvedRelPath, new Set());
+    map.get(load.resolvedRelPath).add(load.page);
+  }
+  return map;
+}
+
+function findLiteralFetches(jsRelPath, jsText, lineStarts) {
+  const refs = [];
+  const fetchRe = /fetch\s*\(\s*("([^"]+)"|'([^']+)'|`([^`]+)`)/g;
+  let match;
+  while ((match = fetchRe.exec(jsText)) !== null) {
+    const value = match[2] || match[3] || match[4] || "";
+    const where = indexToLineCol(lineStarts, match.index);
+    refs.push({
+      kind: "fetch",
+      jsFile: jsRelPath,
+      url: value,
+      classification: classifyUrl(value),
+      line: where.line,
+      col: where.col
+    });
+  }
+
+  const xhrOpenRe = /\.open\s*\(\s*("GET"|'GET'|`GET`|"POST"|'POST'|`POST`|"PUT"|'PUT'|`PUT`|"DELETE"|'DELETE'|`DELETE`)\s*,\s*("([^"]+)"|'([^']+)'|`([^`]+)`)/g;
+  while ((match = xhrOpenRe.exec(jsText)) !== null) {
+    const value = match[4] || match[5] || match[6] || "";
+    const where = indexToLineCol(lineStarts, match.index);
+    refs.push({
+      kind: "xhr_open",
+      jsFile: jsRelPath,
+      url: value,
+      classification: classifyUrl(value),
+      line: where.line,
+      col: where.col
+    });
+  }
+
+  const wrapperFetchers = [];
+  const fnRe = /function\s+([A-Za-z_$][\w$]*)\s*\(\s*([A-Za-z_$][\w$]*)[^)]*\)\s*{([\s\S]*?)\n}/g;
+  while ((match = fnRe.exec(jsText)) !== null) {
+    const fnName = match[1];
+    const paramName = match[2];
+    const body = match[3] || "";
+    if (new RegExp(`fetch\\s*\\(\\s*${paramName}\\b`).test(body)) {
+      wrapperFetchers.push(fnName);
+    }
+  }
+
+  for (const fnName of wrapperFetchers) {
+    const callRe = new RegExp(`\\b${fnName}\\s*\\(\\s*(\"([^\"]+)\"|'([^']+)'|\\\`([^\\\`]+)\\\`)`, "g");
+    let callMatch;
+    while ((callMatch = callRe.exec(jsText)) !== null) {
+      const value = callMatch[2] || callMatch[3] || callMatch[4] || "";
+      const where = indexToLineCol(lineStarts, callMatch.index);
+      refs.push({
+        kind: "fetch_wrapper_call",
+        jsFile: jsRelPath,
+        url: value,
+        classification: classifyUrl(value),
+        line: where.line,
+        col: where.col,
+        wrapperFunction: fnName
+      });
+    }
+  }
+
+  return refs;
+}
+
+function inferSelectorGuards(jsText) {
+  const lines = jsText.split(/\r?\n/);
+  const lineStarts = getLineStarts(jsText);
+  const mountDefs = [];
+  const assignRe = /(const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:document\.)?(getElementById|querySelector)\(\s*("([^"]+)"|'([^']+)')\s*\)/g;
+  let match;
+  while ((match = assignRe.exec(jsText)) !== null) {
+    const varName = match[2];
+    const method = match[3];
+    const rawSelector = match[5] || match[6] || "";
+    const id = method === "getElementById"
+      ? rawSelector
+      : rawSelector.startsWith("#")
+        ? rawSelector.slice(1)
+        : null;
+    if (!id) continue;
+
+    const where = indexToLineCol(lineStarts, match.index);
+    const scanStart = Math.max(0, where.line - 1);
+    const scanEnd = Math.min(lines.length - 1, scanStart + 10);
+    const lookahead = lines.slice(scanStart, scanEnd + 1).join("\n");
+    const guarded =
+      new RegExp(`if\\s*\\(\\s*!\\s*${varName}\\s*\\)`, "m").test(lookahead) ||
+      new RegExp(`if\\s*\\(\\s*${varName}\\s*\\)`, "m").test(lookahead) ||
+      new RegExp(`${varName}\\s*&&`, "m").test(lookahead);
+
+    mountDefs.push({
+      id,
+      varName,
+      method,
+      line: where.line,
+      col: where.col,
+      guarded
+    });
+  }
+  return mountDefs;
+}
+
+function findIdSelectors(jsText) {
+  const ids = [];
+  const lineStarts = getLineStarts(jsText);
+  const selectorRe = /(getElementById|querySelector|querySelectorAll)\(\s*("([^"]+)"|'([^']+)')\s*\)/g;
+  let match;
+  while ((match = selectorRe.exec(jsText)) !== null) {
+    const method = match[1];
+    const raw = match[3] || match[4] || "";
+    let id = null;
+    if (method === "getElementById") id = raw;
+    else if (raw.startsWith("#")) id = raw.slice(1);
+    if (!id) continue;
+    const where = indexToLineCol(lineStarts, match.index);
+    ids.push({ id, method, line: where.line, col: where.col });
+  }
+  return ids;
+}
+
+function getGitTrackedFiles() {
+  const probe = cp.spawnSync("git", ["ls-files", "-z"], {
+    cwd: rootDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (probe.status !== 0) {
+    const fallback = [];
+    walkFiles(rootDir, fallback, (full) => !full.includes(`${path.sep}.git${path.sep}`));
+    return fallback.map((full) => toPosix(path.relative(rootDir, full)));
+  }
+  return String(probe.stdout || "")
+    .split("\0")
+    .filter(Boolean)
+    .map((entry) => toPosix(entry));
+}
+
+function isLikelyTextFile(relPath) {
+  const ext = path.extname(relPath).toLowerCase();
+  if (DIAGNOSTIC_TEXT_EXTENSIONS.has(ext)) return true;
+  const basename = path.basename(relPath);
+  return basename === ".gitignore" || basename === ".gitattributes" || basename === ".node-version";
+}
+
+function searchTextHits(pattern, options = {}) {
+  const files = options.files || getGitTrackedFiles();
+  const regex = typeof pattern === "string" ? new RegExp(pattern, options.flags || "i") : pattern;
+  const hits = [];
+  for (const relPath of files) {
+    const relNorm = toPosix(relPath);
+    if (DIAGNOSTIC_IGNORE_FILES.has(relNorm)) continue;
+    if (DIAGNOSTIC_IGNORE_PREFIXES.some((prefix) => relNorm.startsWith(prefix))) continue;
+    if (!isLikelyTextFile(relPath)) continue;
+    const absPath = path.join(rootDir, relPath);
+    if (!fs.existsSync(absPath)) continue;
+    let raw;
+    try {
+      raw = readUtf8(absPath);
+    } catch {
+      continue;
+    }
+    const lines = raw.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      if (regex.test(lines[i])) {
+        hits.push({ file: relPath, line: i + 1, text: lines[i] });
+      }
+      regex.lastIndex = 0;
+    }
+  }
+  return hits;
+}
+
+function collectGeneratorScriptEvidence() {
+  const scriptDir = path.join(rootDir, "scripts");
+  const files = [];
+  if (!fs.existsSync(scriptDir)) return [];
+  walkFiles(scriptDir, files, (full) => /\.(js|ps1|sh|md)$/i.test(full));
+  const evidence = [];
+  for (const filePath of files) {
+    const rel = toPosix(path.relative(rootDir, filePath));
+    const text = readUtf8(filePath);
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      if (/verified-counts\.json|assets\/data\/detections\.json|assets\/data\/media\.json|assets\/data\/projects\.json/i.test(lines[i])) {
+        evidence.push({ file: rel, line: i + 1, text: lines[i] });
+      }
+    }
+  }
+  return evidence;
+}
+
+function collectCloudflareOutputEvidence() {
+  const files = [
+    "README.md",
+    "START_HERE.md",
+    "site/README_DEPLOY.md",
+    "docs/hosting/CLOUDFLARE_PAGES.md",
+    "docs/execution/HOSTING_TRANSFER_PROOF_PACK.md"
+  ];
+  const evidence = [];
+  for (const rel of files) {
+    const abs = path.join(rootDir, rel);
+    if (!fs.existsSync(abs)) continue;
+    const lines = readUtf8(abs).split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      if (/Cloudflare Pages|publish directory|build output directory|site\//i.test(lines[i])) {
+        evidence.push({ file: rel, line: i + 1, text: lines[i] });
+      }
+    }
+  }
+  return evidence;
+}
+
+function inferCanonicalIntent(canonicalKinds) {
+  const ordered = [
+    ["pretty_no_slash", canonicalKinds.pretty_no_slash],
+    ["pretty_with_slash", canonicalKinds.pretty_with_slash],
+    ["file", canonicalKinds.file],
+    ["root", canonicalKinds.root],
+    ["other", canonicalKinds.other]
+  ].sort((a, b) => b[1] - a[1]);
+
+  const top = ordered[0];
+  if (!top || top[1] === 0) return "unknown";
+  if (top[0] === "pretty_no_slash") return "pretty_no_slash";
+  if (top[0] === "pretty_with_slash") return "pretty_with_slash";
+  if (top[0] === "file") return "file_html";
+  return top[0];
+}
+
+function dedupeObjects(items, keyFn) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items) {
+    const key = keyFn(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+function buildTopRootCauses(input) {
+  const causes = [];
+
+  causes.push({
+    rank: 1,
+    title: "Mixed local asset path strategies + trailing slash route variance",
+    whyIntermittent:
+      "Relative asset URLs can resolve differently for /page versus /page/, so different canonicalization outcomes produce different asset paths per deploy and cache state.",
+    evidence: {
+      siteConvention: input.siteConvention,
+      homepageAbsoluteInnerRelativePattern: input.homepageAbsoluteInnerRelativePattern,
+      trailingHazardCount: input.trailingHazardCount,
+      missingAssetCount: input.missingAssetCount
+    },
+    howToConfirm:
+      "In DevTools Network, compare requests for /security and /security/. Look for /security/assets/... 404s versus /assets/... 200s.",
+    minimalFix:
+      "Standardize local asset references to root-absolute paths (/assets/...) across all HTML pages."
+  });
+
+  causes.push({
+    rank: 2,
+    title: "Fetch URL inconsistency and missing timeout/fallback behavior",
+    whyIntermittent:
+      "Relative fetch URLs are document-URL dependent and can fail under slash variants; fetches without timeout/fallback can leave permanent loading placeholders.",
+    evidence: {
+      inconsistentStrategies: input.fetchInconsistentStrategies,
+      timeoutRiskFiles: input.fetchTimeoutRiskFiles,
+      suspiciousFetches: input.suspiciousFetches.length
+    },
+    howToConfirm:
+      "Use DevTools Network + Console on live pages and force slow/offline mode. Failed JSON requests without UI fallback indicate hanging lanes.",
+    minimalFix:
+      "Use root-absolute fetch URLs (/assets/data/...) and enforce a 1.5-2.0s timeout with fallback rendering."
+  });
+
+  causes.push({
+    rank: 3,
+    title: "Generated artifacts can drift from deployment inputs",
+    whyIntermittent:
+      "If generated JSON artifacts are not consistently present (or generated from stale content), deploy output can differ even when source HTML appears unchanged.",
+    evidence: { artifacts: input.generatedArtifactPresence },
+    howToConfirm:
+      "Check Cloudflare build logs for generation script execution and verify deployed files under /assets/data and /assets/verified-counts.json.",
+    minimalFix:
+      "Guarantee generation step in build command and add CI assertion that required artifacts exist before deploy."
+  });
+
+  causes.push({
+    rank: 4,
+    title: "Edge/browser cache mixing old HTML with newer JS/CSS payloads",
+    whyIntermittent:
+      "A stale HTML shell can reference outdated script paths or mount contracts while newer assets are cached separately, causing progressive inconsistent behavior.",
+    evidence: { cloudflareEvidenceCount: input.cloudflareEvidence.length },
+    howToConfirm:
+      "Hard refresh + cache-disabled devtools test. Compare response headers and ETags for HTML vs JS assets across affected and unaffected sessions.",
+    minimalFix:
+      "Set short cache for HTML and immutable cache strategy for fingerprinted assets; purge cache on critical routing/path changes."
+  });
+
+  causes.push({
+    rank: 5,
+    title: "Repository/owner rename leftovers and external raw URL dependencies",
+    whyIntermittent:
+      "Old owner URLs may redirect unpredictably across mirrors/caches; raw.githubusercontent dependencies are sensitive to owner/repo/path changes.",
+    evidence: {
+      legacyOwnerHits: input.legacyOwnerHits.length,
+      rawGithubHits: input.rawGithubHits.length,
+      netlifyHits: input.netlifyHits.length
+    },
+    howToConfirm:
+      "Search deployed source for raylee-ops and raw.githubusercontent.com, then test those links directly for redirects or 404s.",
+    minimalFix:
+      "Replace old owner references with raylee-hawkins and prefer same-origin packaged assets over raw external URLs."
+  });
+
+  return causes;
+}
+
+function toRootAbsoluteAssetPath(rawPath) {
+  const clean = stripQueryHash(rawPath);
+  const suffix = rawPath.slice(clean.length);
+  const noDot = clean.replace(/^(\.\/|\.\.\/)+/, "");
+  const noLeading = noDot.replace(/^\/+/, "");
+  if (noLeading.startsWith("assets/")) return `/${noLeading}${suffix}`;
+  return `/${noLeading}${suffix}`;
+}
+
+function buildRecommendedPatchSections(input) {
+  const htmlRelativeAssetRefs = input.allLocalAssetRefs
+    .filter((ref) => ref.classification === "relative")
+    .filter((ref) => /^(assets\/|\.\/assets\/|\.\.\/assets\/)/i.test(ref.value))
+    .map((ref) => ({
+      file: ref.page,
+      line: ref.line,
+      current: ref.value,
+      suggested: toRootAbsoluteAssetPath(ref.value)
+    }));
+
+  const jsRelativeFetchRefs = input.fetchEntries
+    .filter((entry) => entry.classification === "relative")
+    .filter((entry) => /(^assets\/|^\.\/assets\/|^\.\.\/assets\/)/i.test(entry.url))
+    .map((entry) => ({
+      file: entry.jsFile,
+      line: entry.line,
+      current: entry.url,
+      suggested: toRootAbsoluteAssetPath(entry.url)
+    }));
+
+  const uniquePrettyPages = Array.from(
+    new Set(
+      input.trailingHazardsDeduped
+        .map((hazard) => {
+          const rel = hazard.page.replace(/^site\//, "");
+          const name = rel.replace(/\.html$/i, "");
+          return name === "index" ? null : name;
+        })
+        .filter(Boolean)
+    )
+  ).sort();
+
+  const redirectPatch = uniquePrettyPages.map((name) => `/${name}/ /${name} 301`);
+
+  return {
+    htmlAssetPathRewrites: htmlRelativeAssetRefs,
+    jsFetchPathRewrites: jsRelativeFetchRefs,
+    redirectsCanonicalSuggestions: redirectPatch,
+    ciSanityCheckSuggestion: {
+      command: "node scripts/diagnose-site.js --fail-on-issues",
+      description:
+        "Fail CI if relative local asset references, slash-hazard paths, or unresolved local assets are detected."
+    }
+  };
+}
+
+function markdownTable(headers, rows) {
+  const head = `| ${headers.join(" | ")} |`;
+  const sep = `| ${headers.map(() => "---").join(" | ")} |`;
+  const body = rows.map((row) => `| ${row.map((cell) => String(cell)).join(" | ")} |`);
+  return [head, sep, ...body].join("\n");
+}
+
+function formatPathLine(file, line) {
+  return `\`${file}:${line}\``;
+}
+
+function escapePipes(text) {
+  return String(text || "").replaceAll("|", "\\|").trim();
+}
+
+function analyze() {
+  const nowIso = new Date().toISOString();
+  const htmlFiles = collectHtmlFiles();
+  const pageAnalysis = htmlFiles.map((filePath) => parseHtmlFile(filePath));
+
+  const pageSummaries = [];
+  const localAssetMissing = [];
+  const trailingSlashHazards = [];
+  const canonicalPatterns = [];
+  const allLocalAssetRefs = [];
+
+  for (const page of pageAnalysis) {
+    let localAbsoluteCount = 0;
+    let localRelativeCount = 0;
+    let externalCount = 0;
+    let specialCount = 0;
+    const localStyles = new Set();
+
+    for (const ref of page.refs) {
+      if (!isLocalClass(ref.classification) && ref.classification !== "external" && ref.classification !== "special") continue;
+      if (ref.classification === "absolute_root") {
+        localAbsoluteCount += 1;
+        localStyles.add("absolute_root");
+      } else if (ref.classification === "relative") {
+        localRelativeCount += 1;
+        localStyles.add("relative");
+      } else if (ref.classification === "external") {
+        externalCount += 1;
+      } else if (ref.classification === "special") {
+        specialCount += 1;
+      }
+
+      if (isLocalClass(ref.classification)) {
+        allLocalAssetRefs.push({
+          page: page.relPath,
+          line: ref.line,
+          tag: ref.tag,
+          attr: ref.attr,
+          value: ref.value,
+          classification: ref.classification
+        });
+      }
+    }
+
+    const mixedLocalAssetStrategy = localStyles.size > 1;
+    const scenarios = pageRouteScenarios(page.relPath.replace(/^site\//, ""));
+
+    for (const ref of page.refs) {
+      if (!isLocalClass(ref.classification)) continue;
+      for (const scenario of scenarios) {
+        const resolvedPathname = resolveLocalUrlForScenario(ref.value, scenario.routePath);
+        const resolvedFsPath = resolvedPathToFsPath(resolvedPathname);
+        const exists = fsPathExists(resolvedFsPath);
+        if (!exists) {
+          localAssetMissing.push({
+            page: page.relPath,
+            line: ref.line,
+            refValue: ref.value,
+            refClass: ref.classification,
+            scenario: scenario.kind,
+            scenarioRoutePath: scenario.routePath,
+            resolvedPathname,
+            resolvedFile: resolvedFsPath ? toPosix(path.relative(rootDir, resolvedFsPath)) : null
+          });
+        }
+      }
+
+      if (ref.classification === "relative") {
+        const noSlash = scenarios.find((s) => s.kind === "pretty_no_slash");
+        const withSlash = scenarios.find((s) => s.kind === "pretty_with_slash");
+        if (noSlash && withSlash) {
+          const pathNoSlash = resolveLocalUrlForScenario(ref.value, noSlash.routePath);
+          const pathWithSlash = resolveLocalUrlForScenario(ref.value, withSlash.routePath);
+          const existsNoSlash = fsPathExists(resolvedPathToFsPath(pathNoSlash));
+          const existsWithSlash = fsPathExists(resolvedPathToFsPath(pathWithSlash));
+          if (existsNoSlash && !existsWithSlash) {
+            trailingSlashHazards.push({
+              page: page.relPath,
+              line: ref.line,
+              refValue: ref.value,
+              noSlashRoute: noSlash.routePath,
+              withSlashRoute: withSlash.routePath,
+              resolvedNoSlash: pathNoSlash,
+              resolvedWithSlash: pathWithSlash
+            });
+          }
+        }
+      }
+    }
+
+    if (page.canonicalHref) {
+      canonicalPatterns.push({ page: page.relPath, canonicalHref: page.canonicalHref });
+    }
+
+    pageSummaries.push({
+      page: page.relPath,
+      canonicalHref: page.canonicalHref,
+      localAbsoluteCount,
+      localRelativeCount,
+      externalCount,
+      specialCount,
+      mixedLocalAssetStrategy,
+      duplicateIds: page.duplicateIds
+    });
+  }
+  const absoluteTotal = pageSummaries.reduce((sum, p) => sum + p.localAbsoluteCount, 0);
+  const relativeTotal = pageSummaries.reduce((sum, p) => sum + p.localRelativeCount, 0);
+  const siteConvention = absoluteTotal >= relativeTotal ? "absolute_root" : "relative";
+
+  const indexSummary = pageSummaries.find((p) => p.page === "site/index.html");
+  const nonIndexRelativePages = pageSummaries.filter((p) => p.page !== "site/index.html" && p.localRelativeCount > 0);
+  const homepageAbsoluteInnerRelativePattern = Boolean(
+    indexSummary && indexSummary.localAbsoluteCount > 0 && indexSummary.localRelativeCount === 0 && nonIndexRelativePages.length > 0
+  );
+
+  const redirectsExists = fs.existsSync(path.join(siteDir, "_redirects"));
+  const headersExists = fs.existsSync(path.join(siteDir, "_headers"));
+  const redirectsRaw = redirectsExists ? readUtf8(path.join(siteDir, "_redirects")) : "";
+  const headersRaw = headersExists ? readUtf8(path.join(siteDir, "_headers")) : "";
+
+  const canonicalKinds = { file: 0, pretty_no_slash: 0, pretty_with_slash: 0, root: 0, other: 0 };
+  for (const item of canonicalPatterns) {
+    if (!item.canonicalHref) continue;
+    let pathname = null;
+    try {
+      pathname = new URL(item.canonicalHref).pathname;
+    } catch {
+      pathname = item.canonicalHref;
+    }
+    if (pathname === "/") canonicalKinds.root += 1;
+    else if (/\.html$/i.test(pathname)) canonicalKinds.file += 1;
+    else if (pathname.endsWith("/")) canonicalKinds.pretty_with_slash += 1;
+    else if (pathname.startsWith("/")) canonicalKinds.pretty_no_slash += 1;
+    else canonicalKinds.other += 1;
+  }
+
+  const jsFiles = collectJsFilesUnderAssets();
+  const scriptLoads = extractLocalScriptLoads(pageAnalysis);
+  const scriptToPages = mapScriptsToPages(scriptLoads);
+  const fetchEntries = [];
+  const scriptMountReferences = [];
+
+  for (const jsFile of jsFiles) {
+    const jsRel = toPosix(path.relative(rootDir, jsFile));
+    const jsRaw = readUtf8(jsFile);
+    const lineStarts = getLineStarts(jsRaw);
+    const literals = findLiteralFetches(jsRel, jsRaw, lineStarts);
+    const mountDefs = inferSelectorGuards(jsRaw);
+    const selectorIds = findIdSelectors(jsRaw);
+    const loadedBy = Array.from(scriptToPages.get(jsRel) || []).sort();
+
+    const idGuardMap = new Map();
+    for (const mount of mountDefs) {
+      if (!idGuardMap.has(mount.id)) idGuardMap.set(mount.id, false);
+      idGuardMap.set(mount.id, idGuardMap.get(mount.id) || mount.guarded);
+    }
+
+    for (const selector of selectorIds) {
+      scriptMountReferences.push({
+        script: jsRel,
+        id: selector.id,
+        line: selector.line,
+        col: selector.col,
+        loadedByPages: loadedBy,
+        guarded: idGuardMap.has(selector.id) ? idGuardMap.get(selector.id) : false
+      });
+    }
+
+    for (const entry of literals) {
+      const localChecks = [];
+      if (isLocalClass(entry.classification)) {
+        if (entry.classification === "absolute_root") {
+          const resolvedPathname = stripQueryHash(entry.url);
+          const fsPath = resolvedPathToFsPath(resolvedPathname);
+          localChecks.push({
+            page: null,
+            scenario: "absolute_root",
+            routePath: "/",
+            resolvedPathname,
+            resolvedFile: fsPath ? toPosix(path.relative(rootDir, fsPath)) : null,
+            exists: fsPathExists(fsPath)
+          });
+        } else {
+          const contexts = loadedBy.length > 0 ? loadedBy : pageAnalysis.map((p) => p.relPath);
+          for (const page of contexts) {
+            const scenarios = pageRouteScenarios(page.replace(/^site\//, ""));
+            for (const scenario of scenarios) {
+              const resolvedPathname = resolveLocalUrlForScenario(entry.url, scenario.routePath);
+              const fsPath = resolvedPathToFsPath(resolvedPathname);
+              localChecks.push({
+                page,
+                scenario: scenario.kind,
+                routePath: scenario.routePath,
+                resolvedPathname,
+                resolvedFile: fsPath ? toPosix(path.relative(rootDir, fsPath)) : null,
+                exists: fsPathExists(fsPath)
+              });
+            }
+          }
+        }
+      }
+
+      fetchEntries.push({ ...entry, loadedByPages: loadedBy, localChecks });
+    }
+  }
+
+  const domMissingByScriptPage = [];
+  const pageIdSetMap = new Map();
+  for (const page of pageAnalysis) {
+    pageIdSetMap.set(page.relPath, new Set(page.pageIds.map((item) => item.id)));
+  }
+
+  for (const mount of scriptMountReferences) {
+    for (const page of mount.loadedByPages) {
+      const ids = pageIdSetMap.get(page) || new Set();
+      if (!ids.has(mount.id)) {
+        domMissingByScriptPage.push({
+          script: mount.script,
+          page,
+          id: mount.id,
+          scriptLine: mount.line,
+          guarded: mount.guarded
+        });
+      }
+    }
+  }
+
+  const duplicateIdFindings = pageAnalysis
+    .filter((p) => p.duplicateIds.length > 0)
+    .map((p) => ({ page: p.relPath, duplicateIds: p.duplicateIds }));
+
+  const jsonUrlsReferenced = [];
+  for (const entry of fetchEntries) {
+    if (/\.json(\?|#|$)/i.test(entry.url)) {
+      jsonUrlsReferenced.push({ jsFile: entry.jsFile, line: entry.line, url: entry.url, classification: entry.classification });
+    }
+  }
+
+  const generatedArtifactPresence = GENERATED_ARTIFACTS_EXPECTED.map((rel) => ({
+    file: rel,
+    exists: fs.existsSync(path.join(rootDir, rel))
+  }));
+
+  const generatorScriptEvidence = collectGeneratorScriptEvidence();
+  const cloudflareEvidence = collectCloudflareOutputEvidence();
+
+  const legacyOwnerHits = [];
+  for (const token of OLD_OWNER_PATTERNS) {
+    const hits = searchTextHits(token, { flags: "i" });
+    for (const hit of hits) legacyOwnerHits.push({ token, ...hit });
+  }
+
+  const rawGithubHits = searchTextHits(/raw\.githubusercontent\.com/i);
+  const netlifyHits = searchTextHits(/netlify/i);
+
+  const githubOwnerRegex = /github\.com\/([A-Za-z0-9_.-]+)\//ig;
+  const githubOwnerHits = [];
+  for (const relPath of getGitTrackedFiles()) {
+    if (!isLikelyTextFile(relPath)) continue;
+    const absPath = path.join(rootDir, relPath);
+    if (!fs.existsSync(absPath)) continue;
+    let text;
+    try {
+      text = readUtf8(absPath);
+    } catch {
+      continue;
+    }
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      let match;
+      while ((match = githubOwnerRegex.exec(lines[i])) !== null) {
+        githubOwnerHits.push({ file: relPath, line: i + 1, owner: match[1], text: lines[i] });
+      }
+      githubOwnerRegex.lastIndex = 0;
+    }
+  }
+
+  const legacyOwnersDetected = Array.from(
+    new Set(
+      githubOwnerHits
+        .map((hit) => String(hit.owner || "").toLowerCase())
+        .filter((owner) => owner && owner !== CURRENT_GITHUB_OWNER.toLowerCase())
+    )
+  ).sort();
+
+  const fetchInconsistentStrategies = (() => {
+    const classes = new Set(
+      fetchEntries
+        .map((entry) => entry.classification)
+        .filter((classification) => classification === "absolute_root" || classification === "relative")
+    );
+    return classes.size > 1;
+  })();
+
+  const fetchTimeoutRiskFiles = [];
+  for (const jsFile of jsFiles) {
+    const jsRel = toPosix(path.relative(rootDir, jsFile));
+    const raw = readUtf8(jsFile);
+    if (!/fetch\s*\(/.test(raw)) continue;
+    const hasAbortController = /AbortController/.test(raw);
+    const hasTimeoutRace = /setTimeout|Promise\.race/.test(raw);
+    if (!hasAbortController && !hasTimeoutRace) {
+      fetchTimeoutRiskFiles.push(jsRel);
+    }
+  }
+
+  const missingLocalAssetsDeduped = dedupeObjects(localAssetMissing, (item) =>
+    `${item.page}|${item.line}|${item.refValue}|${item.scenario}|${item.resolvedPathname}`
+  );
+  const trailingHazardsDeduped = dedupeObjects(trailingSlashHazards, (item) =>
+    `${item.page}|${item.line}|${item.refValue}|${item.withSlashRoute}|${item.resolvedWithSlash}`
+  );
+  const domMissingDeduped = dedupeObjects(domMissingByScriptPage, (item) =>
+    `${item.script}|${item.page}|${item.id}|${item.scriptLine}`
+  );
+
+  const assetPagesDifferingFromConvention = pageSummaries
+    .filter((p) => siteConvention === "absolute_root" ? p.localRelativeCount > 0 : p.localAbsoluteCount > 0)
+    .map((p) => p.page);
+
+  const suspiciousFetches = fetchEntries.filter((entry) => {
+    if (entry.classification === "external") return true;
+    if (entry.classification === "relative") {
+      const slashFailures = entry.localChecks.filter((check) => check.scenario === "pretty_with_slash" && !check.exists);
+      if (slashFailures.length > 0) return true;
+    }
+    return entry.localChecks.some((check) => !check.exists);
+  });
+
+  const topRootCauses = buildTopRootCauses({
+    siteConvention,
+    homepageAbsoluteInnerRelativePattern,
+    trailingHazardCount: trailingHazardsDeduped.length,
+    missingAssetCount: missingLocalAssetsDeduped.length,
+    fetchInconsistentStrategies,
+    fetchTimeoutRiskFiles,
+    suspiciousFetches,
+    generatedArtifactPresence,
+    cloudflareEvidence,
+    legacyOwnerHits,
+    rawGithubHits,
+    netlifyHits
+  });
+
+  const canonicalizationIntent = inferCanonicalIntent(canonicalKinds);
+  const recommendedPatchSections = buildRecommendedPatchSections({
+    allLocalAssetRefs,
+    fetchEntries,
+    trailingHazardsDeduped
+  });
+
+  const summary = {
+    generatedAt: nowIso,
+    environment: { cwd: rootDir, siteDir: toPosix(path.relative(rootDir, siteDir)) || "site" },
+    coverage: { htmlFilesScanned: htmlFiles.length, jsFilesScanned: jsFiles.length, fetchCallsFound: fetchEntries.length },
+    checks: {
+      assetPathAudit: {
+        siteConvention,
+        absoluteTotal,
+        relativeTotal,
+        homepageAbsoluteInnerRelativePattern,
+        pagesDifferingFromConvention: assetPagesDifferingFromConvention,
+        perPage: pageSummaries
+      },
+      canonicalization: {
+        redirectsFilePresent: redirectsExists,
+        headersFilePresent: headersExists,
+        redirectsPreview: redirectsRaw.split(/\r?\n/).slice(0, 20),
+        headersPreview: headersRaw.split(/\r?\n/).slice(0, 20),
+        canonicalKinds,
+        canonicalizationIntent,
+        trailingSlashHazards: trailingHazardsDeduped
+      },
+      localResolver: { localAssetMissingReferences: missingLocalAssetsDeduped },
+      fetchAudit: {
+        inconsistentLocalFetchStrategies: fetchInconsistentStrategies,
+        timeoutRiskFiles: fetchTimeoutRiskFiles,
+        fetchEntries,
+        suspiciousFetches
+      },
+      dataArtifacts: {
+        expectedArtifacts: generatedArtifactPresence,
+        referencedJsonUrls: jsonUrlsReferenced,
+        generatorScriptEvidence,
+        cloudflareOutputEvidence: cloudflareEvidence
+      },
+      renameRegression: {
+        currentOwner: CURRENT_GITHUB_OWNER,
+        legacyOwnerTokens: OLD_OWNER_PATTERNS,
+        legacyOwnerHits,
+        rawGithubHits,
+        netlifyHits,
+        legacyOwnersDetected
+      },
+      domMounts: {
+        duplicateIds: duplicateIdFindings,
+        scriptMountReferences,
+        missingMountsByPage: domMissingDeduped
+      },
+      rootCauseRanking: topRootCauses
+    },
+    fixPlan: {
+      recommendedConvention: "Use root-absolute local asset URLs: /assets/...",
+      recommendedPatchSections
+    },
+    runInstructions: {
+      node: "node scripts/diagnose-site.js",
+      nodeFailOnIssues: "node scripts/diagnose-site.js --fail-on-issues",
+      localServer: [
+        "python -m http.server --directory site 8000",
+        "Open http://127.0.0.1:8000/ in a browser.",
+        "Test both /security and /security/ to validate relative-path behavior."
+      ]
+    }
+  };
+
+  return { summary, markdown: buildMarkdownReport(summary) };
+}
+function buildMarkdownReport(summary) {
+  const sections = [];
+  const checks = summary.checks;
+
+  sections.push(`# Static Site Diagnosis Report`);
+  sections.push("");
+  sections.push(`Generated: \`${summary.generatedAt}\``);
+  sections.push(`Root: \`${summary.environment.cwd}\``);
+  sections.push(`Site directory: \`${summary.environment.siteDir}\``);
+  sections.push("");
+  sections.push(`## Scope`);
+  sections.push(`- HTML asset path consistency audit across all \`site/*.html\` pages`);
+  sections.push(`- Trailing slash and canonicalization hazard analysis`);
+  sections.push(`- Static-host URL resolution simulation for local assets`);
+  sections.push(`- JS fetch/XHR URL audit`);
+  sections.push(`- Generated data artifact and hosting build expectations`);
+  sections.push(`- Rename regression checks (\`raylee-ops\`, \`netlify\`, raw GitHub URLs)`);
+  sections.push(`- DOM mount contract checks (JS selectors vs page IDs)`);
+  sections.push("");
+
+  sections.push(`## Sample Run Output`);
+  sections.push("```text");
+  sections.push(`HTML files scanned: ${summary.coverage.htmlFilesScanned}`);
+  sections.push(`JS files scanned: ${summary.coverage.jsFilesScanned}`);
+  sections.push(`Fetch calls found: ${summary.coverage.fetchCallsFound}`);
+  sections.push(`Trailing-slash hazards: ${checks.canonicalization.trailingSlashHazards.length}`);
+  sections.push(`Missing local asset resolutions: ${checks.localResolver.localAssetMissingReferences.length}`);
+  sections.push(`Legacy owner hits: ${checks.renameRegression.legacyOwnerHits.length}`);
+  sections.push(`Netlify hits: ${checks.renameRegression.netlifyHits.length}`);
+  sections.push("```");
+  sections.push("");
+
+  sections.push(`## A) Asset Path Consistency Audit (HTML)`);
+  sections.push(`Site-wide local asset convention inferred: \`${checks.assetPathAudit.siteConvention}\``);
+  sections.push(`Homepage absolute + inner-page relative pattern detected: \`${checks.assetPathAudit.homepageAbsoluteInnerRelativePattern}\``);
+  sections.push("");
+  sections.push(markdownTable(
+    ["Page", "Absolute Local", "Relative Local", "External", "Mixed", "Canonical"],
+    checks.assetPathAudit.perPage.map((page) => [
+      `\`${page.page}\``,
+      page.localAbsoluteCount,
+      page.localRelativeCount,
+      page.externalCount,
+      page.mixedLocalAssetStrategy ? "yes" : "no",
+      page.canonicalHref ? `\`${page.canonicalHref}\`` : "-"
+    ])
+  ));
+  if (checks.assetPathAudit.pagesDifferingFromConvention.length > 0) {
+    sections.push("");
+    sections.push(`Pages differing from site convention:`);
+    for (const page of checks.assetPathAudit.pagesDifferingFromConvention) {
+      sections.push(`- \`${page}\``);
+    }
+  }
+  sections.push("");
+
+  sections.push(`## B) Trailing Slash + Canonicalization Hazards`);
+  sections.push(`Canonicalization intent inferred: \`${checks.canonicalization.canonicalizationIntent}\``);
+  sections.push(`- \`site/_redirects\` present: \`${checks.canonicalization.redirectsFilePresent}\``);
+  sections.push(`- \`site/_headers\` present: \`${checks.canonicalization.headersFilePresent}\``);
+  sections.push(``);
+  sections.push(`Trailing-slash hazard examples:`);
+  const hazardExamples = checks.canonicalization.trailingSlashHazards.slice(0, 20);
+  if (hazardExamples.length === 0) {
+    sections.push(`- No relative-asset slash hazards detected.`);
+  } else {
+    for (const hazard of hazardExamples) {
+      sections.push(`- ${formatPathLine(hazard.page, hazard.line)} ref \`${hazard.refValue}\` -> \`${hazard.resolvedNoSlash}\` on \`${hazard.noSlashRoute}\`, but \`${hazard.resolvedWithSlash}\` on \`${hazard.withSlashRoute}\``);
+    }
+  }
+  sections.push("");
+
+  sections.push(`## C) Local Static-Serve Fetch/Path Simulation`);
+  for (const cmd of summary.runInstructions.localServer) {
+    sections.push(`- \`${cmd}\``);
+  }
+  sections.push(`- Missing local asset resolutions: ${checks.localResolver.localAssetMissingReferences.length}`);
+  for (const miss of checks.localResolver.localAssetMissingReferences.slice(0, 40)) {
+    sections.push(`- ${formatPathLine(miss.page, miss.line)} \`${miss.refValue}\` scenario \`${miss.scenario}\` -> \`${miss.resolvedPathname}\` (${miss.resolvedFile || "no file"})`);
+  }
+  sections.push("");
+
+  sections.push(`## D) JS Runtime Fetch Audit`);
+  sections.push(`- Inconsistent local fetch strategy: \`${checks.fetchAudit.inconsistentLocalFetchStrategies}\``);
+  sections.push(`- Files with fetch but no timeout primitives: ${checks.fetchAudit.timeoutRiskFiles.length}`);
+  for (const file of checks.fetchAudit.timeoutRiskFiles) {
+    sections.push(`  - \`${file}\``);
+  }
+  sections.push(markdownTable(
+    ["Fetch Site", "URL", "Class", "Loaded By", "Local Check"],
+    checks.fetchAudit.fetchEntries.map((entry) => [
+      `\`${entry.jsFile}:${entry.line}\``,
+      `\`${entry.url}\``,
+      entry.classification,
+      entry.loadedByPages.length ? entry.loadedByPages.map((p) => `\`${p}\``).join(", ") : "(unknown)",
+      entry.localChecks.length ? (entry.localChecks.every((c) => c.exists) ? "ok" : "has-missing") : "-"
+    ])
+  ));
+  sections.push(`Suspicious fetch URLs:`);
+  if (checks.fetchAudit.suspiciousFetches.length === 0) {
+    sections.push(`- None`);
+  } else {
+    for (const entry of checks.fetchAudit.suspiciousFetches.slice(0, 120)) {
+      sections.push(`- ${formatPathLine(entry.jsFile, entry.line)} \`${entry.url}\` (${entry.classification})`);
+    }
+  }
+  sections.push("");
+
+  sections.push(`## E) Data Artifact Presence + Generation Expectations`);
+  for (const item of checks.dataArtifacts.expectedArtifacts) {
+    sections.push(`- \`${item.file}\` -> ${item.exists ? "present" : "missing"}`);
+  }
+  sections.push(`Generation script evidence:`);
+  for (const hit of checks.dataArtifacts.generatorScriptEvidence.slice(0, 60)) {
+    sections.push(`- ${formatPathLine(hit.file, hit.line)} ${escapePipes(hit.text)}`);
+  }
+  sections.push(`Cloudflare output evidence:`);
+  for (const hit of checks.dataArtifacts.cloudflareOutputEvidence.slice(0, 60)) {
+    sections.push(`- ${formatPathLine(hit.file, hit.line)} ${escapePipes(hit.text)}`);
+  }
+  sections.push("");
+
+  sections.push(`## F) Old Identifier / Rename Regression Checks`);
+  sections.push(`Current owner baseline: \`${checks.renameRegression.currentOwner}\``);
+  sections.push(`Legacy owners detected: ${checks.renameRegression.legacyOwnersDetected.length ? checks.renameRegression.legacyOwnersDetected.map((owner) => `\`${owner}\``).join(", ") : "(none)"}`);
+  sections.push(``);
+  sections.push(`raylee-ops/old owner hits:`);
+  for (const hit of checks.renameRegression.legacyOwnerHits.slice(0, 160)) {
+    sections.push(`- ${formatPathLine(hit.file, hit.line)} [${hit.token}] ${escapePipes(hit.text)}`);
+  }
+  sections.push(`raw.githubusercontent.com hits:`);
+  for (const hit of checks.renameRegression.rawGithubHits.slice(0, 160)) {
+    sections.push(`- ${formatPathLine(hit.file, hit.line)} ${escapePipes(hit.text)}`);
+  }
+  sections.push(`netlify hits:`);
+  for (const hit of checks.renameRegression.netlifyHits.slice(0, 160)) {
+    sections.push(`- ${formatPathLine(hit.file, hit.line)} ${escapePipes(hit.text)}`);
+  }
+  sections.push("");
+
+  sections.push(`## G) Content/DOM Mount Mismatch Checks`);
+  sections.push(`Duplicate ID findings: ${checks.domMounts.duplicateIds.length}`);
+  for (const dup of checks.domMounts.duplicateIds) {
+    sections.push(`- \`${dup.page}\` duplicate IDs: ${dup.duplicateIds.map((id) => `\`${id}\``).join(", ")}`);
+  }
+  sections.push(`Missing script mount IDs by page: ${checks.domMounts.missingMountsByPage.length}`);
+  for (const miss of checks.domMounts.missingMountsByPage.slice(0, 160)) {
+    sections.push(`- ${formatPathLine(miss.script, miss.scriptLine)} expects \`#${miss.id}\` on \`${miss.page}\` (guarded=${miss.guarded})`);
+  }
+  sections.push("");
+
+  sections.push(`## H) Ranked Top 5 Causes of Progressive Degradation`);
+  for (const cause of checks.rootCauseRanking) {
+    sections.push(`### ${cause.rank}. ${cause.title}`);
+    sections.push(`- Why intermittent: ${cause.whyIntermittent}`);
+    sections.push(`- How to confirm: ${cause.howToConfirm}`);
+    sections.push(`- Minimal fix: ${cause.minimalFix}`);
+    sections.push(`- Evidence: \`${JSON.stringify(cause.evidence)}\``);
+    sections.push("");
+  }
+
+  sections.push(`## Minimal Safe Fix Plan`);
+  sections.push(`1. Standardize local asset references in HTML to root-absolute \`/assets/...\`.`);
+  sections.push(`2. Standardize local fetch URLs in JS to root-absolute \`/assets/data/...\`.`);
+  sections.push(`3. Add canonical slash redirects in \`site/_redirects\` if pretty-no-slash is canonical.`);
+  sections.push(`4. Enforce timeout + fallback rendering for all async loading lanes.`);
+  sections.push(`5. Add CI sanity gate: \`node scripts/diagnose-site.js --fail-on-issues\`.`);
+  sections.push("");
+
+  sections.push(`### Recommended Fix Patch Sections`);
+  sections.push(`#### HTML asset path rewrites`);
+  for (const item of summary.fixPlan.recommendedPatchSections.htmlAssetPathRewrites.slice(0, 220)) {
+    sections.push(`- ${formatPathLine(item.file, item.line)} \`${item.current}\` -> \`${item.suggested}\``);
+  }
+  sections.push(`#### JS fetch path rewrites`);
+  for (const item of summary.fixPlan.recommendedPatchSections.jsFetchPathRewrites.slice(0, 220)) {
+    sections.push(`- ${formatPathLine(item.file, item.line)} \`${item.current}\` -> \`${item.suggested}\``);
+  }
+  sections.push(`#### _redirects canonical suggestions`);
+  if (summary.fixPlan.recommendedPatchSections.redirectsCanonicalSuggestions.length > 0) {
+    sections.push("```text");
+    for (const line of summary.fixPlan.recommendedPatchSections.redirectsCanonicalSuggestions) {
+      sections.push(line);
+    }
+    sections.push("```");
+  } else {
+    sections.push(`- No canonical redirect additions suggested.`);
+  }
+  sections.push(`#### CI sanity check`);
+  sections.push(`- ${summary.fixPlan.recommendedPatchSections.ciSanityCheckSuggestion.description}`);
+  sections.push(`- Command: \`${summary.fixPlan.recommendedPatchSections.ciSanityCheckSuggestion.command}\``);
+  sections.push("");
+
+  sections.push(`## Re-run Instructions`);
+  sections.push(`- Node only: \`${summary.runInstructions.node}\``);
+  sections.push(`- Fail CI on issues: \`${summary.runInstructions.nodeFailOnIssues}\``);
+  sections.push(`- Report outputs: \`${toPosix(path.relative(rootDir, markdownOut))}\`, \`${toPosix(path.relative(rootDir, jsonOut))}\``);
+
+  return sections.join("\n");
+}
+
+function main() {
+  if (!fs.existsSync(siteDir)) {
+    console.error(`Missing site directory: ${siteDir}`);
+    process.exit(1);
+  }
+
+  const { summary, markdown } = analyze();
+  ensureDir(docsDir);
+  fs.writeFileSync(markdownOut, markdown + "\n", "utf8");
+  fs.writeFileSync(jsonOut, JSON.stringify(summary, null, 2) + "\n", "utf8");
+
+  const rootCauses = summary.checks.rootCauseRanking;
+  console.log([
+    `Static site diagnosis complete.`,
+    `Report: ${toPosix(path.relative(rootDir, markdownOut))}`,
+    `JSON: ${toPosix(path.relative(rootDir, jsonOut))}`,
+    `HTML files scanned: ${summary.coverage.htmlFilesScanned}`,
+    `JS files scanned: ${summary.coverage.jsFilesScanned}`,
+    `Fetch calls found: ${summary.coverage.fetchCallsFound}`,
+    `Trailing-slash hazards: ${summary.checks.canonicalization.trailingSlashHazards.length}`,
+    `Missing local asset resolutions: ${summary.checks.localResolver.localAssetMissingReferences.length}`,
+    `Top cause #1: ${rootCauses[0] ? rootCauses[0].title : "n/a"}`
+  ].join("\n"));
+
+  const criticalIssueCount =
+    summary.checks.canonicalization.trailingSlashHazards.length +
+    summary.checks.localResolver.localAssetMissingReferences.length +
+    summary.checks.fetchAudit.suspiciousFetches.length;
+
+  if (failOnIssues && criticalIssueCount > 0) {
+    console.error(`Failing due to critical issues count: ${criticalIssueCount}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/diagnose-site.ps1
+++ b/scripts/diagnose-site.ps1
@@ -1,0 +1,15 @@
+param(
+  [switch]$FailOnIssues
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location -LiteralPath $root
+
+$argsList = @("scripts/diagnose-site.js")
+if ($FailOnIssues) {
+  $argsList += "--fail-on-issues"
+}
+
+node @argsList

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+const baseUrl = process.argv[2] || "https://hawkinsops.com";
+
+const assetUrls = [
+  `${baseUrl}/assets/styles.css`,
+  `${baseUrl}/assets/app.js`,
+  `${baseUrl}/assets/portfolio-data.js`,
+  `${baseUrl}/assets/data/detections.json`,
+  `${baseUrl}/assets/data/media.json`,
+  `${baseUrl}/assets/verified-counts.json`
+];
+
+const jsonUrls = [
+  `${baseUrl}/assets/data/detections.json`,
+  `${baseUrl}/assets/data/media.json`,
+  `${baseUrl}/assets/verified-counts.json`
+];
+
+const redirectCases = [
+  { name: "security", slash: `${baseUrl}/security/`, allowed: ["/security", "/security.html"] },
+  { name: "projects", slash: `${baseUrl}/projects/`, allowed: ["/projects", "/projects.html"] },
+  { name: "lab", slash: `${baseUrl}/lab/`, allowed: ["/lab", "/lab.html"] },
+  { name: "proof", slash: `${baseUrl}/proof/`, allowed: ["/proof", "/proof.html"] }
+];
+
+function firstNonWhitespaceChar(text) {
+  if (!text) return "";
+  const t = String(text).trimStart();
+  return t.length ? t[0] : "";
+}
+
+function toAbsolute(base, location) {
+  if (!location) return null;
+  if (/^https?:\/\//i.test(location)) return location;
+  if (location.startsWith("/")) return `${base}${location}`;
+  return `${base}/${location}`;
+}
+
+async function request(url, redirect = "follow") {
+  try {
+    const res = await fetch(url, { redirect, cache: "no-store" });
+    const body = await res.text();
+    return {
+      ok: true,
+      status: res.status,
+      body,
+      location: res.headers.get("location") || "",
+      error: ""
+    };
+  } catch (err) {
+    return { ok: false, status: 0, body: "", location: "", error: err && err.message ? err.message : String(err) };
+  }
+}
+
+function normalizeLocationPath(location) {
+  if (!location) return "";
+  try {
+    if (/^https?:\/\//i.test(location)) {
+      return new URL(location).pathname;
+    }
+  } catch {
+    return location;
+  }
+  return location;
+}
+
+function pushResult(results, check, url, expected, actual, pass, detail) {
+  results.push({ check, url, expected, actual, pass, detail: detail || "" });
+}
+
+function printTable(results) {
+  const headers = ["Check", "Url", "Expected", "Actual", "Pass", "Detail"];
+  const widths = {
+    Check: 18,
+    Url: 52,
+    Expected: 35,
+    Actual: 22,
+    Pass: 6
+  };
+
+  const pad = (value, width) => {
+    const s = String(value ?? "");
+    if (s.length <= width) return s.padEnd(width, " ");
+    return `${s.slice(0, Math.max(0, width - 1))}…`;
+  };
+
+  console.log(
+    `${pad(headers[0], widths.Check)} ${pad(headers[1], widths.Url)} ${pad(headers[2], widths.Expected)} ${pad(headers[3], widths.Actual)} ${pad(headers[4], widths.Pass)} ${headers[5]}`
+  );
+  console.log(
+    `${"-".repeat(widths.Check)} ${"-".repeat(widths.Url)} ${"-".repeat(widths.Expected)} ${"-".repeat(widths.Actual)} ${"-".repeat(widths.Pass)} ${"-".repeat(40)}`
+  );
+
+  for (const row of results) {
+    console.log(
+      `${pad(row.check, widths.Check)} ${pad(row.url, widths.Url)} ${pad(row.expected, widths.Expected)} ${pad(row.actual, widths.Actual)} ${pad(String(row.pass), widths.Pass)} ${row.detail}`
+    );
+  }
+}
+
+async function main() {
+  const results = [];
+  const responseMap = new Map();
+
+  for (const url of assetUrls) {
+    const res = await request(url, "follow");
+    responseMap.set(url, res);
+    const pass = res.ok && res.status === 200;
+    pushResult(results, "ASSET_200", url, "HTTP 200", res.ok ? `HTTP ${res.status}` : "ERROR", pass, res.ok ? "" : res.error);
+  }
+
+  for (const url of jsonUrls) {
+    const res = responseMap.get(url) || (await request(url, "follow"));
+    const first = firstNonWhitespaceChar(res.body);
+    const pass = res.ok && res.status === 200 && (first === "{" || first === "[");
+    const detail = !res.ok ? res.error : first === "<" ? "Response begins with '<' (likely HTML error page)" : "";
+    pushResult(
+      results,
+      "JSON_SHAPE",
+      url,
+      "Starts with { or [ (not <)",
+      res.ok ? `HTTP ${res.status}, starts '${first}'` : "ERROR",
+      pass,
+      detail
+    );
+  }
+
+  for (const item of redirectCases) {
+    const redirectRes = await request(item.slash, "manual");
+    const locationPath = normalizeLocationPath(redirectRes.location);
+    const statusPass = redirectRes.ok && (redirectRes.status === 301 || redirectRes.status === 308);
+    const locationPass = item.allowed.includes(locationPath);
+    const passShape = statusPass && locationPass;
+
+    pushResult(
+      results,
+      "REDIRECT_SHAPE",
+      item.slash,
+      `301/308 to ${item.allowed.join(" or ")}`,
+      redirectRes.ok ? `HTTP ${redirectRes.status}, Location: ${redirectRes.location}` : "ERROR",
+      passShape,
+      redirectRes.ok ? "" : redirectRes.error
+    );
+
+    const finalUrl = toAbsolute(baseUrl, redirectRes.location) || `${baseUrl}${item.allowed[0]}`;
+    const finalRes = await request(finalUrl, "follow");
+    pushResult(
+      results,
+      "REDIRECT_FINAL_200",
+      finalUrl,
+      "HTTP 200",
+      finalRes.ok ? `HTTP ${finalRes.status}` : "ERROR",
+      finalRes.ok && finalRes.status === 200,
+      finalRes.ok ? "" : finalRes.error
+    );
+  }
+
+  printTable(results);
+  const failed = results.filter((r) => !r.pass).length;
+  const passed = results.length - failed;
+  console.log("");
+  console.log(`Smoke summary: ${passed}/${results.length} passed, ${failed} failed.`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/smoke-production.ps1
+++ b/scripts/smoke-production.ps1
@@ -1,0 +1,226 @@
+param(
+  [string]$BaseUrl = "https://hawkinsops.com",
+  [int]$TimeoutSeconds = 20
+)
+
+$ErrorActionPreference = "Stop"
+
+function New-HttpClient {
+  param(
+    [bool]$AllowRedirect = $true,
+    [int]$TimeoutSec = 20
+  )
+
+  $handler = [System.Net.Http.HttpClientHandler]::new()
+  $handler.AllowAutoRedirect = $AllowRedirect
+  $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
+  $client = [System.Net.Http.HttpClient]::new($handler)
+  $client.Timeout = [System.TimeSpan]::FromSeconds($TimeoutSec)
+  $client.DefaultRequestHeaders.UserAgent.ParseAdd("HawkinsOps-Smoke/1.0")
+  return $client
+}
+
+function Invoke-HttpGet {
+  param(
+    [System.Net.Http.HttpClient]$Client,
+    [string]$Url
+  )
+
+  try {
+    $response = $Client.GetAsync($Url).GetAwaiter().GetResult()
+    $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    $locationHeader = $null
+    if ($response.Headers.Location) {
+      $locationHeader = $response.Headers.Location.OriginalString
+    }
+
+    return [pscustomobject]@{
+      Ok       = $true
+      Url      = $Url
+      Status   = [int]$response.StatusCode
+      Body     = [string]$body
+      Location = $locationHeader
+      Error    = $null
+    }
+  } catch {
+    return [pscustomobject]@{
+      Ok       = $false
+      Url      = $Url
+      Status   = $null
+      Body     = ""
+      Location = $null
+      Error    = $_.Exception.Message
+    }
+  }
+}
+
+function Get-FirstNonWhitespaceChar {
+  param([string]$Text)
+  if ([string]::IsNullOrWhiteSpace($Text)) { return "" }
+  $trimmed = $Text.TrimStart()
+  if ([string]::IsNullOrEmpty($trimmed)) { return "" }
+  return $trimmed.Substring(0, 1)
+}
+
+function Resolve-LocationUrl {
+  param(
+    [string]$Base,
+    [string]$Location
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Location)) { return $null }
+  if ($Location -match "^https?://") { return $Location }
+  if ($Location.StartsWith("/")) { return "$Base$Location" }
+  return "$Base/$Location"
+}
+
+function Add-Result {
+  param(
+    [System.Collections.Generic.List[object]]$Results,
+    [string]$Check,
+    [string]$Url,
+    [string]$Expected,
+    [string]$Actual,
+    [bool]$Pass,
+    [string]$Detail
+  )
+
+  $Results.Add([pscustomobject]@{
+      Check    = $Check
+      Url      = $Url
+      Expected = $Expected
+      Actual   = $Actual
+      Pass     = $Pass
+      Detail   = $Detail
+    })
+}
+
+$clientFollow = New-HttpClient -AllowRedirect $true -TimeoutSec $TimeoutSeconds
+$clientNoFollow = New-HttpClient -AllowRedirect $false -TimeoutSec $TimeoutSeconds
+$results = [System.Collections.Generic.List[object]]::new()
+
+$assetUrls = @(
+  "$BaseUrl/assets/styles.css",
+  "$BaseUrl/assets/app.js",
+  "$BaseUrl/assets/portfolio-data.js",
+  "$BaseUrl/assets/data/detections.json",
+  "$BaseUrl/assets/data/media.json",
+  "$BaseUrl/assets/verified-counts.json"
+)
+
+$responseMap = @{}
+foreach ($url in $assetUrls) {
+  $resp = Invoke-HttpGet -Client $clientFollow -Url $url
+  $responseMap[$url] = $resp
+  $pass = $resp.Ok -and $resp.Status -eq 200
+  $actual = if ($resp.Ok) { "HTTP $($resp.Status)" } else { "ERROR" }
+  $detail = if ($resp.Ok) { "" } else { $resp.Error }
+  Add-Result -Results $results -Check "ASSET_200" -Url $url -Expected "HTTP 200" -Actual $actual -Pass $pass -Detail $detail
+}
+
+$jsonUrls = @(
+  "$BaseUrl/assets/data/detections.json",
+  "$BaseUrl/assets/data/media.json",
+  "$BaseUrl/assets/verified-counts.json"
+)
+
+foreach ($url in $jsonUrls) {
+  $resp = $responseMap[$url]
+  if (-not $resp) {
+    $resp = Invoke-HttpGet -Client $clientFollow -Url $url
+  }
+  $first = Get-FirstNonWhitespaceChar -Text $resp.Body
+  $pass = $resp.Ok -and $resp.Status -eq 200 -and ($first -eq "{" -or $first -eq "[")
+  $actual = if (-not $resp.Ok) {
+    "ERROR"
+  } else {
+    "HTTP $($resp.Status), starts '$first'"
+  }
+  $detail = if (-not $resp.Ok) {
+    $resp.Error
+  } elseif ($first -eq "<") {
+    "Response begins with '<' (likely HTML error page)"
+  } else {
+    ""
+  }
+  Add-Result -Results $results -Check "JSON_SHAPE" -Url $url -Expected "Starts with { or [ (not <)" -Actual $actual -Pass $pass -Detail $detail
+}
+
+$redirectCases = @(
+  @{ Name = "security"; Slash = "$BaseUrl/security/"; AllowedTargets = @("/security", "/security.html") },
+  @{ Name = "projects"; Slash = "$BaseUrl/projects/"; AllowedTargets = @("/projects", "/projects.html") },
+  @{ Name = "lab"; Slash = "$BaseUrl/lab/"; AllowedTargets = @("/lab", "/lab.html") },
+  @{ Name = "proof"; Slash = "$BaseUrl/proof/"; AllowedTargets = @("/proof", "/proof.html") }
+)
+
+foreach ($case in $redirectCases) {
+  $slashUrl = [string]$case.Slash
+  $allowedTargets = @($case.AllowedTargets)
+
+  $redirectResp = Invoke-HttpGet -Client $clientNoFollow -Url $slashUrl
+
+  $locationHeader = if ($redirectResp.Ok) { [string]$redirectResp.Location } else { "" }
+  $locationPath = ""
+  if (-not [string]::IsNullOrWhiteSpace($locationHeader)) {
+    if ($locationHeader -match "^https?://") {
+      try {
+        $locationPath = ([System.Uri]$locationHeader).AbsolutePath
+      } catch {
+        $locationPath = $locationHeader
+      }
+    } else {
+      $locationPath = $locationHeader
+    }
+  }
+
+  $statusPass = $redirectResp.Ok -and ($redirectResp.Status -eq 301 -or $redirectResp.Status -eq 308)
+  $locationPass = $false
+  foreach ($target in $allowedTargets) {
+    if ($locationPath -eq $target) {
+      $locationPass = $true
+      break
+    }
+  }
+
+  $redirectPass = $statusPass -and $locationPass
+  $redirectActual = if ($redirectResp.Ok) {
+    "HTTP $($redirectResp.Status), Location: $locationHeader"
+  } else {
+    "ERROR"
+  }
+  $redirectDetail = if ($redirectResp.Ok) {
+    ""
+  } else {
+    $redirectResp.Error
+  }
+  Add-Result -Results $results -Check "REDIRECT_SHAPE" -Url $slashUrl -Expected "301/308 to $($allowedTargets -join ' or ')" -Actual $redirectActual -Pass $redirectPass -Detail $redirectDetail
+
+  $finalUrl = Resolve-LocationUrl -Base $BaseUrl -Location $locationHeader
+  if ([string]::IsNullOrWhiteSpace($finalUrl)) {
+    $finalUrl = "$BaseUrl$($allowedTargets[0])"
+  }
+  $finalResp = Invoke-HttpGet -Client $clientFollow -Url $finalUrl
+  $finalPass = $finalResp.Ok -and $finalResp.Status -eq 200
+  $finalActual = if ($finalResp.Ok) { "HTTP $($finalResp.Status)" } else { "ERROR" }
+  $finalDetail = if ($finalResp.Ok) { "" } else { $finalResp.Error }
+  Add-Result -Results $results -Check "REDIRECT_FINAL_200" -Url $finalUrl -Expected "HTTP 200" -Actual $finalActual -Pass $finalPass -Detail $finalDetail
+}
+
+$table = $results |
+  Sort-Object Check, Url |
+  Format-Table Check, Url, Expected, Actual, Pass, Detail -AutoSize -Wrap |
+  Out-String -Width 4096
+Write-Host $table
+
+$passed = ($results | Where-Object { $_.Pass }).Count
+$failed = ($results | Where-Object { -not $_.Pass }).Count
+$total = $results.Count
+
+Write-Host ""
+Write-Host "Smoke summary: $passed/$total passed, $failed failed."
+
+if ($failed -gt 0) {
+  exit 1
+}
+
+exit 0

--- a/scripts/verify/no-netlify.js
+++ b/scripts/verify/no-netlify.js
@@ -28,14 +28,26 @@ const textExt = new Set([
 const historicalAllowPrefixes = [
   path.join("PROOF_PACK", "hosting_transfer_cloudflare", "run_")
 ];
+const diagnosticAllowPrefixes = [
+  path.join("docs", "diagnosis")
+];
 const selfAllowFiles = new Set([
   path.join("scripts", "verify", "no-netlify.js").replaceAll("\\", "/"),
-  path.join("scripts", "verify", "README.md").replaceAll("\\", "/")
+  path.join("scripts", "verify", "README.md").replaceAll("\\", "/"),
+  path.join("scripts", "diagnose-site.js").replaceAll("\\", "/"),
+  path.join("scripts", "diagnose-site.ps1").replaceAll("\\", "/")
 ]);
 
 function isHistoricalAllowed(relPath) {
   const normalized = relPath.replaceAll("\\", "/");
   return historicalAllowPrefixes.some((prefix) =>
+    normalized.startsWith(prefix.replaceAll("\\", "/"))
+  );
+}
+
+function isDiagnosticAllowed(relPath) {
+  const normalized = relPath.replaceAll("\\", "/");
+  return diagnosticAllowPrefixes.some((prefix) =>
     normalized.startsWith(prefix.replaceAll("\\", "/"))
   );
 }
@@ -86,6 +98,7 @@ for (const relTracked of tracked) {
   const relNorm = relTracked.replaceAll("\\", "/");
   if (selfAllowFiles.has(relNorm)) continue;
   if (isHistoricalAllowed(relTracked)) continue;
+  if (isDiagnosticAllowed(relTracked)) continue;
 
   let content = "";
   try {

--- a/site/404.html
+++ b/site/404.html
@@ -16,9 +16,9 @@
 <meta name="twitter:title" content="HawkinsOps | Page not found">
 <meta name="twitter:description" content="The requested page was not found. Return to verified portfolio pages.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+<link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
 <section style="padding-top:110px">

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,4 +1,8 @@
 # Cloudflare Pages serves extensionless routes for matching .html files.
 # Keep this file for canonical file-path redirects only.
+/security/ /security 301
+/projects/ /projects 301
+/lab/ /lab 301
+/proof/ /proof 301
 /Raylee_Hawkins_Resume.pdf /assets/Raylee_Hawkins_Resume.pdf 301
 /assets/raylee_hawkins_resume.pdf /assets/Raylee_Hawkins_Resume.pdf 301

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -105,6 +105,13 @@
   }
   wireCopy();
 
+  function fetchJsonWithTimeout(url, options) {
+    if (typeof window.fetchJsonWithTimeout === 'function') {
+      return window.fetchJsonWithTimeout(url, options);
+    }
+    return Promise.resolve(null);
+  }
+
   // Scroll reveal utilities (disabled entirely when reduced motion is requested).
   const reducedMotionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
   let revealObserver = null;
@@ -272,9 +279,8 @@
   // Load verified counts generated from PROOF_PACK/VERIFIED_COUNTS.md
   async function loadVerifiedCounts() {
     try {
-      const response = await fetch('assets/verified-counts.json', { cache: 'no-store' });
-      if (!response.ok) return;
-      const data = await response.json();
+      const data = await fetchJsonWithTimeout('/assets/verified-counts.json', { timeoutMs: 1500 });
+      if (!data || typeof data !== 'object') return;
       const counts = data && data.counts ? data.counts : null;
       if (!counts) return;
 

--- a/site/assets/components/sections/media-gallery.js
+++ b/site/assets/components/sections/media-gallery.js
@@ -140,11 +140,9 @@ export async function initMediaGalleries(preloadedItems) {
   const roots = Array.from(document.querySelectorAll("[data-media-gallery]"));
   if (!roots.length) return;
   let items = normalizeSafeItems(preloadedItems);
-  if (!items.length) {
-    const res = await fetch("assets/data/media.json", { cache: "no-store" });
-    if (!res.ok) return;
-    const payload = await res.json();
-    items = normalizeSafeItems(payload.media);
+  if (!items.length && typeof window.fetchJsonWithTimeout === "function") {
+    const payload = await window.fetchJsonWithTimeout("/assets/data/media.json", { timeoutMs: 1500 });
+    items = normalizeSafeItems(payload && payload.media);
   }
   roots.forEach((root) => renderMediaGallery(root, items));
 }

--- a/site/assets/fetch-utils.js
+++ b/site/assets/fetch-utils.js
@@ -1,0 +1,34 @@
+(function (root) {
+  function toTimeout(value) {
+    var n = Number(value);
+    if (!Number.isFinite(n) || n <= 0) return 1500;
+    return Math.round(n);
+  }
+
+  function fetchJsonWithTimeout(url, options) {
+    var config = options || {};
+    var timeoutMs = toTimeout(config.timeoutMs);
+    var controller = typeof AbortController === "function" ? new AbortController() : null;
+    var timer = root.setTimeout(function () {
+      if (controller) controller.abort();
+    }, timeoutMs);
+
+    return root
+      .fetch(url, {
+        cache: "no-store",
+        signal: controller ? controller.signal : undefined
+      })
+      .then(function (response) {
+        if (!response.ok) throw new Error("HTTP " + response.status + " for " + url);
+        return response.json();
+      })
+      .catch(function () {
+        return null;
+      })
+      .finally(function () {
+        root.clearTimeout(timer);
+      });
+  }
+
+  root.fetchJsonWithTimeout = fetchJsonWithTimeout;
+})(window);

--- a/site/assets/home.js
+++ b/site/assets/home.js
@@ -145,20 +145,9 @@
     });
   }
 
-  function withTimeout(url, timeoutMs) {
-    var controller = new AbortController();
-    var timer = window.setTimeout(function () {
-      controller.abort();
-    }, timeoutMs);
-
-    return fetch(url, { cache: "no-store", signal: controller.signal })
-      .then(function (response) {
-        if (!response.ok) throw new Error("HTTP " + response.status + " for " + url);
-        return response.json();
-      })
-      .finally(function () {
-        clearTimeout(timer);
-      });
+  function fetchJsonWithTimeout(url, timeoutMs) {
+    if (typeof window.fetchJsonWithTimeout !== "function") return Promise.resolve(null);
+    return window.fetchJsonWithTimeout(url, { timeoutMs: timeoutMs });
   }
 
   function toNumber(value, fallback) {
@@ -190,8 +179,11 @@
   }
 
   function loadKpis() {
-    return withTimeout("/assets/verified-counts.json", KPI_TIMEOUT_MS)
+    return fetchJsonWithTimeout("/assets/verified-counts.json", KPI_TIMEOUT_MS)
       .then(function (payload) {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Missing verified counts payload");
+        }
         var counts = payload && payload.counts && typeof payload.counts === "object" ? payload.counts : {};
         var verifiedOn = payload && typeof payload.verified_on === "string" ? payload.verified_on : FALLBACK_COUNTS.verified_on;
         renderKpis(counts, verifiedOn);
@@ -296,8 +288,11 @@
   }
 
   function loadTagCoverage() {
-    withTimeout("/assets/data/detections.json", TAG_TIMEOUT_MS)
+    fetchJsonWithTimeout("/assets/data/detections.json", TAG_TIMEOUT_MS)
       .then(function (payload) {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Missing detections payload");
+        }
         var stats = collectTagStats(payload);
         if (!stats.length) {
           renderTagFallback("No tag data found in payload");

--- a/site/assets/portfolio-data.js
+++ b/site/assets/portfolio-data.js
@@ -4,12 +4,13 @@ import { initMediaGalleries } from "./components/sections/media-gallery.js";
 import { renderCoverageChart, renderDetectionsByTagChart, renderDetectionsByTagMiniChart } from "./components/sections/svg-charts.js";
 
 const jsonCache = new Map();
+const JSON_TIMEOUT_MS = 1500;
 
 async function loadJson(path) {
   if (jsonCache.has(path)) return jsonCache.get(path);
-  const res = await fetch(path, { cache: "no-store" });
-  if (!res.ok) throw new Error(`Failed to fetch ${path}`);
-  const payload = await res.json();
+  if (typeof window.fetchJsonWithTimeout !== "function") return null;
+  const payload = await window.fetchJsonWithTimeout(path, { timeoutMs: JSON_TIMEOUT_MS });
+  if (!payload || typeof payload !== "object") return null;
   jsonCache.set(path, payload);
   return payload;
 }
@@ -226,10 +227,10 @@ async function initProjectsPage() {
   const root = document.querySelector("[data-projects-root]");
   if (!root) return;
   const [data, mediaData] = await Promise.all([
-    loadJson("assets/data/projects.json"),
-    loadJson("assets/data/media.json")
+    loadJson("/assets/data/projects.json"),
+    loadJson("/assets/data/media.json")
   ]);
-  const projects = data.projects || [];
+  const projects = Array.isArray(data && data.projects) ? data.projects : [];
   bindFilters({
     sourceItems: projects,
     listingNode: root.querySelector("[data-listing]"),
@@ -238,17 +239,20 @@ async function initProjectsPage() {
     kind: "projects"
   });
   renderProjectProofCards(root.querySelector("[data-project-proof]"), projects);
-  renderProjectToolMarks(root.querySelector("[data-project-tools]"), mediaData.media || []);
+  renderProjectToolMarks(
+    root.querySelector("[data-project-tools]"),
+    Array.isArray(mediaData && mediaData.media) ? mediaData.media : []
+  );
 }
 
 async function initDetectionsPage() {
   const root = document.querySelector("[data-detections-root]");
   if (!root) return;
   const [data, verified] = await Promise.all([
-    loadJson("assets/data/detections.json"),
-    loadJson("assets/verified-counts.json").catch(() => null)
+    loadJson("/assets/data/detections.json"),
+    loadJson("/assets/verified-counts.json")
   ]);
-  const detections = data.detections || [];
+  const detections = Array.isArray(data && data.detections) ? data.detections : [];
   bindFilters({
     sourceItems: detections,
     listingNode: root.querySelector("[data-listing]"),
@@ -272,15 +276,21 @@ async function initHomeDashboard() {
   if (!coverageRoot && !tagRoot && !galleryRoot) return null;
 
   const [verified, detectionsData, mediaData] = await Promise.all([
-    loadJson("assets/verified-counts.json"),
-    loadJson("assets/data/detections.json"),
-    loadJson("assets/data/media.json")
+    loadJson("/assets/verified-counts.json"),
+    loadJson("/assets/data/detections.json"),
+    loadJson("/assets/data/media.json")
   ]);
 
-  if (coverageRoot) renderCoverageChart(coverageRoot, verified);
-  if (tagRoot) renderDetectionsByTagChart(tagRoot, detectionsData.detections || [], { limit: 10, idPrefix: "home-tag" });
+  if (coverageRoot) renderCoverageChart(coverageRoot, verified || {});
+  if (tagRoot) {
+    renderDetectionsByTagChart(
+      tagRoot,
+      Array.isArray(detectionsData && detectionsData.detections) ? detectionsData.detections : [],
+      { limit: 10, idPrefix: "home-tag" }
+    );
+  }
 
-  return Array.isArray(mediaData.media) ? mediaData.media : [];
+  return Array.isArray(mediaData && mediaData.media) ? mediaData.media : [];
 }
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="Migrating Legacy Detection Rules from Python 2 to Python 3">
 <meta name="twitter:description" content="Failure modes, migration workflow, and validation methods for SOC code in legacy-heavy environments.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
 <nav>
@@ -115,7 +115,8 @@
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="Case Study | Building + validating 29 Wazuh rule blocks">
 <meta name="twitter:description" content="Objective, test method, verification commands, evidence path, and next improvements.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
 <nav>
@@ -121,7 +121,8 @@ pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</pre>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/index.html
+++ b/site/index.html
@@ -260,6 +260,7 @@ pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</code></pre>
     <p class="copyright">© <span id="yearNow">2026</span> Raylee Hawkins</p>
   </div>
 </footer>
+<script src="/assets/fetch-utils.js" defer></script>
 <script src="/assets/home.js" defer></script>
 </body>
 </html>

--- a/site/lab.html
+++ b/site/lab.html
@@ -16,8 +16,8 @@
 <meta name="twitter:title" content="HawkinsOps | Home Lab">
 <meta name="twitter:description" content="Lab environment used to validate detections and incident response workflows.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <script>
   (function () {
     var saved = localStorage.getItem('rh-theme');
@@ -25,8 +25,8 @@
     document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
   })();
 </script>
-<link rel="stylesheet" href="assets/styles.css">
-<link rel="stylesheet" href="assets/design-system.css">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/design-system.css">
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -186,6 +186,7 @@
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>

--- a/site/projects.html
+++ b/site/projects.html
@@ -16,8 +16,8 @@
 <meta name="twitter:title" content="HawkinsOps | Raylee Hawkins | Projects">
 <meta name="twitter:description" content="Evidence-first project catalog with reproducible artifacts and verified-lane references tied to PROOF_PACK/VERIFIED_COUNTS.md.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <script>
   (function () {
     var saved = localStorage.getItem('rh-theme');
@@ -25,8 +25,8 @@
     document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
   })();
 </script>
-<link rel="stylesheet" href="assets/styles.css">
-<link rel="stylesheet" href="assets/design-system.css">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/design-system.css">
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -123,7 +123,8 @@
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
-<script type="module" src="assets/portfolio-data.js"></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
+<script type="module" src="/assets/portfolio-data.js"></script>
 </body>
 </html>

--- a/site/proof.html
+++ b/site/proof.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="HawkinsOps | Proof Pack">
 <meta name="twitter:description" content="Clone, run verification commands, and match counts to repository artifacts.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -150,7 +150,8 @@ pwsh -File .\scripts\build-wazuh-bundle.ps1</pre>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/resume.html
+++ b/site/resume.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="Raylee Hawkins | Resume">
 <meta name="twitter:description" content="SOC-track resume focused on detection engineering, reproducible proof, and lab validation.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 <style>
   .resume-shell{padding-top:110px}
   .resume-sheet{max-width:960px;margin:0 auto;background:var(--bg1);border:1px solid var(--bdr);border-radius:16px;padding:28px}
@@ -169,6 +169,7 @@
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>

--- a/site/security.html
+++ b/site/security.html
@@ -16,8 +16,8 @@
 <meta name="twitter:title" content="HawkinsOps | Raylee Hawkins | Security">
 <meta name="twitter:description" content="Verified detection and IR content with reproducible commands. Public counts align to PROOF_PACK/VERIFIED_COUNTS.md.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <script>
   (function () {
     var saved = localStorage.getItem('rh-theme');
@@ -25,8 +25,8 @@
     document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
   })();
 </script>
-<link rel="stylesheet" href="assets/styles.css">
-<link rel="stylesheet" href="assets/design-system.css">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/design-system.css">
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -165,7 +165,8 @@
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
-<script type="module" src="assets/portfolio-data.js"></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
+<script type="module" src="/assets/portfolio-data.js"></script>
 </body>
 </html>

--- a/site/triage.html
+++ b/site/triage.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="HawkinsOps | Triage Simulator">
 <meta name="twitter:description" content="SOC triage workflow practice with investigation pivots and evidence checklists.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -188,7 +188,8 @@ document.addEventListener('DOMContentLoaded', () => {
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary\n- normalize site HTML local asset references to root-absolute /assets/...\n- normalize JS data fetch URLs to /assets/... and /assets/data/...\n- add shared fetch timeout helper to prevent hanging loading states\n- add canonical slash redirects for /security/, /projects/, /lab/, /proof/\n- add diagnostic gate and production smoke scripts\n\n## Validation\n- node scripts/diagnose-site.js --fail-on-issues\n- pwsh -NoProfile -File scripts/smoke-production.ps1 (17/17 pass on network-enabled host)