### PR TITLE
site: add lab architecture section to homepage

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -554,11 +554,111 @@ body.triage-sim .btn-mini:hover{
 .sys-proof-visual img{display:block;width:100%;height:auto}
 .sys-proof-caption{font-family:var(--mono);font-size:.76rem;color:var(--faint);line-height:1.65;margin-top:14px;max-width:78ch}
 
-/* Who I Am */
-.who-section{padding:48px 0;border-top:1px solid var(--bdr)}
-.who-body{max-width:62ch}
-.who-body p{font-size:.94rem;color:var(--dim);line-height:1.72;margin-bottom:12px}
-.who-body p:last-child{margin-bottom:0}
+/* Lab Architecture */
+.lab-arch{padding:48px 0;border-top:1px solid var(--bdr)}
+.lab-arch-intro{font-size:.9rem;color:var(--dim);line-height:1.65;max-width:68ch;margin-bottom:24px}
+.lab-arch-link{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:.72rem;color:var(--faint);text-decoration:none;margin-top:16px;transition:color .18s}
+.lab-arch-link:hover{color:var(--acc)}
+.lab-arch-link span{transition:transform .2s}
+.lab-arch-link:hover span{transform:translateX(2px)}
+
+/* Architecture diagram */
+.arch-diagram{margin-top:4px}
+.arch-env{
+  border:1px solid var(--bdr2);
+  border-radius:14px;
+  padding:20px;
+  position:relative;
+  background:linear-gradient(160deg,rgba(12,12,12,.92),rgba(8,8,8,.97));
+}
+.arch-env-label{
+  position:absolute;
+  top:-9px;
+  left:16px;
+  padding:0 8px;
+  background:var(--bg);
+  font-family:var(--mono);
+  font-size:.62rem;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.arch-env-nodes{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.arch-node{
+  flex:1;
+  min-width:140px;
+  border:1px solid var(--bdr);
+  border-radius:10px;
+  padding:14px;
+  background:linear-gradient(170deg,rgba(16,16,16,.96),rgba(10,10,10,.99));
+}
+.arch-node--accent{border-color:rgba(var(--acc-rgb),.36)}
+.arch-node-head{
+  font-family:var(--mono);
+  font-size:.58rem;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+  color:var(--faint);
+  margin-bottom:6px;
+}
+.arch-node--accent .arch-node-head{color:var(--acc)}
+.arch-node-name{
+  font-family:var(--head);
+  font-size:.92rem;
+  font-weight:600;
+  color:var(--txt);
+  margin-bottom:4px;
+}
+.arch-node-detail{
+  font-family:var(--mono);
+  font-size:.66rem;
+  color:var(--dim);
+  line-height:1.5;
+}
+.arch-arrow{
+  font-family:var(--mono);
+  font-size:1rem;
+  color:var(--bdr2);
+  flex:0 0 auto;
+  user-select:none;
+}
+.arch-vert{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  padding:6px 0;
+}
+.arch-vert-line{
+  width:1px;
+  height:28px;
+  background:var(--bdr2);
+}
+.arch-vert-label{
+  font-family:var(--mono);
+  font-size:.58rem;
+  color:var(--faint);
+  margin-top:4px;
+  margin-bottom:4px;
+  letter-spacing:.03em;
+}
+.arch-output-row{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  max-width:480px;
+  margin:0 auto;
+  flex-wrap:wrap;
+}
+
+/* Light theme */
+html[data-theme="light"] .arch-env{background:linear-gradient(160deg,rgba(255,255,255,.90),rgba(245,248,254,.95));border-color:var(--bdr2)}
+html[data-theme="light"] .arch-env-label{background:var(--bg)}
+html[data-theme="light"] .arch-node{background:linear-gradient(170deg,rgba(255,255,255,.95),rgba(248,250,254,.98))}
 
 /* Review Path */
 .review-section{padding:56px 0}
@@ -599,12 +699,17 @@ html[data-theme="light"] .proof-strip-inner{background:linear-gradient(180deg,rg
   .home-main .hero{padding-top:82px;padding-bottom:36px}
   .review-section .g3{grid-template-columns:1fr}
   .review-section .lane-card{min-height:auto}
+  .arch-output-row{max-width:100%}
 }
 @media(max-width:640px){
   .home-main .htitle{font-size:1.9rem;line-height:1.08}
   .home-main .hsub{font-size:.93rem}
   .proof-strip-counts{font-size:.7rem}
   .sys-proof-caption{font-size:.7rem}
+  .arch-env-nodes{flex-direction:column;align-items:stretch}
+  .arch-arrow{text-align:center;transform:rotate(90deg)}
+  .arch-output-row{flex-direction:column;align-items:stretch;max-width:100%}
+  .arch-node{min-width:auto}
 }
 
 /* Footer expanded layout */

--- a/site/index.html
+++ b/site/index.html
@@ -88,27 +88,70 @@
   </div>
 </header>
 
+<section class="lab-arch">
+  <div class="ctr">
+    <div class="slbl">Infrastructure</div>
+    <h2 class="stitle">The lab behind it</h2>
+    <p class="lab-arch-intro">Single Proxmox host running isolated VMs. Real telemetry flows from endpoint through Wazuh into automated triage. Splunk handles investigation pivots. Everything runs on RFC1918 subnets — test traffic stays in the lab, evidence comes out.</p>
+
+    <div class="arch-diagram">
+      <div class="arch-env">
+        <div class="arch-env-label">Proxmox Hypervisor</div>
+        <div class="arch-env-nodes">
+          <div class="arch-node">
+            <div class="arch-node-head">Endpoint</div>
+            <div class="arch-node-name">Windows 11</div>
+            <div class="arch-node-detail">Sysmon · Wazuh Agent</div>
+          </div>
+          <div class="arch-arrow" aria-hidden="true">→</div>
+          <div class="arch-node">
+            <div class="arch-node-head">SIEM</div>
+            <div class="arch-node-name">Wazuh Manager</div>
+            <div class="arch-node-detail">Indexer · REST API · Custom rules</div>
+          </div>
+          <div class="arch-arrow" aria-hidden="true">→</div>
+          <div class="arch-node">
+            <div class="arch-node-head">Search</div>
+            <div class="arch-node-name">Splunk</div>
+            <div class="arch-node-detail">SPL queries · Investigation pivots</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arch-vert">
+        <div class="arch-vert-line"></div>
+        <div class="arch-vert-label">Tailscale · port 9200</div>
+      </div>
+
+      <div class="arch-env-nodes arch-output-row">
+        <div class="arch-node arch-node--accent">
+          <div class="arch-node-head">Automation</div>
+          <div class="arch-node-name">AutoSOC Pipeline</div>
+          <div class="arch-node-detail">poll → triage → redact → pack</div>
+        </div>
+        <div class="arch-arrow" aria-hidden="true">→</div>
+        <div class="arch-node">
+          <div class="arch-node-head">Output</div>
+          <div class="arch-node-name">GitHub</div>
+          <div class="arch-node-detail">Evidence PRs · Reviewable packs</div>
+        </div>
+      </div>
+    </div>
+
+    <a class="lab-arch-link" href="/soc-lab">Full lab details <span>→</span></a>
+  </div>
+</section>
+
 <section class="sys-proof">
   <div class="ctr">
-    <div class="slbl">System</div>
-    <h2 class="stitle">How it works</h2>
+    <div class="slbl">Pipeline</div>
+    <h2 class="stitle">How AutoSOC works</h2>
     <div class="sys-proof-visual">
       <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg"
            alt="AutoSOC pipeline: alert intake (poll-alerts.py), triage decision (triage.py), evidence pack (redact.py + assemble-pack.py), GitHub PR escalation (create-pr.py)"
            loading="lazy" width="1200" height="280">
     </div>
     <p class="sys-proof-caption">poll-alerts.py queries the Wazuh indexer on schedule. triage.py dispositions each alert against policy.yaml. redact.py strips identifiers. assemble-pack.py generates the evidence pack. create-pr.py opens a GitHub PR. Orchestrated by run-pipeline.py on Task Scheduler.</p>
-  </div>
-</section>
-
-<section class="who-section">
-  <div class="ctr">
-    <div class="slbl">Background</div>
-    <h2 class="stitle">Who I am</h2>
-    <div class="who-body">
-      <p>I'm Raylee Hawkins. I'm building toward a SOC Analyst role through hands-on lab work — not just certifications. My homelab runs Proxmox, Wazuh, and Grafana across multiple VMs. I write Sigma rules, build IR playbooks, and automate triage workflows.</p>
-      <p>AutoSOC is the clearest example: a pipeline that handles real Wazuh alerts end to end. This portfolio exists to prove the work, not to talk about it.</p>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- New lab architecture diagram showing multi-VM Proxmox environment
- Homepage now: Hero → Lab Architecture → AutoSOC Pipeline → Review Path → Proof Strip
- HTML/CSS diagram (theme-aware, responsive), not an image
- Links to /soc-lab for full detail

## Verified
- [x] `drift_scan.py` — PASS
- [x] `diagnose-site.js --fail-on-issues` — PASS
- [x] `public-safety-scan.ps1` — PASS
- [x] `data-verified` bindings intact
- [x] `/data/counts.js` loads

## Test plan
- [ ] Visual check: architecture diagram layout desktop dark/light
- [ ] Visual check: mobile responsive (nodes stack vertically)
- [ ] Confirm lab details link resolves to /soc-lab

🤖 Generated with [Claude Code](https://claude.com/claude-code)