### PR TITLE
Update : surface March 2026 AutoSOC release lane and proof links

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -5,4 +5,5 @@
 /security /detections 301
 /lab /soc-lab 301
 /triage /soc-lab 301
+/march-2026-release /march-2026-release.html 200
 /proof/honeypot /honeypot-proof.html 200

--- a/site/index.html
+++ b/site/index.html
@@ -211,7 +211,7 @@
       <div class="met"><div class="met-icon mi-spl">SPL</div><div class="met-v" data-verified="splunk">8</div><div class="met-l">Splunk queries</div><a class="met-link" href="/detections">→ browse</a></div>
       <div class="met"><div class="met-icon mi-ir">IR</div><div class="met-v" data-verified="ir">10</div><div class="met-l">IR playbooks</div><a class="met-link" href="/case-study-ir-playbooks">→ view</a></div>
     </div>
-    <div class="lupd verify-date">Last verified: <span data-verified-date>02-24-2026</span></div>
+    <div class="lupd verify-date">Last verified: <span data-verified-date>03-03-2026</span></div>
     <div class="verify-panel" style="margin-top:8px">
       <div class="verify-panel-h">
         <span>Verify commands</span>
@@ -219,6 +219,52 @@
       </div>
       <pre id="homeVerifyCmdLong" class="verify-code">pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1
 pwsh -NoProfile -File .\scripts\verify\generate-verified-counts.ps1 -OutFile .\PROOF_PACK\VERIFIED_COUNTS.md</pre>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="ctr home-shell">
+    <div class="slbl">March 2026</div>
+    <h2 class="stitle">Release window and proof trail</h2>
+    <p class="sdesc">March upgrades are documented as a single evidence chain: release notes, operations runbook, rootcheck closeout, and the live system map.</p>
+    <div class="g2 lane-grid">
+      <a class="card lane-card" href="/march-2026-release" style="text-decoration:none" data-lane="fastest">
+        <span class="lane-tag">TIMELINE</span>
+        <div class="card-ttl">March 2026 accomplishments</div>
+        <div class="card-sub">One-page timeline with shipped changes, proof links, and reproducible validation commands.</div>
+        <div class="lane-cta" aria-hidden="true">Open lane <span>-></span></div>
+      </a>
+      <a class="card lane-card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/RELEASE_NOTES_v1.4.0.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none" data-lane="systems">
+        <span class="lane-tag">RELEASE</span>
+        <div class="card-ttl">AutoSOC v1.4.0 release notes</div>
+        <div class="card-sub">End-to-end pipeline validation, hardening changes, rootcheck tuning closeout, and reviewer paths.</div>
+        <div class="lane-cta" aria-hidden="true">Open lane <span>-></span></div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="ctr home-shell">
+    <div class="slbl">Ship Log</div>
+    <h2 class="stitle">What shipped this week</h2>
+    <div class="g3">
+      <a class="card" href="/march-2026-release" style="text-decoration:none">
+        <div class="card-ttl">AutoSOC end-to-end loop</div>
+        <div class="card-sub">Scheduler-backed run pipeline validated: ingest -> triage -> redact -> pack -> repo-staged output.</div>
+        <div class="card-meta"><span class="tag">v1.4.0</span><span class="tag">Operational</span></div>
+      </a>
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/ROOTCHECK_CLOSEOUT_REDACTED_2026-03-02.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-ttl">Rootcheck tuning closeout</div>
+        <div class="card-sub">False-positive escalation path narrowed and documented with sanitized closure artifacts.</div>
+        <div class="card-meta"><span class="tag">Rule tuning</span><span class="tag">Closeout proof</span></div>
+      </a>
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_OPERATIONS_RUNBOOK_03-02-2026.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-ttl">Sysmon + triage quality controls</div>
+        <div class="card-sub">Sysmon telemetry integration, noisy-rule suppression, and daily triage quality artifact generation.</div>
+        <div class="card-meta"><span class="tag">Sysmon</span><span class="tag">Quality gate</span></div>
+      </a>
     </div>
   </div>
 </section>

