### PR TITLE
Update : add AutoSOC Sysmon EID 1/3/10 local rules

### DIFF
--- a/wazuh/pack/rules/local_rules.xml
+++ b/wazuh/pack/rules/local_rules.xml
@@ -8,5 +8,39 @@
     </mitre>
     <group>execution,powershell,</group>
   </rule>
-</group>
 
+  <rule id="100310" level="10">
+    <if_group>windows,sysmon,</if_group>
+    <field name="win.system.eventID">^1$</field>
+    <field name="win.eventdata.image">(?i).*(powershell|pwsh|cmd|wscript|cscript|mshta|rundll32|regsvr32|wmic|certutil|bitsadmin|msbuild|installutil)\.exe$</field>
+    <description>AutoSOC Sysmon EID 1 suspicious process creation</description>
+    <mitre>
+      <id>T1059</id>
+      <id>T1218</id>
+    </mitre>
+    <group>process_creation,execution,autosoc_signal,</group>
+  </rule>
+
+  <rule id="100311" level="12">
+    <if_group>windows,sysmon,</if_group>
+    <field name="win.system.eventID">^3$</field>
+    <field name="win.eventdata.image">(?i).*(powershell|pwsh|cmd|wscript|cscript|mshta|rundll32|regsvr32|wmic|certutil|bitsadmin)\.exe$</field>
+    <description>AutoSOC Sysmon EID 3 suspicious process network connection</description>
+    <mitre>
+      <id>T1041</id>
+      <id>T1105</id>
+    </mitre>
+    <group>network,exfiltration,command_and_control,autosoc_signal,</group>
+  </rule>
+
+  <rule id="100312" level="13">
+    <if_group>windows,sysmon,</if_group>
+    <field name="win.system.eventID">^10$</field>
+    <field name="win.eventdata.targetImage">(?i).*\\lsass\.exe$</field>
+    <description>AutoSOC Sysmon EID 10 process access to LSASS</description>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+    <group>credential_access,lsass,autosoc_signal,</group>
+  </rule>
+</group>


### PR DESCRIPTION
## Summary\n- add three high-signal local Wazuh rules for Sysmon Event IDs 1, 3, and 10\n- keep scope narrow to suspicious process creation, suspicious network-capable LOLBIN usage, and LSASS access\n\n## Validation\n- pwsh -NoProfile -File .\\scripts\\verify\\verify-counts.ps1\n- python .\\scripts\\drift_scan.py\n\n## Note\n- Unify with current AutoSOC triage flow by raising high-confidence Sysmon signals into existing pipeline gates.