### PR TITLE
site: two-level system visuals on homepage

### DIFF
--- a/site/assets/pp_soc_integration/autosoc-pipe-diagram.svg
+++ b/site/assets/pp_soc_integration/autosoc-pipe-diagram.svg
@@ -1,48 +1,56 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" role="img" aria-label="AutoSOC pipeline: alert intake, triage decision, evidence pack, GitHub PR escalation">
-  <title>AutoSOC Pipeline Architecture</title>
-  <desc>Four-stage automated triage pipeline: Alert Intake via poll-alerts.py, Triage Decision via triage.py, Evidence Pack via redact.py and assemble-pack.py, Escalation output via create-pr.py</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 240" role="img" aria-label="AutoSOC workflow: alert intake, triage, redaction, evidence pack, PR escalation">
+  <title>AutoSOC Workflow</title>
+  <desc>Five-stage automated triage workflow: Alert Intake via poll-alerts.py, Triage via triage.py, Redaction via redact.py, Evidence Pack via assemble-pack.py, Escalation via create-pr.py</desc>
 
-  <!-- NODE 1 — Alert Intake -->
-  <rect x="60" y="65" width="228" height="150" rx="8" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
-  <rect x="61" y="66" width="226" height="1" fill="#ffffff" fill-opacity="0.04"/>
-  <text x="76" y="113" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="40" font-weight="700" fill="#7ab8ff" fill-opacity="0.11" letter-spacing="-1.5">01</text>
-  <text x="76" y="135" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="9" fill="#324a62" letter-spacing="2.2">INTAKE</text>
-  <text x="76" y="162" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="14.5" font-weight="600" fill="#ccd8ee">Alert Intake</text>
-  <text x="76" y="186" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="11" fill="#3d5a78">poll-alerts.py</text>
+  <!-- Stage 01 — Intake -->
+  <rect x="28" y="55" width="184" height="130" rx="6" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <text x="42" y="96" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="34" font-weight="700" fill="#7ab8ff" fill-opacity="0.10" letter-spacing="-1">01</text>
+  <text x="42" y="114" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="8.5" fill="#324a62" letter-spacing="2">INTAKE</text>
+  <text x="42" y="138" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="13" font-weight="600" fill="#ccd8ee">Alert Intake</text>
+  <text x="42" y="158" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#3d5a78">poll-alerts.py</text>
 
-  <!-- CONNECTOR 1 -->
-  <line x1="292" y1="140" x2="337" y2="140" stroke="#1c2a38" stroke-width="1.5"/>
-  <path d="M334,135.5 L344,140 L334,144.5 L336.5,140 Z" fill="#1c2a38"/>
+  <!-- Connector 1→2 -->
+  <line x1="216" y1="120" x2="236" y2="120" stroke="#1c2a38" stroke-width="1.5"/>
+  <path d="M233,116 L241,120 L233,124 L235,120 Z" fill="#1c2a38"/>
 
-  <!-- NODE 2 — Decision -->
-  <rect x="344" y="65" width="228" height="150" rx="8" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
-  <rect x="345" y="66" width="226" height="1" fill="#ffffff" fill-opacity="0.04"/>
-  <text x="360" y="113" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="40" font-weight="700" fill="#7ab8ff" fill-opacity="0.11" letter-spacing="-1.5">02</text>
-  <text x="360" y="135" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="9" fill="#324a62" letter-spacing="2.2">TRIAGE</text>
-  <text x="360" y="162" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="14.5" font-weight="600" fill="#ccd8ee">Decision</text>
-  <text x="360" y="186" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="11" fill="#3d5a78">triage.py</text>
+  <!-- Stage 02 — Triage -->
+  <rect x="244" y="55" width="184" height="130" rx="6" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <text x="258" y="96" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="34" font-weight="700" fill="#7ab8ff" fill-opacity="0.10" letter-spacing="-1">02</text>
+  <text x="258" y="114" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="8.5" fill="#324a62" letter-spacing="2">TRIAGE</text>
+  <text x="258" y="138" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="13" font-weight="600" fill="#ccd8ee">Decision</text>
+  <text x="258" y="158" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#3d5a78">triage.py</text>
 
-  <!-- CONNECTOR 2 -->
-  <line x1="576" y1="140" x2="621" y2="140" stroke="#1c2a38" stroke-width="1.5"/>
-  <path d="M618,135.5 L628,140 L618,144.5 L620.5,140 Z" fill="#1c2a38"/>
+  <!-- Connector 2→3 -->
+  <line x1="432" y1="120" x2="452" y2="120" stroke="#1c2a38" stroke-width="1.5"/>
+  <path d="M449,116 L457,120 L449,124 L451,120 Z" fill="#1c2a38"/>
 
