### PR TITLE
site: replace lab diagram with SVG

### DIFF
--- a/site/assets/pp_soc_integration/lab-architecture.svg
+++ b/site/assets/pp_soc_integration/lab-architecture.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 510" role="img" aria-label="SOC lab architecture: Proxmox hypervisor with Windows endpoint, Wazuh Manager, and Splunk, connected to AutoSOC pipeline and GitHub review output">
+  <title>SOC Lab Architecture</title>
+  <desc>Proxmox hypervisor running Windows 11 endpoint (Sysmon, Wazuh Agent), Wazuh Manager (Indexer, REST API), and Splunk. Wazuh indexer connects via Tailscale port 9200 to AutoSOC automation pipeline, which outputs evidence PRs to GitHub for review.</desc>
+
+  <!-- PROXMOX BOUNDARY -->
+  <rect x="40" y="25" width="1120" height="215" rx="12" fill="none" stroke="#1c2534" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="72" y="13" width="196" height="24" rx="4" fill="#080c14"/>
+  <text x="84" y="30" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#3d5a78" letter-spacing="2">PROXMOX HYPERVISOR</text>
+
+  <!-- NODE 1 — Windows Endpoint -->
+  <rect x="70" y="58" width="300" height="152" rx="8" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <rect x="71" y="59" width="298" height="1" fill="#ffffff" fill-opacity="0.04"/>
+  <text x="88" y="100" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="9" fill="#324a62" letter-spacing="2.2">ENDPOINT</text>
+  <text x="88" y="126" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="15" font-weight="600" fill="#ccd8ee">Windows 11</text>
+  <text x="88" y="152" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="11" fill="#3d5a78">Sysmon · Wazuh Agent</text>
+  <text x="88" y="174" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#283848">Telemetry source</text>
+
+  <!-- CONNECTOR 1→2 -->
+  <line x1="374" y1="134" x2="444" y2="134" stroke="#1c2a38" stroke-width="1.5"/>
+  <path d="M441,129.5 L451,134 L441,138.5 L443.5,134 Z" fill="#1c2a38"/>
+
+  <!-- NODE 2 — Wazuh Manager -->
+  <rect x="450" y="58" width="300" height="152" rx="8" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <rect x="451" y="59" width="298" height="1" fill="#ffffff" fill-opacity="0.04"/>
+  <text x="468" y="100" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="9" fill="#324a62" letter-spacing="2.2">SIEM</text>
+  <text x="468" y="126" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="15" font-weight="600" fill="#ccd8ee">Wazuh Manager</text>
+  <text x="468" y="152" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="11" fill="#3d5a78">Indexer · REST API</text>
+  <text x="468" y="174" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#283848">Custom rules · 100000+ range</text>
+
+  <!-- CONNECTOR 2→3 -->
+  <line x1="754" y1="134" x2="824" y2="134" stroke="#1c2a38" stroke-width="1.5"/>
+  <path d="M821,129.5 L831,134 L821,138.5 L823.5,134 Z" fill="#1c2a38"/>
+
+  <!-- NODE 3 — Splunk -->
+  <rect x="830" y="58" width="300" height="152" rx="8" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <rect x="831" y="59" width="298" height="1" fill="#ffffff" fill-opacity="0.04"/>
+  <text x="848" y="100" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="9" fill="#324a62" letter-spacing="2.2">SEARCH</text>
+  <text x="848" y="126" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="15" font-weight="600" fill="#ccd8ee">Splunk</text>
+  <text x="848" y="152" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="11" fill="#3d5a78">SPL queries</text>
+  <text x="848" y="174" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#283848">Investigation pivots</text>
+
+  <!-- VERTICAL CONNECTOR — Wazuh down to AutoSOC -->
+  <line x1="600" y1="214" x2="600" y2="328" stroke="#264870" stroke-width="1.5"/>
+  <path d="M595.5,325 L600,335 L604.5,325 L600,327.5 Z" fill="#264870"/>
+  <text x="616" y="278" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="9.5" fill="#3d5a78" letter-spacing="0.5">Tailscale · port 9200</text>
+
+  <!-- NODE 4 — AutoSOC Pipeline (accent) -->
+  <rect x="270" y="342" width="290" height="148" rx="8" fill="#0c1320" stroke="#3d6494" stroke-width="1"/>
+  <rect x="271" y="343" width="288" height="1" fill="#7ab8ff" fill-opacity="0.07"/>
+  <text x="288" y="384" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="9" fill="#3d6494" letter-spacing="2.2">AUTOMATION</text>
+  <text x="288" y="410" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="15" font-weight="600" fill="#7ab8ff">AutoSOC Pipeline</text>
+  <text x="288" y="436" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="11" fill="#3d5a78">poll → triage → redact → pack</text>
+  <text x="288" y="458" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#283848">Scheduled · Task Scheduler</text>
+
+  <!-- CONNECTOR 4→5 -->
+  <line x1="564" y1="416" x2="634" y2="416" stroke="#264870" stroke-width="1.5"/>
+  <path d="M631,411.5 L641,416 L631,420.5 L633.5,416 Z" fill="#264870"/>
+
+  <!-- NODE 5 — GitHub Review (output) -->
+  <rect x="640" y="342" width="290" height="148" rx="8" fill="#0c1320" stroke="#3d6494" stroke-width="1"/>
+  <rect x="641" y="343" width="288" height="1" fill="#7ab8ff" fill-opacity="0.07"/>
+  <text x="658" y="384" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="9" fill="#3d6494" letter-spacing="2.2">OUTPUT</text>
+  <text x="658" y="410" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="15" font-weight="600" fill="#7ab8ff">GitHub Review</text>
+  <text x="658" y="436" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="11" fill="#3d5a78">Evidence PRs</text>
+  <text x="658" y="458" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#283848">Reviewable packs · Redacted</text>
+</svg>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -556,109 +556,14 @@ body.triage-sim .btn-mini:hover{
 
 /* Lab Architecture */
 .lab-arch{padding:48px 0;border-top:1px solid var(--bdr)}
-.lab-arch-intro{font-size:.9rem;color:var(--dim);line-height:1.65;max-width:68ch;margin-bottom:24px}
+.lab-arch-intro{font-size:.9rem;color:var(--dim);line-height:1.65;max-width:68ch;margin-bottom:20px}
+.lab-arch-visual{border:1px solid var(--bdr2);border-radius:14px;overflow:hidden;background:rgba(6,8,14,.95)}
+.lab-arch-visual img{display:block;width:100%;height:auto}
 .lab-arch-link{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:.72rem;color:var(--faint);text-decoration:none;margin-top:16px;transition:color .18s}
 .lab-arch-link:hover{color:var(--acc)}
 .lab-arch-link span{transition:transform .2s}
 .lab-arch-link:hover span{transform:translateX(2px)}
-
-/* Architecture diagram */
-.arch-diagram{margin-top:4px}
-.arch-env{
-  border:1px solid var(--bdr2);
-  border-radius:14px;
-  padding:20px;
-  position:relative;
-  background:linear-gradient(160deg,rgba(12,12,12,.92),rgba(8,8,8,.97));
-}
-.arch-env-label{
-  position:absolute;
-  top:-9px;
-  left:16px;
-  padding:0 8px;
-  background:var(--bg);
-  font-family:var(--mono);
-  font-size:.62rem;
-  letter-spacing:.1em;
-  text-transform:uppercase;
-  color:var(--faint);
-}
-.arch-env-nodes{
-  display:flex;
-  align-items:center;
-  gap:12px;
-  flex-wrap:wrap;
-}
-.arch-node{
-  flex:1;
-  min-width:140px;
-  border:1px solid var(--bdr);
-  border-radius:10px;
-  padding:14px;
-  background:linear-gradient(170deg,rgba(16,16,16,.96),rgba(10,10,10,.99));
-}
-.arch-node--accent{border-color:rgba(var(--acc-rgb),.36)}
-.arch-node-head{
-  font-family:var(--mono);
-  font-size:.58rem;
-  letter-spacing:.1em;
-  text-transform:uppercase;
-  color:var(--faint);
-  margin-bottom:6px;
-}
-.arch-node--accent .arch-node-head{color:var(--acc)}
-.arch-node-name{
-  font-family:var(--head);
-  font-size:.92rem;
-  font-weight:600;
-  color:var(--txt);
-  margin-bottom:4px;
-}
-.arch-node-detail{
-  font-family:var(--mono);
-  font-size:.66rem;
-  color:var(--dim);
-  line-height:1.5;
-}
-.arch-arrow{
-  font-family:var(--mono);
-  font-size:1rem;
-  color:var(--bdr2);
-  flex:0 0 auto;
-  user-select:none;
-}
-.arch-vert{
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  padding:6px 0;
-}
-.arch-vert-line{
-  width:1px;
-  height:28px;
-  background:var(--bdr2);
-}
-.arch-vert-label{
-  font-family:var(--mono);
-  font-size:.58rem;
-  color:var(--faint);
-  margin-top:4px;
-  margin-bottom:4px;
-  letter-spacing:.03em;
-}
-.arch-output-row{
-  display:flex;
-  align-items:center;
-  gap:12px;
-  max-width:480px;
-  margin:0 auto;
-  flex-wrap:wrap;
-}
-
-/* Light theme */
-html[data-theme="light"] .arch-env{background:linear-gradient(160deg,rgba(255,255,255,.90),rgba(245,248,254,.95));border-color:var(--bdr2)}
-html[data-theme="light"] .arch-env-label{background:var(--bg)}
-html[data-theme="light"] .arch-node{background:linear-gradient(170deg,rgba(255,255,255,.95),rgba(248,250,254,.98))}
+html[data-theme="light"] .lab-arch-visual{background:rgba(240,244,252,.95);border-color:var(--bdr2)}
 
 /* Review Path */
 .review-section{padding:56px 0}
@@ -699,17 +604,12 @@ html[data-theme="light"] .proof-strip-inner{background:linear-gradient(180deg,rg
   .home-main .hero{padding-top:82px;padding-bottom:36px}
   .review-section .g3{grid-template-columns:1fr}
   .review-section .lane-card{min-height:auto}
-  .arch-output-row{max-width:100%}
 }
 @media(max-width:640px){
   .home-main .htitle{font-size:1.9rem;line-height:1.08}
   .home-main .hsub{font-size:.93rem}
   .proof-strip-counts{font-size:.7rem}
   .sys-proof-caption{font-size:.7rem}
-  .arch-env-nodes{flex-direction:column;align-items:stretch}
-  .arch-arrow{text-align:center;transform:rotate(90deg)}
-  .arch-output-row{flex-direction:column;align-items:stretch;max-width:100%}
-  .arch-node{min-width:auto}
 }
 
 /* Footer expanded layout */

--- a/site/index.html
+++ b/site/index.html
@@ -93,51 +93,11 @@
     <div class="slbl">Infrastructure</div>
     <h2 class="stitle">The lab behind it</h2>
     <p class="lab-arch-intro">Single Proxmox host running isolated VMs. Real telemetry flows from endpoint through Wazuh into automated triage. Splunk handles investigation pivots. Everything runs on RFC1918 subnets — test traffic stays in the lab, evidence comes out.</p>
-
-    <div class="arch-diagram">
-      <div class="arch-env">
-        <div class="arch-env-label">Proxmox Hypervisor</div>
-        <div class="arch-env-nodes">
-          <div class="arch-node">
-            <div class="arch-node-head">Endpoint</div>
-            <div class="arch-node-name">Windows 11</div>
-            <div class="arch-node-detail">Sysmon · Wazuh Agent</div>
-          </div>
-          <div class="arch-arrow" aria-hidden="true">→</div>
-          <div class="arch-node">
-            <div class="arch-node-head">SIEM</div>
-            <div class="arch-node-name">Wazuh Manager</div>
-            <div class="arch-node-detail">Indexer · REST API · Custom rules</div>
-          </div>
-          <div class="arch-arrow" aria-hidden="true">→</div>
-          <div class="arch-node">
-            <div class="arch-node-head">Search</div>
-            <div class="arch-node-name">Splunk</div>
-            <div class="arch-node-detail">SPL queries · Investigation pivots</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="arch-vert">
-        <div class="arch-vert-line"></div>
-        <div class="arch-vert-label">Tailscale · port 9200</div>
-      </div>
-
-      <div class="arch-env-nodes arch-output-row">
-        <div class="arch-node arch-node--accent">
-          <div class="arch-node-head">Automation</div>
-          <div class="arch-node-name">AutoSOC Pipeline</div>
-          <div class="arch-node-detail">poll → triage → redact → pack</div>
-        </div>
-        <div class="arch-arrow" aria-hidden="true">→</div>
-        <div class="arch-node">
-          <div class="arch-node-head">Output</div>
-          <div class="arch-node-name">GitHub</div>
-          <div class="arch-node-detail">Evidence PRs · Reviewable packs</div>
-        </div>
-      </div>
+    <div class="lab-arch-visual">
+      <img src="/assets/pp_soc_integration/lab-architecture.svg"
+           alt="SOC lab architecture: Proxmox hypervisor running Windows 11 endpoint (Sysmon + Wazuh Agent), Wazuh Manager (Indexer + REST API), and Splunk, connected via Tailscale to AutoSOC pipeline and GitHub review output"
+           loading="lazy" width="1200" height="510">
     </div>
-
     <a class="lab-arch-link" href="/soc-lab">Full lab details <span>→</span></a>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- New `lab-architecture.svg` matching pipe-diagram visual language
- Shows Proxmox boundary, Windows endpoint, Wazuh Manager, Splunk, vertical Tailscale connector, AutoSOC + GitHub output
- Replaces HTML/CSS box diagram with proper homepage-grade SVG
- Removed ~80 lines of dead arch-node/arch-env CSS

## Verified
- [x] `public-safety-scan.ps1` — PASS
- [x] `drift_scan.py` — PASS
- [x] `diagnose-site.js --fail-on-issues` — PASS