--- a/site/march-2026-release.html
+++ b/site/march-2026-release.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+<head>
+<title>HawkinsOps | March 2026 Release Timeline</title>
+<meta name="description" content="Canonical March 2026 HawkinsOps timeline: AutoSOC release v1.4.0, rootcheck tuning closeout, Sysmon integration, and homepage proof upgrades.">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#07070b">
+<link rel="canonical" href="https://hawkinsops.com/march-2026-release">
+<meta property="og:type" content="website">
+<meta property="og:title" content="HawkinsOps | March 2026 Release Timeline">
+<meta property="og:description" content="AutoSOC release progression for March 2026 with direct proof links and reproducible commands.">
+<meta property="og:url" content="https://hawkinsops.com/march-2026-release">
+<meta property="og:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.svg?v=03-02-2026-2">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="HawkinsOps | March 2026 Release Timeline">
+<meta name="twitter:description" content="AutoSOC release progression for March 2026 with direct proof links and reproducible commands.">
+<meta name="twitter:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.svg?v=03-02-2026-2">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
+<script>
+  (function () {
+    var saved = null;
+    try { saved = localStorage.getItem('rh-theme'); } catch (err) { saved = null; }
+    var sysDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (sysDark ? 'dark' : 'light'));
+  })();
+</script>
+<link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+<!-- @include:nav:start -->
+<nav>
+  <div class="nav-i">
+    <a class="logo" href="/"><span class="logo-monogram" aria-hidden="true">RH</span><b>Hawkins</b>Ops</a>
+    <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
+    <ul class="nav-l">
+      <li><a href="/">Home</a></li>
+      <li><a href="/soc-lab">SOC/Lab</a></li>
+      <li><a href="/detections">Detections</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/projects">Projects</a></li>
+      <li><a href="/wildcard">Extras</a></li>
+      <li><a href="/resume">Resume</a></li>
+    </ul>
+    <a class="btn btn-p nav-cta" href="/proof">View Proof Pack</a>
+    <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
+  </div>
+</nav>
+<div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
+  <a href="/">Home</a>
+  <a href="/soc-lab">SOC/Lab</a>
+  <a href="/detections">Detections</a>
+  <a href="/proof">Proof</a>
+  <a href="/projects">Projects</a>
+  <a href="/wildcard">Extras</a>
+  <a href="/resume">Resume</a>
+</div>
+
+<!-- @include:nav:end -->
+
+<main>
+<section style="padding-top:110px">
+  <div class="ctr">
+    <div class="slbl">March 2026</div>
+    <h1 class="stitle">AutoSOC release timeline (canonical)</h1>
+    <p class="sdesc">
+      This page is the single source for March 2026 accomplishments. It tracks what shipped, where the proof lives,
+      and what to run to reproduce the claims.
+    </p>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="ctr">
+    <div class="slbl">What Shipped</div>
+    <h2 class="stitle">Release milestones</h2>
+    <div class="g2">
+      <div class="card">
+        <div class="card-ttl">03-02-2026: AutoSOC operational hardening</div>
+        <div class="card-sub">Pipeline reliability improvements landed: retry/backoff ingest path, queue overflow guard, idle-cycle telemetry, and log retention metadata.</div>
+        <div class="card-meta"><span class="tag">Pipeline</span><span class="tag">Hardening</span></div>
+      </div>
+      <div class="card">
+        <div class="card-ttl">03-02-2026: Rootcheck closeout</div>
+        <div class="card-sub">High-noise rootcheck alert stream was tuned and closed with documented, redacted evidence and integrity checks.</div>
+        <div class="card-meta"><span class="tag">Rule tuning</span><span class="tag">Closeout</span></div>
+      </div>
+      <div class="card">
+        <div class="card-ttl">03-03-2026: Sysmon integration controls</div>
+        <div class="card-sub">Sysmon source handling and noisy module-load suppression were integrated into triage logic to reduce false escalations.</div>
+        <div class="card-meta"><span class="tag">Sysmon</span><span class="tag">Triage policy</span></div>
+      </div>
+      <div class="card">
+        <div class="card-ttl">03-03-2026: v1.4.0 release closure</div>
+        <div class="card-sub">Release notes consolidated with runbook, rootcheck closeout references, and reviewer validation paths.</div>
+        <div class="card-meta"><span class="tag">Release</span><span class="tag">Documentation</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="ctr">
+    <div class="slbl">Proof Links</div>
+    <h2 class="stitle">Primary evidence sources</h2>
+    <div class="g2">
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/RELEASE_NOTES_v1.4.0.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-ttl">Release notes v1.4.0</div>
+        <div class="card-sub">Consolidated release summary and deployment outcomes.</div>
+      </a>
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_OPERATIONS_RUNBOOK_03-02-2026.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-ttl">AutoSOC operations runbook</div>
+        <div class="card-sub">Scheduler commands, run steps, and failure handling playbook.</div>
+      </a>
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/ROOTCHECK_CLOSEOUT_REDACTED_2026-03-02.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-ttl">Rootcheck closeout report</div>
+        <div class="card-sub">Sanitized closure report for rootcheck tuning activity.</div>
+      </a>
+      <a class="card" href="/proof" style="text-decoration:none">
+        <div class="card-ttl">Proof Pack lane</div>
+        <div class="card-sub">Reproducible verification commands and count source of truth.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="ctr">
+    <div class="slbl">Reproduce</div>
+    <h2 class="stitle">Validation commands</h2>
+    <div class="term">
+      <div class="term-h">
+        <div class="td td-r"></div><div class="td td-y"></div><div class="td td-g"></div>
+        <div class="term-t">Repository verification</div>
+        <div class="term-actions"><button class="tbtn" type="button" data-copy="cMarchVerify">Copy</button></div>
+      </div>
+      <pre id="cMarchVerify" class="term-b">pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1
+python .\scripts\drift_scan.py</pre>
+    </div>
+    <div class="term">
+      <div class="term-h">
+        <div class="td td-r"></div><div class="td td-y"></div><div class="td td-g"></div>
+        <div class="term-t">Triage quality artifact generation</div>
+        <div class="term-actions"><button class="tbtn" type="button" data-copy="cMarchQuality">Copy</button></div>
+      </div>
+      <pre id="cMarchQuality" class="term-b">python C:\RH\OPS\50_System\Scripts\Automation\auto-soc\triage-quality.py --window-hours 24 --compare-previous --csv
+pwsh -NoProfile -File C:\RH\OPS\50_System\Scripts\Automation\auto-soc\render-triage-quality-chart.ps1</pre>
+    </div>
+  </div>
+</section>
+
+</main>
+<!-- @include:footer:start -->
+<footer>
+  <div class="ctr">
+    <p><b>HawkinsOps</b> • Huntsville-adjacent (North Alabama)</p>
+    <div class="fl">
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
+      <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
+    </div>
+  </div>
+</footer>
+
+<!-- @include:footer:end -->
+<script src="/assets/fetch-utils.js" defer></script>
+<script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/site/projects.html
+++ b/site/projects.html
@@ -75,6 +75,34 @@
 
 <section class="section-tight">
   <div class="ctr">