-  <!-- NODE 3 — Evidence Pack -->
-  <rect x="628" y="65" width="228" height="150" rx="8" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
-  <rect x="629" y="66" width="226" height="1" fill="#ffffff" fill-opacity="0.04"/>
-  <text x="644" y="113" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="40" font-weight="700" fill="#7ab8ff" fill-opacity="0.11" letter-spacing="-1.5">03</text>
-  <text x="644" y="135" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="9" fill="#324a62" letter-spacing="2.2">PACKAGE</text>
-  <text x="644" y="162" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="14.5" font-weight="600" fill="#ccd8ee">Evidence Pack</text>
-  <text x="644" y="186" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="10.5" fill="#3d5a78">redact + assemble-pack</text>
+  <!-- Stage 03 — Redact -->
+  <rect x="460" y="55" width="184" height="130" rx="6" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <text x="474" y="96" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="34" font-weight="700" fill="#7ab8ff" fill-opacity="0.10" letter-spacing="-1">03</text>
+  <text x="474" y="114" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="8.5" fill="#324a62" letter-spacing="2">REDACT</text>
+  <text x="474" y="138" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="13" font-weight="600" fill="#ccd8ee">Sanitize</text>
+  <text x="474" y="158" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#3d5a78">redact.py</text>
 
-  <!-- CONNECTOR 3 — brighter, signals output -->
-  <line x1="860" y1="140" x2="905" y2="140" stroke="#264870" stroke-width="1.5"/>
-  <path d="M902,135.5 L912,140 L902,144.5 L904.5,140 Z" fill="#264870"/>
+  <!-- Connector 3→4 -->
+  <line x1="648" y1="120" x2="668" y2="120" stroke="#1c2a38" stroke-width="1.5"/>
+  <path d="M665,116 L673,120 L665,124 L667,120 Z" fill="#1c2a38"/>
 
