### PR TITLE
site: Phase 4 final + cleanup (index.html, styles.css, build-site-includes.js)

### DIFF
--- a/scripts/build-site-includes.js
+++ b/scripts/build-site-includes.js
@@ -13,10 +13,13 @@ const targetPages = fs
   .map((entry) => path.join("site", entry.name))
   .sort();
 
-const includeDefs = {
+const includePaths = {
   nav: path.join("site", "partials", "nav.html"),
   footer: path.join("site", "partials", "footer.html")
 };
+const includeDefs = Object.fromEntries(
+  Object.entries(includePaths).filter(([, relPath]) => fs.existsSync(path.join(root, relPath)))
+);
 
 const routesPath = path.join("scripts", "config", "routes.json");
 
@@ -46,6 +49,10 @@ function markerRegex(name, kind) {
 function findBlock(html, name, relPath) {
   const startMatches = [...html.matchAll(markerRegex(name, "start"))];
   const endMatches = [...html.matchAll(markerRegex(name, "end"))];
+
+  if (startMatches.length === 0 && endMatches.length === 0) {
+    return null;
+  }
 
   if (startMatches.length !== 1 || endMatches.length !== 1) {
     fail(
@@ -115,11 +122,14 @@ function renderFooter() {
   return normalize(readUtf8(includeDefs.footer));
 }
 
-const routes = parseRoutes();
-const includes = {
-  nav: renderNav(routes),
-  footer: renderFooter()
-};
+const includes = {};
+if (includeDefs.nav) {
+  const routes = parseRoutes();
+  includes.nav = renderNav(routes);
+}
+if (includeDefs.footer) {
+  includes.footer = renderFooter();
+}
 
 const changedFiles = [];
 
@@ -131,11 +141,11 @@ targetPages.forEach((relPath) => {
   const newline = detectNewline(raw);
   let html = normalize(raw);
 
-  const navBlock = findBlock(html, "nav", relPath);
-  html = replaceBlock(html, navBlock, includes.nav);
-
-  const footerBlock = findBlock(html, "footer", relPath);
-  html = replaceBlock(html, footerBlock, includes.footer);
+  Object.entries(includes).forEach(([name, replacement]) => {
+    const block = findBlock(html, name, relPath);
+    if (!block) return;
+    html = replaceBlock(html, block, replacement);
+  });
 
   const next = html.replace(/\n/g, newline);
   if (next !== raw) {

--- a/site/index.html
+++ b/site/index.html
@@ -139,14 +139,16 @@
     </div>
 
     <div class="arch-ledger">
-      <span class="arch-ledger-label">Verified runs</span>
-      <span class="arch-ledger-item">4 cases processed</span>
+      <span class="arch-ledger-label">Verified inventory</span>
+      <span class="arch-ledger-item"><span data-verified="detections">-</span> detections</span>
       <span class="arch-ledger-sep" aria-hidden="true">·</span>
-      <span class="arch-ledger-item">1 <code>AUTO_CLOSE_BENIGN</code></span>
+      <span class="arch-ledger-item"><span data-verified="sigma">-</span> <code>Sigma</code></span>
       <span class="arch-ledger-sep" aria-hidden="true">·</span>
-      <span class="arch-ledger-item">1 <code>AUTO_CLOSE_KNOWN_FP</code></span>
+      <span class="arch-ledger-item"><span data-verified="wazuh">-</span> <code>Wazuh</code></span>
       <span class="arch-ledger-sep" aria-hidden="true">·</span>
-      <span class="arch-ledger-item">2 <code>ESCALATED</code> with full evidence packs</span>
+      <span class="arch-ledger-item"><span data-verified="splunk">-</span> <code>Splunk</code></span>
+      <span class="arch-ledger-sep" aria-hidden="true">·</span>
+      <span class="arch-ledger-item"><span data-verified="ir">-</span> IR playbooks</span>
     </div>
 
     <div class="architecture-links">
@@ -218,4 +220,3 @@
 <script src="/assets/app.js" defer></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
Finalizes the Phase 4 homepage architecture section and removes the obsolete nav partial dependency from the include builder.

## Changes
- updates `site/index.html` architecture section
- updates `site/assets/styles.css` for the final Phase 4 visual state
- updates `scripts/build-site-includes.js` so missing `site/partials/nav.html` no longer breaks include checks
- keeps verified counts pipeline intact
- keeps nav system intact

## Validation
- `node scripts/generate-site-data.js` PASS
- `pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1` PASS
- `python .\scripts\drift_scan.py` PASS
- `node .\scripts\diagnose-site.js` PASS

## Notes
Remote/main already contains the earlier nav remediation and routing fixes.
This PR lands the final 3-file cleanup delta still local on `website_cleanup_counts_and_includes`.