+    <div class="slbl">March 2026</div>
+    <h2 class="stitle">Newly shipped and verifiable</h2>
+    <p class="sdesc">This section tracks March release work with direct links to evidence, operations documentation, and release notes.</p>
+    <div class="g3">
+      <a class="card" href="/march-2026-release" style="text-decoration:none">
+        <div class="card-click">Read →</div>
+        <div class="card-ttl">March 2026 accomplishment timeline</div>
+        <div class="card-sub">Single canonical timeline for homepage upgrade, rootcheck tuning, Sysmon integration, and AutoSOC release closeout.</div>
+        <div class="card-meta"><span class="tag">Timeline</span><span class="tag">Canonical</span></div>
+      </a>
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/RELEASE_NOTES_v1.4.0.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-click">Open →</div>
+        <div class="card-ttl">Release notes v1.4.0</div>
+        <div class="card-sub">AutoSOC end-to-end operational release with hardening details and reviewer links.</div>
+        <div class="card-meta"><span class="tag">Release</span><span class="tag">AutoSOC</span></div>
+      </a>
+      <a class="card" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_OPERATIONS_RUNBOOK_03-02-2026.md" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+        <div class="card-click">Open →</div>
+        <div class="card-ttl">Operations runbook</div>
+        <div class="card-sub">Daily/weekly operational checklist, scheduler commands, and failure handling for pipeline operations.</div>
+        <div class="card-meta"><span class="tag">Runbook</span><span class="tag">Ops</span></div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="ctr">
     <div class="slbl">Featured</div>
     <h2 class="stitle">The flagship project</h2>
 

