### PR TITLE
feat: apply no-pink theme patch to deployed site output

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -16,9 +16,9 @@
 <meta name="twitter:title" content="HawkinsOps | Page not found">
 <meta name="twitter:description" content="The requested page was not found. Return to verified portfolio pages.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+<link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
 <section style="padding-top:110px">

--- a/site/README_DEPLOY.md
+++ b/site/README_DEPLOY.md
@@ -13,13 +13,11 @@ If you only upload `index.html`, the resume PDF and styling will 404 (because ho
 
 ## Hosting strategy
 - Primary production hosting: **Cloudflare Pages**
-- Rollback hosting: **Netlify** (rollback-only, previews disabled to reduce credit burn)
-- Publish directory for both hosts: `site/`
+- Publish directory: `site/`
 
 ## Update counts
 Counts are sourced from your repo releases / verification artifacts:
-- `raylee-ops/HawkinsOperations`
+- `raylee-hawkins/HawkinsOperations`
 - Local verification script: `scripts/verify/verify-counts.ps1`
 
 When counts change, update the numbers on `index.html`, `security.html`, and `proof.html` (search for the digits).
-

--- a/site/assets/badges/automation.svg
+++ b/site/assets/badges/automation.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Automation icon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="20" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="44" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="32" cy="44" r="7" fill="#ff3ea5"/>
-  <path d="M25 24l5 12M39 24l-5 12" stroke="#ff3ea5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="44" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="32" cy="44" r="7" fill="#b89cff"/>
+  <path d="M25 24l5 12M39 24l-5 12" stroke="#b89cff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/site/assets/badges/sigma.svg
+++ b/site/assets/badges/sigma.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sigma logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#ff8fcb"/>
+  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#7ab8ff"/>
 </svg>

--- a/site/assets/badges/splunk.svg
+++ b/site/assets/badges/splunk.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Splunk logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="18" cy="32" r="4" fill="#ff8fcb"/>
-  <path d="M24 44L40 20h10L34 44z" fill="#ff3ea5"/>
+  <circle cx="18" cy="32" r="4" fill="#7ab8ff"/>
+  <path d="M24 44L40 20h10L34 44z" fill="#b89cff"/>
 </svg>

--- a/site/assets/badges/wazuh.svg
+++ b/site/assets/badges/wazuh.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Wazuh logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#ff8fcb"/>
-  <path d="M20 50h24v4H20z" fill="#ff3ea5"/>
+  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#7ab8ff"/>
+  <path d="M20 50h24v4H20z" fill="#b89cff"/>
 </svg>

--- a/site/assets/favicon.svg
+++ b/site/assets/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HawkinsOps favicon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h8v14h16V16h8v32h-8V38H24v10h-8z" fill="#ff8fcb"/>
-  <circle cx="50" cy="50" r="5" fill="#ff3ea5"/>
+  <path d="M16 16h8v14h16V16h8v32h-8V38H24v10h-8z" fill="#7ab8ff"/>
+  <circle cx="50" cy="50" r="5" fill="#b89cff"/>
 </svg>

--- a/site/assets/logos/automation.svg
+++ b/site/assets/logos/automation.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Automation icon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="20" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="44" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="32" cy="44" r="7" fill="#ff3ea5"/>
-  <path d="M25 24l5 12M39 24l-5 12" stroke="#ff3ea5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="44" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="32" cy="44" r="7" fill="#b89cff"/>
+  <path d="M25 24l5 12M39 24l-5 12" stroke="#b89cff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/site/assets/logos/sigma.svg
+++ b/site/assets/logos/sigma.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sigma logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#ff8fcb"/>
+  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#7ab8ff"/>
 </svg>

--- a/site/assets/logos/splunk.svg
+++ b/site/assets/logos/splunk.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Splunk logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="18" cy="32" r="4" fill="#ff8fcb"/>
-  <path d="M24 44L40 20h10L34 44z" fill="#ff3ea5"/>
+  <circle cx="18" cy="32" r="4" fill="#7ab8ff"/>
+  <path d="M24 44L40 20h10L34 44z" fill="#b89cff"/>
 </svg>

--- a/site/assets/logos/wazuh.svg
+++ b/site/assets/logos/wazuh.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Wazuh logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#ff8fcb"/>
-  <path d="M20 50h24v4H20z" fill="#ff3ea5"/>
+  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#7ab8ff"/>
+  <path d="M20 50h24v4H20z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/assets-badges-automation-36aa2147ed.svg
+++ b/site/assets/media/assets-badges-automation-36aa2147ed.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Automation icon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="20" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="44" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="32" cy="44" r="7" fill="#ff3ea5"/>
-  <path d="M25 24l5 12M39 24l-5 12" stroke="#ff3ea5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="44" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="32" cy="44" r="7" fill="#b89cff"/>
+  <path d="M25 24l5 12M39 24l-5 12" stroke="#b89cff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/site/assets/media/assets-badges-sigma-a00fcaf8d4.svg
+++ b/site/assets/media/assets-badges-sigma-a00fcaf8d4.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sigma logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#ff8fcb"/>
+  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#7ab8ff"/>
 </svg>

--- a/site/assets/media/assets-badges-splunk-3040c8f48f.svg
+++ b/site/assets/media/assets-badges-splunk-3040c8f48f.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Splunk logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="18" cy="32" r="4" fill="#ff8fcb"/>
-  <path d="M24 44L40 20h10L34 44z" fill="#ff3ea5"/>
+  <circle cx="18" cy="32" r="4" fill="#7ab8ff"/>
+  <path d="M24 44L40 20h10L34 44z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/assets-badges-wazuh-a9baecedc0.svg
+++ b/site/assets/media/assets-badges-wazuh-a9baecedc0.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Wazuh logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#ff8fcb"/>
-  <path d="M20 50h24v4H20z" fill="#ff3ea5"/>
+  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#7ab8ff"/>
+  <path d="M20 50h24v4H20z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/assets-logos-automation-85a1e87692.svg
+++ b/site/assets/media/assets-logos-automation-85a1e87692.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Automation icon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="20" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="44" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="32" cy="44" r="7" fill="#ff3ea5"/>
-  <path d="M25 24l5 12M39 24l-5 12" stroke="#ff3ea5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="44" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="32" cy="44" r="7" fill="#b89cff"/>
+  <path d="M25 24l5 12M39 24l-5 12" stroke="#b89cff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/site/assets/media/assets-logos-sigma-7b3d17f300.svg
+++ b/site/assets/media/assets-logos-sigma-7b3d17f300.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sigma logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#ff8fcb"/>
+  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#7ab8ff"/>
 </svg>

--- a/site/assets/media/assets-logos-splunk-1df11b14bf.svg
+++ b/site/assets/media/assets-logos-splunk-1df11b14bf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Splunk logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="18" cy="32" r="4" fill="#ff8fcb"/>
-  <path d="M24 44L40 20h10L34 44z" fill="#ff3ea5"/>
+  <circle cx="18" cy="32" r="4" fill="#7ab8ff"/>
+  <path d="M24 44L40 20h10L34 44z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/assets-logos-wazuh-11e7cf3bd9.svg
+++ b/site/assets/media/assets-logos-wazuh-11e7cf3bd9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Wazuh logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#ff8fcb"/>
-  <path d="M20 50h24v4H20z" fill="#ff3ea5"/>
+  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#7ab8ff"/>
+  <path d="M20 50h24v4H20z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/site-assets-badges-automation.svg
+++ b/site/assets/media/site-assets-badges-automation.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Automation icon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="20" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="44" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="32" cy="44" r="7" fill="#ff3ea5"/>
-  <path d="M25 24l5 12M39 24l-5 12" stroke="#ff3ea5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="44" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="32" cy="44" r="7" fill="#b89cff"/>
+  <path d="M25 24l5 12M39 24l-5 12" stroke="#b89cff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/site/assets/media/site-assets-badges-sigma.svg
+++ b/site/assets/media/site-assets-badges-sigma.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sigma logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#ff8fcb"/>
+  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#7ab8ff"/>
 </svg>

--- a/site/assets/media/site-assets-badges-splunk.svg
+++ b/site/assets/media/site-assets-badges-splunk.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Splunk logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="18" cy="32" r="4" fill="#ff8fcb"/>
-  <path d="M24 44L40 20h10L34 44z" fill="#ff3ea5"/>
+  <circle cx="18" cy="32" r="4" fill="#7ab8ff"/>
+  <path d="M24 44L40 20h10L34 44z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/site-assets-badges-wazuh.svg
+++ b/site/assets/media/site-assets-badges-wazuh.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Wazuh logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#ff8fcb"/>
-  <path d="M20 50h24v4H20z" fill="#ff3ea5"/>
+  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#7ab8ff"/>
+  <path d="M20 50h24v4H20z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/site-assets-favicon-2641013eae.svg
+++ b/site/assets/media/site-assets-favicon-2641013eae.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HawkinsOps favicon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h8v14h16V16h8v32h-8V38H24v10h-8z" fill="#ff8fcb"/>
-  <circle cx="50" cy="50" r="5" fill="#ff3ea5"/>
+  <path d="M16 16h8v14h16V16h8v32h-8V38H24v10h-8z" fill="#7ab8ff"/>
+  <circle cx="50" cy="50" r="5" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/site-assets-favicon.svg
+++ b/site/assets/media/site-assets-favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HawkinsOps favicon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h8v14h16V16h8v32h-8V38H24v10h-8z" fill="#ff8fcb"/>
-  <circle cx="50" cy="50" r="5" fill="#ff3ea5"/>
+  <path d="M16 16h8v14h16V16h8v32h-8V38H24v10h-8z" fill="#7ab8ff"/>
+  <circle cx="50" cy="50" r="5" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/site-assets-logos-automation.svg
+++ b/site/assets/media/site-assets-logos-automation.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Automation icon">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="20" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="44" cy="20" r="7" fill="#ff8fcb"/>
-  <circle cx="32" cy="44" r="7" fill="#ff3ea5"/>
-  <path d="M25 24l5 12M39 24l-5 12" stroke="#ff3ea5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="44" cy="20" r="7" fill="#7ab8ff"/>
+  <circle cx="32" cy="44" r="7" fill="#b89cff"/>
+  <path d="M25 24l5 12M39 24l-5 12" stroke="#b89cff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/site/assets/media/site-assets-logos-sigma.svg
+++ b/site/assets/media/site-assets-logos-sigma.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sigma logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#ff8fcb"/>
+  <path d="M16 16h32v8H28l16 16-16 16h20v8H16v-8l18-16-18-16z" fill="#7ab8ff"/>
 </svg>

--- a/site/assets/media/site-assets-logos-splunk.svg
+++ b/site/assets/media/site-assets-logos-splunk.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Splunk logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <circle cx="18" cy="32" r="4" fill="#ff8fcb"/>
-  <path d="M24 44L40 20h10L34 44z" fill="#ff3ea5"/>
+  <circle cx="18" cy="32" r="4" fill="#7ab8ff"/>
+  <path d="M24 44L40 20h10L34 44z" fill="#b89cff"/>
 </svg>

--- a/site/assets/media/site-assets-logos-wazuh.svg
+++ b/site/assets/media/site-assets-logos-wazuh.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Wazuh logo">
   <rect width="64" height="64" rx="12" fill="#0f1220"/>
-  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#ff8fcb"/>
-  <path d="M20 50h24v4H20z" fill="#ff3ea5"/>
+  <path d="M10 14h10l12 23 12-23h10L40 50h-8z" fill="#7ab8ff"/>
+  <path d="M20 50h24v4H20z" fill="#b89cff"/>
 </svg>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -4,27 +4,27 @@
             --bg:#090b13;--bg1:#151a2b;--bg2:#1b2236;--bg3:#24304a;
             --bdr:#344262;--bdr2:#4a5e89;
             --txt:#f7f9ff;--dim:#d7e0f4;--faint:#acbbdc;
-            --acc:#ff9ecd;--acc2:#ffd1dc;--acc-d:rgba(255,158,205,.14);--acc-g:rgba(255,158,205,.24);
+            --acc:#7ab8ff;--acc2:#b8e3ff;--vio:#b89cff;--acc-rgb:122,184,255;--acc2-rgb:184,227,255;--vio-rgb:184,156,255;--acc-d:rgba(var(--acc-rgb),.14);--acc-g:rgba(var(--acc-rgb),.24);
             --red:#ff3b5c;--red-d:rgba(255,59,92,.1);
             --amb:#ffb020;--amb-d:rgba(255,176,32,.1);
-            --blu:#3b82f6;--pur:#a78bfa;
+            --blu:#7ab8ff;--pur:#b89cff;
             --mono:'JetBrains Mono','IBM Plex Mono','Consolas',monospace;
             --sans:'Space Grotesk','Segoe UI',sans-serif;
-            --page-bg:radial-gradient(980px 440px at 90% -10%,rgba(255,158,205,.16),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(123,153,255,.12),transparent 72%),linear-gradient(180deg,#090d17 0%, #0b1020 50%, #0c1324 100%);
+            --page-bg:radial-gradient(980px 440px at 90% -10%,rgba(var(--acc-rgb),.14),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(var(--vio-rgb),.10),transparent 72%),linear-gradient(180deg,#070a12 0%, #090f1f 50%, #0a1326 100%);
             --grid-line:rgba(255,255,255,.012);
             --link:var(--acc2);--link-hover:var(--acc);
             --nav-bg:rgba(8,12,20,.88);
-            --nav-hover-bg:rgba(255,62,165,.08);
-            --nav-active-bg:rgba(255,62,165,.18);
-            --nav-active-border:rgba(255,62,165,.4);
-            --nav-active-shadow:inset 0 -1px 0 rgba(255,143,203,.5);
+            --nav-hover-bg:rgba(var(--acc-rgb),.08);
+            --nav-active-bg:rgba(var(--acc-rgb),.18);
+            --nav-active-border:rgba(var(--acc-rgb),.40);
+            --nav-active-shadow:inset 0 -1px 0 rgba(var(--acc2-rgb),.52);
             --heading:var(--acc);
             --panel-bg:linear-gradient(145deg,rgba(23,28,43,.86),rgba(28,35,54,.93));
-            --panel-shadow:0 16px 34px rgba(255,158,205,.16),inset 0 1px 0 rgba(255,255,255,.06);
+            --panel-shadow:0 16px 34px rgba(var(--acc-rgb),.16),inset 0 1px 0 rgba(255,255,255,.06);
             --term-bg:#0a0e14;--term-head:#0f1319;--term-txt:#e1e7f4;
             --overlay-bg:rgba(6,8,12,.92);
             --hero-mark:rgba(240,246,255,.28);
-            --hero-mark-opacity:.5;
+            --hero-mark-opacity:.5;--stars-o:.46;
         }
         html[data-theme="dark"]{
             --bg:#090b13;--bg1:#151a2b;--bg2:#1b2236;--bg3:#24304a;
@@ -40,30 +40,59 @@
             --bg:#f6f8fc;--bg1:#ffffff;--bg2:#f2f5fb;--bg3:#e9eef7;
             --bdr:#ccd6ea;--bdr2:#b8c5df;
             --txt:#1f2735;--dim:#3b465a;--faint:#5f6b83;
-            --acc:#d63f8c;--acc2:#b91f71;--acc-d:rgba(214,63,140,.12);--acc-g:rgba(214,63,140,.2);
+            --acc:#1f6ea8;--acc2:#7ab8ff;--vio:#6f5bd6;--acc-rgb:31,110,168;--acc2-rgb:122,184,255;--vio-rgb:111,91,214;--acc-d:rgba(var(--acc-rgb),.10);--acc-g:rgba(var(--acc-rgb),.16);
             --red:#c62849;--red-d:rgba(198,40,73,.1);
             --amb:#b77000;--amb-d:rgba(183,112,0,.1);
-            --blu:#255ec7;--pur:#7a5ad3;
-            --page-bg:radial-gradient(980px 440px at 90% -10%,rgba(214,63,140,.12),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(37,94,199,.1),transparent 72%),linear-gradient(180deg,#f9fbff 0%, #f2f6fd 50%, #ecf2fb 100%);
+            --blu:#1f6ea8;--pur:#6f5bd6;
+            --page-bg:radial-gradient(980px 440px at 90% -10%,rgba(var(--acc2-rgb),.10),transparent 72%),radial-gradient(840px 420px at -20% 115%,rgba(var(--vio-rgb),.08),transparent 72%),linear-gradient(180deg,#fbfdff 0%, #f3f7ff 50%, #eef3ff 100%);
             --grid-line:rgba(31,39,53,.035);
-            --link:#7c1f57;--link-hover:#a32772;
+            --link:#1f6ea8;--link-hover:#7ab8ff;
             --nav-bg:rgba(245,248,254,.88);
-            --nav-hover-bg:rgba(214,63,140,.1);
-            --nav-active-bg:rgba(214,63,140,.18);
-            --nav-active-border:rgba(214,63,140,.35);
-            --nav-active-shadow:inset 0 -1px 0 rgba(214,63,140,.45);
-            --heading:#c52f80;
+            --nav-hover-bg:rgba(var(--acc-rgb),.10);
+            --nav-active-bg:rgba(var(--acc-rgb),.18);
+            --nav-active-border:rgba(var(--acc-rgb),.32);
+            --nav-active-shadow:inset 0 -1px 0 rgba(var(--acc2-rgb),.40);
+            --heading:var(--acc);
             --panel-bg:linear-gradient(145deg,rgba(255,255,255,.9),rgba(242,245,251,.95));
             --panel-shadow:0 12px 28px rgba(39,57,94,.08),inset 0 1px 0 rgba(255,255,255,.9);
             --term-bg:#f7f9fe;--term-head:#edf2fb;--term-txt:#1f2735;
             --overlay-bg:rgba(30,40,58,.46);
             --hero-mark:rgba(31,39,53,.26);
-            --hero-mark-opacity:.5;
+            --hero-mark-opacity:.5;--stars-o:.10;
         }
         html{scroll-behavior:smooth}
         body{font-family:var(--sans);background:var(--page-bg);color:var(--txt);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
         body::before{content:'';position:fixed;inset:0;background:linear-gradient(var(--grid-line) 1px,transparent 1px),linear-gradient(90deg,var(--grid-line) 1px,transparent 1px);background-size:64px 64px;pointer-events:none;z-index:0}
+        body::after{
+            content:'';
+            position:fixed;
+            inset:0;
+            pointer-events:none;
+            z-index:0;
+            opacity:var(--stars-o, .42);
+            background:
+              radial-gradient(rgba(255,255,255,.10) 1px, transparent 1px) 0 0/260px 260px,
+              radial-gradient(rgba(255,255,255,.06) 1px, transparent 1px) 40px 60px/340px 340px,
+              radial-gradient(rgba(255,255,255,.04) 1px, transparent 1px) 20px 80px/480px 480px,
+              radial-gradient(1100px 520px at 18% 22%, rgba(var(--acc-rgb), .10), transparent 70%),
+              radial-gradient(900px 520px at 92% 12%, rgba(var(--vio-rgb), .08), transparent 72%),
+              linear-gradient(180deg, rgba(255,255,255,.06) 0%, transparent 28%, rgba(255,255,255,.03) 62%, transparent 100%);
+            mix-blend-mode:screen;
+        }
+
         .ctr{max-width:1200px;margin:0 auto;padding:0 24px;position:relative;z-index:1}
+        .ctr::before,.ctr::after{
+            content:'';
+            position:absolute;
+            top:0;bottom:0;
+            width:1px;
+            pointer-events:none;
+            opacity:.55;
+            background:linear-gradient(180deg,transparent 0%,rgba(255,255,255,.06) 12%,rgba(255,255,255,.06) 88%,transparent 100%);
+        }
+        .ctr::before{left:12px}
+        .ctr::after{right:12px}
+
         a{color:var(--link);text-underline-offset:3px;text-decoration-thickness:1px}
         a:hover{color:var(--link-hover)}
         a:focus-visible,button:focus-visible,.btn:focus-visible,.mob-btn:focus-visible{
@@ -82,11 +111,11 @@
         .nav-l a.act,.nav-l a[aria-current='page']{color:var(--txt);background:var(--nav-active-bg);border-color:var(--nav-active-border);box-shadow:var(--nav-active-shadow)}
         .mob-btn{display:none;background:none;border:1px solid var(--bdr);color:var(--txt);padding:6px 10px;font-family:var(--mono);font-size:.72rem;cursor:pointer}
         .theme-btn{background:var(--bg2);color:var(--txt);border:1px solid var(--bdr2);padding:7px 10px;border-radius:999px;font-family:var(--mono);font-size:.68rem;cursor:pointer;transition:all .2s}
-        .theme-btn:hover{border-color:#ff9ecd;box-shadow:0 0 0 3px rgba(255,158,205,.15)}
+        .theme-btn:hover{border-color:#7ab8ff;box-shadow:0 0 0 3px rgba(var(--acc-rgb),.15)}
 
         /* HERO */
         .hero{min-height:88vh;display:flex;align-items:center;padding-top:74px;position:relative;overflow:hidden}
-        .hero-glow{position:absolute;width:360px;height:360px;border-radius:50%;background:radial-gradient(circle,rgba(255,158,205,.22) 0%,transparent 70%);top:-70px;right:-80px;pointer-events:none;animation:gp 8s ease-in-out infinite}
+        .hero-glow{position:absolute;width:360px;height:360px;border-radius:50%;background:radial-gradient(circle,rgba(var(--acc-rgb),.22) 0%,transparent 70%);top:-70px;right:-80px;pointer-events:none;animation:gp 8s ease-in-out infinite}
         @keyframes gp{0%,100%{opacity:.4;transform:scale(1)}50%{opacity:.65;transform:scale(1.06)}}
         .particles{position:absolute;inset:0;overflow:hidden;pointer-events:none}
         .particle{position:absolute;background:var(--acc);border-radius:50%;opacity:.2;animation:fu linear infinite}
@@ -110,14 +139,14 @@
         .hctas{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px}
         .btn{display:inline-flex;align-items:center;gap:6px;padding:12px 22px;font-family:var(--mono);font-size:.78rem;font-weight:600;text-decoration:none;border:none;cursor:pointer;transition:all .25s;letter-spacing:.02em}
         .btn-p{background:var(--acc);color:var(--bg)}
-        .btn-p:hover{box-shadow:0 0 0 3px rgba(255,158,205,.14),0 10px 18px rgba(255,158,205,.2);transform:translateY(-2px)}
+        .btn-p:hover{box-shadow:0 0 0 3px rgba(var(--acc-rgb),.14),0 10px 18px rgba(var(--acc-rgb),.20);transform:translateY(-2px)}
         .btn-g{background:transparent;color:var(--txt);border:1px solid var(--bdr2)}
         .btn-g:hover{border-color:var(--acc);color:var(--acc)}
         .roles{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:18px}
         .rtag{font-family:var(--mono);font-size:.65rem;padding:4px 10px;border:1px solid var(--bdr);color:var(--dim);background:var(--bg1)}
         .rtag.on{border-color:var(--acc);color:var(--acc);background:var(--acc-d)}
         .status-r{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
-        .sbadge{display:inline-flex;align-items:center;gap:7px;padding:5px 12px;background:var(--acc-d);border:1px solid rgba(255,62,165,.25);font-family:var(--mono);font-size:.68rem;color:var(--acc)}
+        .sbadge{display:inline-flex;align-items:center;gap:7px;padding:5px 12px;background:var(--acc-d);border:1px solid rgba(var(--acc-rgb),.25);font-family:var(--mono);font-size:.68rem;color:var(--acc)}
         .sdot{width:5px;height:5px;border-radius:50%;background:var(--acc);animation:bl 2s infinite}
         @keyframes bl{0%,100%{opacity:1}50%{opacity:.3}}
         .lupd{font-family:var(--mono);font-size:.65rem;color:var(--faint)}
@@ -140,13 +169,13 @@
         .card{background:var(--bg2);border:1px solid var(--bdr);padding:24px;transition:all .24s ease;cursor:pointer;position:relative;color:var(--txt);border-radius:16px}
         .writing-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px}
         .writing-grid .card{display:block;position:relative;overflow:hidden}
-        .card:hover{border-color:var(--acc);transform:translateY(-2px);box-shadow:0 10px 26px rgba(255,62,165,.14)}
+        .card:hover{border-color:var(--acc);transform:translateY(-2px);box-shadow:0 10px 26px rgba(var(--acc-rgb),.14)}
         .card-click{position:absolute;top:10px;right:12px;font-family:var(--mono);font-size:.6rem;color:var(--faint);opacity:0;transition:opacity .2s}
         .card:hover .card-click{opacity:1}
         .tools-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
         .tool-badge{display:flex;align-items:center;gap:10px;padding:12px 14px;border:1px solid var(--bdr);background:linear-gradient(145deg,rgba(29,34,54,.88),rgba(24,30,48,.92));border-radius:14px;transition:transform .22s ease,border-color .22s ease,box-shadow .22s ease}
-        .tool-badge:hover{border-color:var(--acc);transform:translateY(-1px);box-shadow:0 8px 16px rgba(255,158,205,.12)}
-        .tool-glyph{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:8px;background:rgba(255,158,205,.2);color:var(--acc);font-family:var(--mono);font-size:.62rem;font-weight:700;letter-spacing:.02em;flex:0 0 28px}
+        .tool-badge:hover{border-color:var(--acc);transform:translateY(-1px);box-shadow:0 8px 16px rgba(var(--acc-rgb),.12)}
+        .tool-glyph{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:8px;background:rgba(var(--acc-rgb),.20);color:var(--acc);font-family:var(--mono);font-size:.62rem;font-weight:700;letter-spacing:.02em;flex:0 0 28px}
         .tool-badge b{font-size:.82rem}
         .tool-badge span{display:block;color:var(--dim);font-size:.72rem}
 
@@ -172,7 +201,7 @@
         /* PLATFORM */
         .plat-icon{width:40px;height:40px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:.68rem;font-weight:700;margin-bottom:14px}
         .plat-icon.sigma{background:var(--red-d);color:var(--red);border:1px solid rgba(255,59,92,.2)}
-        .plat-icon.wazuh{background:var(--acc-d);color:var(--acc);border:1px solid rgba(255,62,165,.25)}
+        .plat-icon.wazuh{background:var(--acc-d);color:var(--acc);border:1px solid rgba(var(--acc-rgb),.25)}
         .plat-icon.splunk{background:var(--amb-d);color:var(--amb);border:1px solid rgba(255,176,32,.2)}
         .plat-ct{font-family:var(--mono);font-size:2rem;font-weight:700;line-height:1;margin-bottom:2px}
         .plat-nm{font-size:1rem;font-weight:600;margin-bottom:4px}
@@ -211,7 +240,7 @@
         .tl::before{content:'';position:absolute;left:11px;top:0;bottom:0;width:1px;background:var(--bdr)}
         .tli{position:relative;margin-bottom:32px}
         .tld{position:absolute;left:-27px;top:3px;width:9px;height:9px;border-radius:50%;border:2px solid var(--acc);background:var(--bg)}
-        .tli.on .tld{background:var(--acc);box-shadow:0 0 8px rgba(255,62,165,.4)}
+        .tli.on .tld{background:var(--acc);box-shadow:0 0 8px rgba(var(--acc-rgb),.40)}
         .tl-dt{font-family:var(--mono);font-size:.68rem;color:var(--acc);margin-bottom:3px}
         .tl-tt{font-size:.95rem;font-weight:600;margin-bottom:3px}
         .tl-ds{font-size:.82rem;color:var(--dim);line-height:1.5}
@@ -260,7 +289,7 @@
 
         /* FEAT BADGE */
         .fbadge{font-family:var(--mono);font-size:.6rem;padding:3px 7px;display:inline-block;margin-bottom:10px;text-transform:uppercase;letter-spacing:.04em}
-        .fbadge.live{background:var(--acc-d);color:var(--acc);border:1px solid rgba(255,62,165,.24)}
+        .fbadge.live{background:var(--acc-d);color:var(--acc);border:1px solid rgba(var(--acc-rgb),.24)}
         .fbadge.done{background:rgba(59,130,246,.1);color:var(--blu);border:1px solid rgba(59,130,246,.2)}
         .fbadge.exp{background:rgba(167,139,250,.1);color:var(--pur);border:1px solid rgba(167,139,250,.2)}
         .fstat{font-family:var(--mono);font-size:.7rem;color:var(--faint)}
@@ -319,7 +348,7 @@
   cursor:pointer;
   border-radius:12px;
 }
-.modal-x:hover{border-color:rgba(255,62,165,.35);color:var(--acc)}
+.modal-x:hover{border-color:rgba(var(--acc-rgb),.35);color:var(--acc)}
 .mob-menu{
   display:none;
   position:fixed;
@@ -338,10 +367,10 @@
   color:var(--dim);
   text-decoration:none;
 }
-.mob-menu a:hover{color:var(--acc);background:rgba(255,62,165,.08)}
+.mob-menu a:hover{color:var(--acc);background:rgba(var(--acc-rgb),.08)}
 .mob-menu a.act,.mob-menu a[aria-current='page']{
   color:var(--txt);
-  background:rgba(255,62,165,.2);
+  background:rgba(var(--acc-rgb),.20);
   border-left:3px solid var(--acc);
   padding-left:21px;
 }

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="Migrating Legacy Detection Rules from Python 2 to Python 3">
 <meta name="twitter:description" content="Failure modes, migration workflow, and validation methods for SOC code in legacy-heavy environments.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
 <nav>
@@ -109,13 +109,14 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="Case Study | Building + validating 29 Wazuh rule blocks">
 <meta name="twitter:description" content="Objective, test method, verification commands, evidence path, and next improvements.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
 <nav>
@@ -115,13 +115,14 @@ pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/index.html
+++ b/site/index.html
@@ -16,8 +16,8 @@
 <meta name="twitter:title" content="HawkinsOps | Raylee Hawkins | Home">
 <meta name="twitter:description" content="Evidence-first SOC portfolio with verified, reproducible security artifacts. Public counts align to PROOF_PACK/VERIFIED_COUNTS.md.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
@@ -28,7 +28,7 @@
       document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
     })();
   </script>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -94,13 +94,13 @@
     </div>
 
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">Clone the repo</a>
+      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">Clone the repo</a>
       <a class="btn btn-g" href="proof.html">See the proof pack</a>
       <a class="btn btn-g" href="mailto:raylee@hawkinsops.com">Email me</a>
     </div>
 
     <div class="sbadge"><span class="sdot"></span> Huntsville-adjacent • North Alabama</div>
-    <div class="lupd">Counts and links align to <code>raylee-ops/HawkinsOperations</code> (verified, reproducible today).</div>
+    <div class="lupd">Counts and links align to <code>raylee-hawkins/HawkinsOperations</code> (verified, reproducible today).</div>
   </div>
 </header>
 
@@ -267,12 +267,13 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>

--- a/site/lab.html
+++ b/site/lab.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="HawkinsOps | Home Lab">
 <meta name="twitter:description" content="Lab environment used to validate detections and incident response workflows.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -128,13 +128,14 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/projects.html
+++ b/site/projects.html
@@ -16,8 +16,8 @@
 <meta name="twitter:title" content="HawkinsOps | Raylee Hawkins | Projects">
 <meta name="twitter:description" content="Evidence-first project catalog with reproducible artifacts and verified-lane references tied to PROOF_PACK/VERIFIED_COUNTS.md.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
@@ -28,7 +28,7 @@
       document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
     })();
   </script>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -69,19 +69,19 @@
     <div class="lupd" style="margin-bottom:14px">Verify lane: <code>pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</code> and <code>pwsh -NoProfile -File .\scripts\verify\generate-verified-counts.ps1 -OutFile .\PROOF_PACK\VERIFIED_COUNTS.md</code>.</div>
 
     <div class="g3">
-      <a class="card" href="https://github.com/raylee-ops/HawkinsOperations/tree/main/projects" target="_blank" rel="noreferrer" style="text-decoration:none">
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/projects" target="_blank" rel="noreferrer" style="text-decoration:none">
         <div class="card-click">Open →</div>
         <div class="card-ttl">Migration Project Folder</div>
         <div class="card-sub">RH_MIGRATION_2026_V2 artifacts and runbooks inside this repo.</div>
         <div class="card-meta"><span class="tag">projects/</span><span class="tag">Subfolder CTA</span></div>
       </a>
-      <a class="card" href="https://github.com/raylee-ops/HawkinsOperations/tree/main/detection-rules" target="_blank" rel="noreferrer" style="text-decoration:none">
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/detection-rules" target="_blank" rel="noreferrer" style="text-decoration:none">
         <div class="card-click">Open →</div>
         <div class="card-ttl">Detection Rules Folder</div>
         <div class="card-sub">Sigma, Wazuh, and Splunk content mapped for review.</div>
         <div class="card-meta"><span class="tag">detection-rules/</span><span class="tag">Subfolder CTA</span></div>
       </a>
-      <a class="card" href="https://github.com/raylee-ops/HawkinsOperations/tree/main/incident-response/playbooks" target="_blank" rel="noreferrer" style="text-decoration:none">
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/incident-response/playbooks" target="_blank" rel="noreferrer" style="text-decoration:none">
         <div class="card-click">Open →</div>
         <div class="card-ttl">IR Playbooks Folder</div>
         <div class="card-sub">Playbook library with clear steps for responders.</div>
@@ -155,7 +155,7 @@
     <li>Target: recruiter-readable change record and technical evidence.</li>
     <li>Structure is kept in the HawkinsOperations repo under <code>projects/</code>.</li>
   </ul>
-  <p><a href="https://github.com/raylee-ops/HawkinsOperations/tree/main/projects" target="_blank" rel="noreferrer">Open projects folder on GitHub</a></p>
+  <p><a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/projects" target="_blank" rel="noreferrer">Open projects folder on GitHub</a></p>
 </template>
 
 <template id="pExperiments">
@@ -165,7 +165,7 @@
     <li>Use-case: evaluation harness patterns that transfer directly to detection validation.</li>
     <li>Repository references live in the HawkinsOps framework workspace.</li>
   </ul>
-  <p><a href="https://github.com/raylee-ops/hawkinsops-framework" target="_blank" rel="noreferrer">Open hawkinsops-framework</a></p>
+  <p><a href="https://github.com/raylee-hawkins/hawkinsops-framework" target="_blank" rel="noreferrer">Open hawkinsops-framework</a></p>
 </template>
 
 <template id="pFilesystem">
@@ -175,19 +175,19 @@
     <li>Table-of-contents repo describing the system layout (system/vault/workspace).</li>
     <li>Pairs with the automation framework repo for cross-platform workflows.</li>
   </ul>
-  <p><a href="https://github.com/raylee-ops/hawkins_ops" target="_blank" rel="noreferrer">Open hawkins_ops</a></p>
+  <p><a href="https://github.com/raylee-hawkins/hawkins_ops" target="_blank" rel="noreferrer">Open hawkins_ops</a></p>
 </template>
 
 <template id="pHawkinsOps">
   <h3>HawkinsOperations (main repo)</h3>
   <p>Production-ready SOC content plus a proof pack that makes the numbers verifiable.</p>
-  <p><a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">Open HawkinsOperations</a></p>
+  <p><a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">Open HawkinsOperations</a></p>
 </template>
 
 <template id="pFramework">
   <h3>HawkinsOps Framework</h3>
   <p>Cross-platform automation scaffolding intended to turn “one-off scripts” into repeatable workflows.</p>
-  <p><a href="https://github.com/raylee-ops/hawkinsops-framework" target="_blank" rel="noreferrer">Open hawkinsops-framework</a></p>
+  <p><a href="https://github.com/raylee-hawkins/hawkinsops-framework" target="_blank" rel="noreferrer">Open hawkinsops-framework</a></p>
 </template>
 
 <div id="modalBg" class="modal-backdrop" aria-hidden="true">
@@ -203,13 +203,14 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/proof.html
+++ b/site/proof.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="HawkinsOps | Proof Pack">
 <meta name="twitter:description" content="Clone, run verification commands, and match counts to repository artifacts.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -63,7 +63,7 @@
     <div class="g2">
       <div class="card">
         <div class="card-ttl">Repo</div>
-        <div class="card-sub"><a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">raylee-ops/HawkinsOperations</a></div>
+        <div class="card-sub"><a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">raylee-hawkins/HawkinsOperations</a></div>
       </div>
       <div class="card">
         <div class="card-ttl">Counts (source of truth)</div>
@@ -88,7 +88,7 @@
         <div class="term-t">Clone + verify counts (PowerShell)</div>
         <div class="term-actions"><button class="tbtn" type="button" data-copy="cProofPS">Copy</button></div>
       </div>
-      <pre id="cProofPS" class="term-b">git clone https://github.com/raylee-ops/HawkinsOperations
+      <pre id="cProofPS" class="term-b">git clone https://github.com/raylee-hawkins/HawkinsOperations
 cd HawkinsOperations
 
 # Reproduce inventory counts locally
@@ -144,13 +144,14 @@ pwsh -File .\scripts\build-wazuh-bundle.ps1</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/resume-content.md
+++ b/site/resume-content.md
@@ -1,6 +1,6 @@
 # Raylee Hawkins
 North Alabama (Huntsville-adjacent)
-raylee@hawkinsops.com | https://github.com/raylee-ops | https://hawkinsops.com | https://linkedin.com/in/raylee-hawkins
+raylee@hawkinsops.com | https://github.com/raylee-hawkins | https://hawkinsops.com | https://linkedin.com/in/raylee-hawkins
 
 ## Headline
 SOC Analyst (T1/T2) candidate focused on detection engineering and security automation.

--- a/site/resume.html
+++ b/site/resume.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="Raylee Hawkins | Resume">
 <meta name="twitter:description" content="SOC-track resume focused on detection engineering, reproducible proof, and lab validation.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 <style>
   .resume-shell{padding-top:110px}
   .resume-sheet{max-width:960px;margin:0 auto;background:var(--bg1);border:1px solid var(--bdr);border-radius:16px;padding:28px}
@@ -84,7 +84,7 @@
         <div class="resume-headline">SOC Analyst (T1/T2) candidate focused on detection engineering + security automation</div>
         <div class="resume-contact">
           North Alabama (Huntsville-adjacent) | <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a> |
-          <a href="https://github.com/raylee-ops" target="_blank" rel="noreferrer">GitHub</a> |
+          <a href="https://github.com/raylee-hawkins" target="_blank" rel="noreferrer">GitHub</a> |
           <a href="https://hawkinsops.com" target="_blank" rel="noreferrer">hawkinsops.com</a> |
           <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
         </div>
@@ -163,12 +163,13 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>

--- a/site/resume.txt
+++ b/site/resume.txt
@@ -3,7 +3,7 @@ SOC Analyst (T1/T2) candidate focused on detection engineering and security auto
 
 Location: North Alabama (Huntsville-adjacent)
 Email: raylee@hawkinsops.com
-GitHub: https://github.com/raylee-ops
+GitHub: https://github.com/raylee-hawkins
 Portfolio: https://hawkinsops.com
 LinkedIn: https://linkedin.com/in/raylee-hawkins
 

--- a/site/security.html
+++ b/site/security.html
@@ -16,8 +16,8 @@
 <meta name="twitter:title" content="HawkinsOps | Raylee Hawkins | Security">
 <meta name="twitter:description" content="Verified detection and IR content with reproducible commands. Public counts align to PROOF_PACK/VERIFIED_COUNTS.md.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
@@ -28,7 +28,7 @@
       document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
     })();
   </script>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -327,13 +327,14 @@ Select-String -Path .\detection-rules\wazuh\rules\*.xml -Pattern '&lt;rule\s+id=
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 

--- a/site/triage.html
+++ b/site/triage.html
@@ -16,12 +16,12 @@
 <meta name="twitter:title" content="HawkinsOps | Triage Simulator">
 <meta name="twitter:description" content="SOC triage workflow practice with investigation pivots and evidence checklists.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og.png">
-<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="/assets/styles.css">
 
 </head>
 <body>
@@ -182,13 +182,14 @@ document.addEventListener('DOMContentLoaded', () => {
   <div class="ctr">
     <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-ops/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noreferrer">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noreferrer">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
     </div>
   </div>
 </footer>
-<script src="assets/app.js" defer></script>
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- apply `hawkinsops_theme_patch_02-17-2026_v2` `site/` payload
- keep runtime stability guardrails by re-normalizing local asset links to `/assets/...`
- remove Netlify marker from `site/README_DEPLOY.md` hosting strategy text

## Verification
- `node scripts/diagnose-site.js --fail-on-issues` (passes: 0 trailing hazards, 0 missing asset resolutions)
- `rg -n "netlify" site -S` (no matches)