### PR TITLE
fix: homepage visual hotfix and interaction hardening

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7,10 +7,24 @@
   const $ = (sel, root=document) => root.querySelector(sel);
   const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
   const html = document.documentElement;
+  function readThemePreference() {
+    try {
+      return localStorage.getItem('rh-theme');
+    } catch {
+      return null;
+    }
+  }
+  function writeThemePreference(value) {
+    try {
+      localStorage.setItem('rh-theme', value);
+    } catch {
+      // ignore persistence errors in locked-down browser modes
+    }
+  }
 
   // Theme toggle (saved preference, otherwise system preference)
   const themeToggle = $('#themeToggle');
-  const savedTheme = localStorage.getItem('rh-theme');
+  const savedTheme = readThemePreference();
   const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const startTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
   html.setAttribute('data-theme', startTheme);
@@ -27,7 +41,7 @@
       const current = html.getAttribute('data-theme') || 'dark';
       const next = current === 'dark' ? 'light' : 'dark';
       html.setAttribute('data-theme', next);
-      localStorage.setItem('rh-theme', next);
+      writeThemePreference(next);
       updateThemeButton(next);
     });
   }

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -68,13 +68,13 @@ html[data-theme="light"] body.home-page {
   width: 100%;
   height: 100%;
   pointer-events: none;
-  opacity: 0.45;
-  filter: blur(0.6px);
+  opacity: 0.2;
+  filter: blur(1px);
   z-index: -2;
 }
 
 html[data-theme="light"] .neural-bg {
-  opacity: 0.34;
+  opacity: 0.16;
 }
 
 .bg-vignette {

--- a/site/assets/home.js
+++ b/site/assets/home.js
@@ -357,7 +357,7 @@
 
     function drawFrame(staticOnly) {
       var rgb = themeRgb();
-      var edge = 158;
+      var edge = 112;
 
       ctx.clearRect(0, 0, width, height);
 
@@ -381,7 +381,8 @@
           var dy = na.y - nb.y;
           var dist = Math.sqrt(dx * dx + dy * dy);
           if (dist > edge) continue;
-          var alpha = (1 - dist / edge) * 0.16;
+          if ((a + b) % 5 !== 0) continue;
+          var alpha = (1 - dist / edge) * 0.045;
           ctx.strokeStyle = "rgba(" + rgb + ", " + alpha.toFixed(3) + ")";
           ctx.lineWidth = 1;
           ctx.beginPath();
@@ -393,7 +394,7 @@
 
       for (var j = 0; j < nodes.length; j += 1) {
         var node = nodes[j];
-        ctx.fillStyle = "rgba(" + rgb + ", 0.44)";
+        ctx.fillStyle = "rgba(" + rgb + ", 0.22)";
         ctx.beginPath();
         ctx.arc(node.x, node.y, node.size, 0, Math.PI * 2);
         ctx.fill();

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -62,7 +62,7 @@
         }
         html{scroll-behavior:smooth}
         body{font-family:var(--sans);background:var(--page-bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-        body::before{content:'';position:fixed;inset:0;background:linear-gradient(var(--grid-line) 1px,transparent 1px),linear-gradient(90deg,var(--grid-line) 1px,transparent 1px);background-size:64px 64px;pointer-events:none;z-index:0}
+        body::before{content:none}
         body::after{
             content:'';
             position:fixed;

--- a/site/lab.html
+++ b/site/lab.html
@@ -20,7 +20,12 @@
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <script>
   (function () {
-    var saved = localStorage.getItem('rh-theme');
+    var saved = null;
+    try {
+      saved = localStorage.getItem('rh-theme');
+    } catch (err) {
+      saved = null;
+    }
     var sysDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
   })();

--- a/site/projects.html
+++ b/site/projects.html
@@ -20,7 +20,12 @@
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <script>
   (function () {
-    var saved = localStorage.getItem('rh-theme');
+    var saved = null;
+    try {
+      saved = localStorage.getItem('rh-theme');
+    } catch (err) {
+      saved = null;
+    }
     var sysDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
   })();

--- a/site/security.html
+++ b/site/security.html
@@ -20,7 +20,12 @@
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <script>
   (function () {
-    var saved = localStorage.getItem('rh-theme');
+    var saved = null;
+    try {
+      saved = localStorage.getItem('rh-theme');
+    } catch (err) {
+      saved = null;
+    }
     var sysDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
   })();


### PR DESCRIPTION
## Why\nFollow-up to merged PR #37. This hotfix addresses reported visual regression and clickability concerns.\n\n## Changes\n- remove non-home grid overlay (styles.css body::before)\n- reduce homepage background mesh intensity and opacity (home.js, home.css)\n- harden theme preference reads/writes against storage-restricted browsers (pp.js)\n- harden inline theme bootstrap on security.html, projects.html, lab.html\n\n## Validation\n- node scripts/verify/no-netlify.js\n- node scripts/diagnose-site.js --fail-on-issues