--- a/site/proof.html
+++ b/site/proof.html
@@ -71,11 +71,44 @@
       The point is that you can verify the claims with commands against a public repo.
       This is what "auditable" looks like when nobody is hand-waving.
     </p>
-    <p class="lupd">All counts on this page are <b>Verified (reproducible today)</b>. "Total library" numbers are not shown.</p>`r`n<p class="lupd">Quick scan: 1) open <code>PROOF_PACK/VERIFIED_COUNTS.md</code> 2) run <code>scripts/verify/verify-counts.ps1</code> 3) compare output to published totals.</p>
+    <p class="lupd">All counts on this page are <b>Verified (reproducible today)</b>. "Total library" numbers are not shown.</p>
+    <p class="lupd">Quick scan: 1) open <code>PROOF_PACK/VERIFIED_COUNTS.md</code> 2) run <code>scripts/verify/verify-counts.ps1</code> 3) compare output to published totals.</p>
 
     <div class="card" style="margin:18px 0 24px 0">
       <div class="card-ttl">Proof → Honeypot (Wazuh)</div>
       <div class="card-sub">Live sanitized alert feed, artifact download, and verification steps. <a href="/proof/honeypot">Open page</a></div>
+    </div>
+
+    <div class="g2">
+      <a class="card" href="/march-2026-release" style="text-decoration:none">
+        <div class="card-ttl">March 2026 release timeline</div>
+        <div class="card-sub">Canonical page for March homepage upgrades, rootcheck tuning, Sysmon integration, and AutoSOC release closure.</div>
+        <div class="card-meta"><span class="tag">Timeline</span><span class="tag">March 2026</span></div>
+      </a>
+      <div class="card">
+        <div class="card-ttl">March quick links</div>
+        <div class="card-sub">
+          <ul style="padding-left:18px;margin:8px 0">
+            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/RELEASE_NOTES_v1.4.0.md" target="_blank" rel="noopener noreferrer">Release notes: v1.4.0</a></li>
+            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_OPERATIONS_RUNBOOK_03-02-2026.md" target="_blank" rel="noopener noreferrer">AutoSOC operations runbook</a></li>
+            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/ROOTCHECK_CLOSEOUT_REDACTED_2026-03-02.md" target="_blank" rel="noopener noreferrer">Rootcheck closeout report</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div style="height:14px"></div>
+
+    <div class="card">
+      <div class="card-ttl">Triage quality artifact panel</div>
+      <div class="card-sub">
+        Daily triage quality artifacts are generated from live pipeline output and compared against prior windows:
+        <code>autosoc-triage-quality-*.md</code>, <code>autosoc-triage-quality-*.json</code>,
+        <code>autosoc-triage-quality-history.csv</code>, and <code>autosoc-triage-quality-trend.png</code>.
+        Use the command below to regenerate from current telemetry.
+      </div>
+      <pre class="term-b" style="margin-top:10px">python C:\RH\OPS\50_System\Scripts\Automation\auto-soc\triage-quality.py --window-hours 24 --compare-previous --csv
+pwsh -NoProfile -File C:\RH\OPS\50_System\Scripts\Automation\auto-soc\render-triage-quality-chart.ps1</pre>
     </div>
 
     <div class="g2">


### PR DESCRIPTION
This PR improves visibility of March 2026 accomplishments and proof paths.\n\nChanges:\n- Add canonical March release timeline page (/march-2026-release)\n- Add March release lane + weekly ship strip on homepage\n- Add March section on Projects page\n- Fix proof page text glitch and add quick-link proof panel\n- Add triage-quality artifact panel and commands\n- Add redirect for /march-2026-release\n\nValidation:\n- verify-counts.ps1 PASS\n- drift_scan.py PASS