-  <!-- NODE 4 — Escalation (output) -->
-  <rect x="912" y="65" width="228" height="150" rx="8" fill="#0c1320" stroke="#3d6494" stroke-width="1"/>
-  <rect x="913" y="66" width="226" height="1" fill="#7ab8ff" fill-opacity="0.07"/>
-  <text x="928" y="113" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="40" font-weight="700" fill="#7ab8ff" fill-opacity="0.26" letter-spacing="-1.5">04</text>
-  <text x="928" y="135" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="9" fill="#3d6494" letter-spacing="2.2">OUTPUT</text>
-  <text x="928" y="162" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="14.5" font-weight="600" fill="#7ab8ff">Escalation</text>
-  <text x="928" y="186" font-family="'JetBrains Mono',Consolas,'Courier New',monospace" font-size="11" fill="#3d5a78">create-pr.py</text>
+  <!-- Stage 04 — Pack -->
+  <rect x="676" y="55" width="184" height="130" rx="6" fill="#0d1018" stroke="#1c2534" stroke-width="1"/>
+  <text x="690" y="96" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="34" font-weight="700" fill="#7ab8ff" fill-opacity="0.10" letter-spacing="-1">04</text>
+  <text x="690" y="114" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="8.5" fill="#324a62" letter-spacing="2">PACKAGE</text>
+  <text x="690" y="138" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="13" font-weight="600" fill="#ccd8ee">Evidence Pack</text>
+  <text x="690" y="158" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#3d5a78">assemble-pack.py</text>
+
+  <!-- Connector 4→5 (brighter — signals output) -->
+  <line x1="864" y1="120" x2="884" y2="120" stroke="#264870" stroke-width="1.5"/>
+  <path d="M881,116 L889,120 L881,124 L883,120 Z" fill="#264870"/>
+
+  <!-- Stage 05 — Escalation (output accent) -->
+  <rect x="892" y="55" width="184" height="130" rx="6" fill="#0c1320" stroke="#3d6494" stroke-width="1"/>
+  <rect x="893" y="56" width="182" height="1" fill="#7ab8ff" fill-opacity="0.07"/>
+  <text x="906" y="96" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="34" font-weight="700" fill="#7ab8ff" fill-opacity="0.22" letter-spacing="-1">05</text>
+  <text x="906" y="114" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="8.5" fill="#3d6494" letter-spacing="2">OUTPUT</text>
+  <text x="906" y="138" font-family="'Sora','Inter','Segoe UI',Arial,sans-serif" font-size="13" font-weight="600" fill="#7ab8ff">Escalation</text>
+  <text x="906" y="158" font-family="'JetBrains Mono','Consolas','Courier New',monospace" font-size="10" fill="#3d5a78">create-pr.py</text>
 </svg>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -548,14 +548,8 @@ body.triage-sim .btn-mini:hover{
 .home-main .hero-meta{display:flex;flex-direction:column;gap:7px}
 .home-main .stitle{font-size:clamp(1.85rem,2.5vw,2.35rem);margin-bottom:18px}
 
-/* System Proof */
-.sys-proof{padding:0 0 56px}
-.sys-proof-visual{border:1px solid var(--bdr2);border-radius:14px;overflow:hidden;background:rgba(6,8,14,.95);margin-top:16px}
-.sys-proof-visual img{display:block;width:100%;height:auto}
-.sys-proof-caption{font-family:var(--mono);font-size:.76rem;color:var(--faint);line-height:1.65;margin-top:14px;max-width:78ch}
-
-/* Lab Architecture */
-.lab-arch{padding:48px 0;border-top:1px solid var(--bdr)}
+/* Lab Architecture — system map, framed environment view */
+.lab-arch{padding:48px 0;border-top:1px solid var(--bdr);background:linear-gradient(180deg,rgba(8,12,20,.35) 0%,transparent 100%)}
 .lab-arch-intro{font-size:.9rem;color:var(--dim);line-height:1.65;max-width:68ch;margin-bottom:20px}
 .lab-arch-visual{border:1px solid var(--bdr2);border-radius:14px;overflow:hidden;background:rgba(6,8,14,.95)}
 .lab-arch-visual img{display:block;width:100%;height:auto}
@@ -563,7 +557,14 @@ body.triage-sim .btn-mini:hover{
 .lab-arch-link:hover{color:var(--acc)}
 .lab-arch-link span{transition:transform .2s}
 .lab-arch-link:hover span{transform:translateX(2px)}
+html[data-theme="light"] .lab-arch{background:linear-gradient(180deg,rgba(235,240,250,.35) 0%,transparent 100%)}
 html[data-theme="light"] .lab-arch-visual{background:rgba(240,244,252,.95);border-color:var(--bdr2)}
+
+/* AutoSOC Workflow — process flow, raw/flush treatment */
+.sys-proof{padding:40px 0 56px;border-top:1px solid var(--bdr)}
+.sys-proof-visual{margin-top:16px;padding:8px 0}
+.sys-proof-visual img{display:block;width:100%;height:auto}
+.sys-proof-caption{font-family:var(--mono);font-size:.76rem;color:var(--faint);line-height:1.65;margin-top:14px;max-width:78ch}
 
 /* Review Path */
 .review-section{padding:56px 0}
@@ -595,7 +596,6 @@ html[data-theme="light"] .lab-arch-visual{background:rgba(240,244,252,.95);borde
 .proof-strip-meta{font-family:var(--mono);font-size:.64rem;color:var(--faint);margin-top:6px}
 
 /* Light theme overrides for new sections */
-html[data-theme="light"] .sys-proof-visual{background:rgba(240,244,252,.95);border-color:var(--bdr2)}
 html[data-theme="light"] .review-section .lane-card{background:linear-gradient(165deg,rgba(255,255,255,.92),rgba(245,248,254,.96))}
 html[data-theme="light"] .proof-strip-inner{background:linear-gradient(180deg,rgba(245,248,254,.96),rgba(240,244,252,.98));border-color:rgba(var(--acc-rgb),.22)}
 

--- a/site/index.html
+++ b/site/index.html
@@ -104,14 +104,14 @@
 
 <section class="sys-proof">
   <div class="ctr">
-    <div class="slbl">Pipeline</div>
-    <h2 class="stitle">How AutoSOC works</h2>
+    <div class="slbl">Workflow</div>
+    <h2 class="stitle">AutoSOC triage flow</h2>
     <div class="sys-proof-visual">
       <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg"
-           alt="AutoSOC pipeline: alert intake (poll-alerts.py), triage decision (triage.py), evidence pack (redact.py + assemble-pack.py), GitHub PR escalation (create-pr.py)"
-           loading="lazy" width="1200" height="280">
+           alt="AutoSOC workflow: alert intake (poll-alerts.py), triage decision (triage.py), redaction (redact.py), evidence pack (assemble-pack.py), PR escalation (create-pr.py)"
+           loading="lazy" width="1200" height="240">
     </div>
-    <p class="sys-proof-caption">poll-alerts.py queries the Wazuh indexer on schedule. triage.py dispositions each alert against policy.yaml. redact.py strips identifiers. assemble-pack.py generates the evidence pack. create-pr.py opens a GitHub PR. Orchestrated by run-pipeline.py on Task Scheduler.</p>
+    <p class="sys-proof-caption">poll-alerts.py queries the Wazuh indexer on schedule. triage.py dispositions each alert against policy.yaml. redact.py strips sensitive identifiers. assemble-pack.py generates the evidence pack. create-pr.py opens a GitHub PR for review. Five scripts, orchestrated by run-pipeline.py on Task Scheduler.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Homepage now shows two visually distinct levels of system truth
- **Lab Architecture** (system map): framed container with background wash, topology layout showing Proxmox boundary with hub/satellite nodes, labeled connections
- **AutoSOC Workflow** (process flow): raw/flush 5-stage linear pipeline (intake → triage → redact → pack → escalation), no container frame
- Pipe-diagram SVG updated from 4 to 5 stages (redact and assemble-pack split)
- Different section labels ("Infrastructure" vs "Workflow"), titles, and container treatments

## Test plan
- [ ] Lab Architecture renders as framed system map with subtle background wash
- [ ] AutoSOC Workflow renders as unframed 5-stage process flow
- [ ] Two visuals read as distinct (system map vs process flow)
- [ ] Review Path and Verified Proof Strip unchanged
- [ ] drift_scan.py passes
- [ ] diagnose-site.js --fail-on-issues passes
- [ ] public-safety-scan.ps1 passes
- [ ] Light theme renders correctly for both sections