### PR TITLE
[SITE] Rename flagship to TriageLoop

### DIFF
--- a/docs/execution/AUTOSOC_PIPELINE_INCIDENT_DEBUG_03-13-2026.md
+++ b/docs/execution/AUTOSOC_PIPELINE_INCIDENT_DEBUG_03-13-2026.md
@@ -1,0 +1,278 @@
+# AutoSOC Pipeline Incident Debug - 03-13-2026
+
+- Status: Resolved
+- Scope: AutoSOC live pipeline ingestion failure, reconciliation follow-up, and recovery validation
+- Started: 03-13-2026
+- Resolved: 03-13-2026
+- Owner: Raylee Hawkins
+
+## 1. Summary
+
+This document tracks the investigation, remediation, and validation work for an AutoSOC live pipeline failure observed on 03-13-2026.
+
+Resolved outcome:
+- the live pipeline returned to `SUCCESS`
+- strict reconciliation returned to `PASS`
+- required host coverage returned to `8/8`
+- the strongest pre-failure corpus and published portfolio metrics remained intact throughout the incident
+
+High-level root cause:
+- primary outage cause: infrastructure-side network disruption prevented the poller from reaching the configured indexer endpoint
+- secondary recovery blocker: the reconciliation script was resolving the wrong repo incident path and failed strict validation until corrected
+
+## 2. Pre-Failure Baseline
+
+These are the strongest known pre-failure metrics used as the baseline for recovery validation.
+
+Published portfolio counts:
+- Total detections: `139`
+- Sigma: `103`
+- Wazuh rule blocks: `28`
+- Wazuh XML files: `24`
+- Splunk detections: `8`
+- IR playbooks: `10`
+
+AutoSOC corpus snapshot:
+- Total cases: `25167`
+- Auto-closed benign: `20942`
+- Auto-closed known FP: `1747`
+- Escalated: `2478`
+- Coverage: `6/8` required hosts
+- Processed telemetry files scanned: `35962`
+
+Primary source files:
+- `PROOF_PACK/VERIFIED_COUNTS.md`
+- `content/incidents.json`
+- external AutoSOC output artifacts mirrored from the working environment during validation
+
+## 3. Detection
+
+The outage pattern was visible in the latest AutoSOC heartbeat artifacts and the 03-13-2026 run log.
+
+Observed run pattern:
+- repeated failures every approximately 5 minutes on 03-13-2026
+- fail stage: `poll-alerts`
+- latest confirmed failed run before recovery:
+  - `run_id`: `autosoc-20260313T164401Z-2384`
+  - `start_utc`: `2026-03-13T16:44:01Z`
+  - `end_utc`: `2026-03-13T16:45:39Z`
+  - `status`: `FAILED`
+  - `run_seconds`: `98.575`
+
+Interpretation:
+- the failure occurred before ingestion and case-processing work, which initially pointed to connectivity or service reachability rather than triage logic
+
+## 4. Evidence Collected
+
+### 4.1 Configuration validation
+
+Confirmed from the configured AutoSOC build environment:
+- the poller still had a configured indexer endpoint
+- the poller still had an available username value
+- the poller still had a readable password-file source
+- the alert index configuration was still present
+
+Interpretation:
+- this did not look like a missing-config or missing-secret failure
+
+### 4.2 Poller error
+
+Observed in the 03-13-2026 run log:
+- `RuntimeError: Indexer connection error after 4 attempts`
+- underlying error: `WinError 10060`
+- failure description: connection attempt timed out because the remote host did not respond
+
+Interpretation:
+- this pointed to connectivity or service availability, not unit-test failure or triage-policy failure
+
+### 4.3 Connectivity checks from the runner
+
+Observed during debugging:
+- endpoint name resolution succeeded
+- direct TCP connectivity to the configured indexer endpoint timed out
+- the runner still retained general internet connectivity
+- the runner still retained mesh-VPN control-plane connectivity
+
+Interpretation:
+- this did not look like a total loss of network on the runner
+- the failure was more consistent with a remote-node reachability problem, a remote service outage, or a broken path between the runner and the indexer endpoint
+
+### 4.4 Infrastructure-side validation
+
+Follow-up validation after network recovery showed:
+- the previously unreachable remote endpoint became reachable again
+- a standalone poller run completed successfully
+- the poller continued to use the expected password-file source
+- the poller returned `POLLED=0` and `NO_NEW_ALERTS=TRUE`, which indicated a healthy path with no new events rather than a failed path
+
+Interpretation:
+- the original blocker was infrastructure-side network reachability, not the Python polling logic itself
+
+## 5. Working Theory and Confirmation
+
+Confirmed fault chain:
+1. infrastructure-side network disruption broke the poller-to-indexer path
+2. once connectivity was restored, the poller recovered
+3. the next blocker surfaced in `reconcile`, where strict validation failed because the script was checking the wrong repo incident path
+
+This sequence matters because it separates the incident into two different classes of failure:
+- an infrastructure outage that blocked ingestion
+- a code-path bug in reconciliation that was only visible after ingestion recovered
+
+## 6. Steps Taken
+
+Completed investigation steps:
+- verified latest heartbeat failure state
+- verified repeated failure pattern in heartbeat history
+- verified fail stage was `poll-alerts`
+- verified configured secret file was present and readable
+- verified the indexer endpoint remained configured
+- verified runner-side network was not fully down
+- verified direct TCP timeout to the configured indexer endpoint
+- restored the upstream network path
+- re-ran `poll-alerts.py` by itself after connectivity recovery
+- re-ran the full pipeline after poller recovery
+- inspected reconciliation logic after the pipeline progressed beyond polling
+- corrected the reconciliation repo path logic
+- re-ran strict reconciliation after the patch
+- re-ran the full pipeline after the reconciliation fix
+
+## 7. Reconciliation Fix
+
+Follow-up debugging confirmed that the reconciliation failure was not caused by missing published incidents or ledger corruption.
+
+Actual issue:
+- the reconciliation script was checking the wrong repo incident path
+- published incident content still existed and was aligned with the ledger and content index
+
+Action taken:
+- updated `reconcile-state.py` to resolve incidents from the actual repo content path first
+- preserved fallback behavior for the legacy non-content path shape
+
+Post-fix reconciliation evidence:
+- `MISMATCH_COUNT=0`
+- `ledger_total_cases=25167`
+- `ledger_escalated_metric=2478`
+- `repo_incident_dirs=2480`
+- `repo_incident_dirs_autosoc_scoped=2478`
+- `content_incidents=2478`
+
+Interpretation:
+- strict reconciliation now passes
+- the published incident inventory and the internal escalation inventory are aligned again
+
+## 8. Recovery Validation
+
+Standalone poller validation after network recovery:
+- poller completed successfully
+- `SECRET_SOURCE=PASS_FILE`
+- `MODE=realtime`
+- `POLLED=0`
+- `SAVED=0`
+- `NO_NEW_ALERTS=TRUE`
+
+Final post-fix pipeline validation:
+- `run_id`: `autosoc-20260313T183711Z-20032`
+- `start_utc`: `2026-03-13T18:37:11Z`
+- `end_utc`: `2026-03-13T18:39:38Z`
+- `duration_seconds`: `146.505`
+- `status`: `SUCCESS`
+- `fail_stage`: blank
+- `cases_scanned`: `25167`
+- `cases_processed`: `0`
+- `reconciliation.status`: `PASS`
+- `reconciliation.mismatch_count`: `0`
+
+Recovered run timings:
+- `tests`: `0.189s`
+- `poll_alerts`: `0.264s`
+- `triage`: `0.174s`
+- `triage_quality`: `15.780s`
+- `triage_quality_chart`: `0.852s`
+- `cases_processing`: `3.808s`
+- `reconcile`: `0.427s`
+- `coverage_check`: `123.624s`
+
+Current state after recovery:
+- the original `poll-alerts` outage is resolved
+- the pipeline completes end-to-end successfully
+- strict reconciliation is repaired and passing
+- required host coverage has returned to full parity
+
+Final validation run after host coverage recovery:
+- `run_id`: `autosoc-20260313T215029Z-31020`
+- `start_utc`: `2026-03-13T21:50:29Z`
+- `end_utc`: `2026-03-13T21:51:01Z`
+- `duration_seconds`: `31.843`
+- `status`: `SUCCESS`
+- `cases_scanned`: `26032`
+- `cases_processed`: `173`
+- `reconciliation.status`: `PASS`
+- `reconciliation.mismatch_count`: `0`
+- `freshness.status`: `PASS`
+- `coverage.status`: `PASS`
+- `coverage.present_hosts`: `8`
+- `coverage.missing_hosts`: `0`
+- `required_coverage_percent`: `100.0`
+
+Recovered host coverage:
+- `ho-fs-01`
+- `HO-GPU-01`
+- `HO-GRAFANA-01`
+- `HO-HONEYPOT-01`
+- `HO-LM-01`
+- `HO-RUNNER-01`
+- `HO-WAZUH-01`
+- `HO-WE-01`
+
+Final interpretation:
+- the platform recovered from ingestion failure to full end-to-end health
+- reconciliation, freshness, and host coverage all returned to `PASS`
+- the last blocker was not a Proxmox or Windows-side pipeline issue; it was delayed arrival of fresh Honeypot alerts into the processed coverage window
+
+## 9. Interview-Safe Explanation
+
+The strongest concise explanation is:
+
+"The high-volume stable corpus was generated during the successful March 2 to March 4 operating window. On March 13, 2026, a network-path issue prevented the poller from reaching the indexer endpoint, which caused repeated scheduled ingestion failures. After restoring connectivity, I found and fixed a separate reconciliation path bug, revalidated strict reconciliation at zero mismatches, and returned the full pipeline to a successful end-to-end state."
+
+## 10. Lessons Learned
+
+- split infrastructure availability metrics from case-processing quality metrics so one outage does not distort the entire story
+- keep a standalone poller validation step available for fast fault-domain isolation
+- treat reconciliation as a separate control-plane check, because it can fail independently after ingestion recovers
+- keep public incident write-ups sanitized while preserving exact operational evidence in the private working environment
+
+## 11. Update Log
+
+### 03-13-2026 Initial Entry
+
+Added initial incident record with:
+- pre-failure baseline metrics
+- failure detection timestamps
+- poller configuration validation
+- timeout evidence
+- runner-side connectivity findings
+- recovery plan and validation criteria
+
+### 03-13-2026 Network Recovery
+
+Added recovery evidence showing:
+- the remote endpoint became reachable again
+- standalone polling completed successfully
+- the pipeline advanced past `poll-alerts`
+
+### 03-13-2026 Reconciliation Fix and Final Recovery
+
+Added final recovery evidence showing:
+- reconciliation path logic was corrected
+- strict reconciliation returned `MISMATCH_COUNT=0`
+- the full pipeline returned to `SUCCESS`
+
+### 03-13-2026 Coverage Closure
+
+Added final validation showing:
+- fresh Honeypot manager alerts were confirmed
+- Windows-side poll and pipeline reruns pulled the remaining host into processed coverage
+- required host coverage returned to `8/8`
+- final heartbeat reported `SUCCESS`, `reconciliation=PASS`, `freshness=PASS`, and `coverage=PASS`

--- a/docs/execution/AUTOSOC_PIPELINE_RECOVERY_CASE_STUDY_03-13-2026.md
+++ b/docs/execution/AUTOSOC_PIPELINE_RECOVERY_CASE_STUDY_03-13-2026.md
@@ -1,0 +1,136 @@
+# AutoSOC Pipeline Recovery Case Study
+
+Date: 2026-03-13
+Status: CLOSED
+Scope: live pipeline outage investigation, recovery, and validation
+
+## Executive Outcome
+
+- Restored a failed AutoSOC live pipeline to full end-to-end `SUCCESS`.
+- Isolated the original outage to infrastructure-side connectivity, not triage logic or secret handling.
+- Identified and fixed a second reconciliation-path bug that only surfaced after ingestion recovered.
+- Revalidated strict reconciliation at `MISMATCH_COUNT=0`.
+- Restored required host telemetry coverage to `8/8`.
+
+## Why This Matters
+
+This project is not a static portfolio mock-up. It is an operating SOC workflow with real pipeline health, control-plane checks, and recovery work. The value of this incident is that it demonstrates fault isolation, debugging discipline, and recovery validation under production-like conditions.
+
+## Starting State
+
+Pre-failure validated system metrics:
+- Total detections: `139`
+- Sigma rules: `103`
+- Wazuh rule blocks: `28`
+- Splunk detections: `8`
+- IR playbooks: `10`
+- Total AutoSOC cases: `25167`
+- Auto-closed benign: `20942`
+- Auto-closed known FP: `1747`
+- Escalated: `2478`
+
+## Problem
+
+On 2026-03-13, scheduled AutoSOC runs were repeatedly failing in `poll-alerts`.
+
+Initial signals:
+- repeated run failures at roughly 5-minute intervals
+- timeout behavior before ingestion and case processing
+- no evidence of a unit-test regression
+- no evidence of missing configuration or missing secret material
+
+## Investigation Approach
+
+The investigation was handled in stages:
+
+1. Validate the failure location.
+- Confirmed the pipeline was failing in `poll-alerts`, before triage and case processing.
+
+2. Rule out obvious configuration drift.
+- Confirmed the poller still had a configured endpoint, user value, and readable password-file source.
+
+3. Separate local runner health from remote endpoint reachability.
+- Confirmed the runner still had general network connectivity.
+- Confirmed direct endpoint connectivity was timing out.
+
+4. Restore the network path first.
+- After upstream connectivity was corrected, the poller completed successfully.
+
+5. Re-run the full pipeline and continue debugging.
+- Once polling recovered, a second failure surfaced in `reconcile`.
+
+6. Fix the reconciliation bug.
+- Found that the reconciliation script was resolving the wrong repo incident path.
+- Patched the script to resolve the actual content path first, with fallback for the legacy layout.
+
+## Root Cause
+
+Primary cause:
+- infrastructure-side network disruption prevented the poller from reaching the configured indexer endpoint
+
+Secondary cause:
+- reconciliation script path resolution did not match the current repo layout, which caused strict validation to fail even after polling recovered
+
+## Fix
+
+Actions taken:
+- restored the network path required for the poller-to-indexer connection
+- revalidated standalone polling
+- patched `reconcile-state.py` to use the correct repo incident path
+- re-ran strict reconciliation
+- re-ran the full pipeline end to end
+
+## Validation
+
+Standalone poller validation after network recovery:
+- `SECRET_SOURCE=PASS_FILE`
+- `MODE=realtime`
+- `POLLED=0`
+- `SAVED=0`
+- `NO_NEW_ALERTS=TRUE`
+
+Strict reconciliation validation after code fix:
+- `ledger_total_cases=25167`
+- `ledger_escalated_metric=2478`
+- `repo_incident_dirs_autosoc_scoped=2478`
+- `content_incidents=2478`
+- `MISMATCH_COUNT=0`
+
+Final pipeline recovery run:
+- `run_id`: `autosoc-20260313T183711Z-20032`
+- `status`: `SUCCESS`
+- `duration_seconds`: `146.505`
+- `cases_scanned`: `25167`
+- `cases_processed`: `0`
+- `reconciliation.status`: `PASS`
+- `reconciliation.mismatch_count`: `0`
+
+Final platform-health validation after coverage closure:
+- `run_id`: `autosoc-20260313T215029Z-31020`
+- `status`: `SUCCESS`
+- `duration_seconds`: `31.843`
+- `cases_scanned`: `26032`
+- `cases_processed`: `173`
+- `reconciliation.status`: `PASS`
+- `reconciliation.mismatch_count`: `0`
+- `freshness.status`: `PASS`
+- `coverage.status`: `PASS`
+- `coverage.present_hosts`: `8`
+- `coverage.missing_hosts`: `0`
+- `required_coverage_percent`: `100.0`
+
+## What This Demonstrates
+
+- Evidence-driven debugging instead of guesswork
+- Ability to separate infrastructure failures from application logic failures
+- Control-plane validation through reconciliation, not just “it runs on my machine”
+- Recovery verification with exact metrics and post-fix reruns
+- Ability to drive an unstable system all the way back to full host coverage, not just partial service restoration
+
+## Interview-Safe Summary
+
+"I diagnosed an AutoSOC live-ingestion outage by isolating the failure to network reachability rather than triage logic, restored polling, then fixed a separate reconciliation path bug that surfaced during retest. The final validation runs returned the pipeline to `SUCCESS`, strict reconciliation to zero mismatches, and required host coverage to `8/8`."
+
+## Related Document
+
+- Detailed incident report: `docs/execution/AUTOSOC_PIPELINE_INCIDENT_DEBUG_03-13-2026.md`

--- a/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md
+++ b/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md
@@ -1,0 +1,35 @@
+# AutoSOC Pipeline Recovery Public Snippets
+
+Date: 2026-03-13
+Status: Ready for reuse
+Scope: recruiter-safe copy derived from the AutoSOC recovery case study
+
+## Site Blurb
+
+Diagnosed and restored a failed AutoSOC live-ingestion pipeline by separating infrastructure reachability issues from application logic, then fixing a second reconciliation-path bug uncovered during retest. Final validation returned the pipeline to `SUCCESS` with strict reconciliation back to `MISMATCH_COUNT=0` and required host coverage restored to `8/8`, while preserving a validated corpus of `25167` cases and `2478` escalations.
+
+## Short Site Variant
+
+Recovered an AutoSOC ingestion outage, fixed a follow-on reconciliation bug, and returned the pipeline to `SUCCESS` with zero reconciliation mismatches and `8/8` required host coverage.
+
+## Resume Bullets
+
+- Diagnosed and restored a SOC automation pipeline by isolating a live-ingestion outage to infrastructure reachability rather than triage logic, then validating full end-to-end recovery.
+- Fixed reconciliation-path logic in AutoSOC governance checks, returning strict validation to `MISMATCH_COUNT=0` and aligning `2478` published escalation artifacts with the case ledger.
+- Operated and validated an AutoSOC corpus of `25167` cases, including `20942` benign auto-closures, `1747` known-false-positive closures, and `2478` escalations.
+
+## Interview Version
+
+I treated it as two separate failures. First, I proved the poller issue was a connectivity problem instead of a Python or secrets problem. After restoring that path, the pipeline advanced far enough to expose a second bug in reconciliation, where the script was checking the wrong repo incident path. I patched that, reran strict reconciliation to zero mismatches, and then reran the full pipeline successfully.
+
+## Safe Metrics To Reuse
+
+- Total detections: `139`
+- IR playbooks: `10`
+- Total AutoSOC cases: `25167`
+- Auto-closed benign: `20942`
+- Auto-closed known FP: `1747`
+- Escalated: `2478`
+- Final recovery run status: `SUCCESS`
+- Final reconciliation mismatch count: `0`
+- Final required host coverage: `8/8`

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -95,6 +95,33 @@
     });
   }
 
+  function formatMetricValue(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return new Intl.NumberFormat('en-US').format(value);
+    }
+    return value;
+  }
+
+  function applyOpsMetricsPayload(payload) {
+    if (!payload || typeof payload !== 'object') return;
+    var metrics = payload.metrics && typeof payload.metrics === 'object' ? payload.metrics : payload;
+    $$('[data-ops]').forEach(function (node) {
+      var key = node.getAttribute('data-ops');
+      var value = key ? metrics[key] : null;
+      if ((typeof value === 'number' && Number.isFinite(value)) || (typeof value === 'string' && value.trim())) {
+        node.textContent = String(formatMetricValue(value));
+      }
+    });
+    $$('[data-ops-status]').forEach(function (node) {
+      var key = node.getAttribute('data-ops-status');
+      var value = key ? metrics[key] : null;
+      if (typeof value === 'string' && value.trim()) {
+        node.textContent = value;
+        node.setAttribute('data-status', value.toLowerCase());
+      }
+    });
+  }
+
   async function loadVerifiedCounts() {
     if (window.HAWKINSOPS_COUNTS && typeof window.HAWKINSOPS_COUNTS === 'object') {
       applyVerifiedPayload(window.HAWKINSOPS_COUNTS);
@@ -107,6 +134,12 @@
       applyVerifiedPayload(payload);
     } catch {
       // keep existing values if the payload is unavailable
+    }
+  }
+
+  function loadOpsMetrics() {
+    if (window.HAWKINSOPS_OPS_METRICS && typeof window.HAWKINSOPS_OPS_METRICS === 'object') {
+      applyOpsMetricsPayload(window.HAWKINSOPS_OPS_METRICS);
     }
   }
 
@@ -278,6 +311,7 @@
   }
 
   loadVerifiedCounts();
+  loadOpsMetrics();
   hydrateLabScreenshots();
 
   // DEV-only overflow detector: local hosts only.

--- a/site/assets/modernize.css
+++ b/site/assets/modernize.css
@@ -324,6 +324,25 @@ img {
   margin-top: 18px;
 }
 
+.m-hero-signals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.m-hero-signal {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 82%, var(--primary-50) 18%);
+  border: 1px solid color-mix(in srgb, var(--primary-700) 18%, var(--border));
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text);
+}
+
 .m-card,
 .m-panel,
 .m-stat,
@@ -924,6 +943,30 @@ img {
   color: var(--primary-300);
 }
 
+.m-ops-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.m-ops-header h2 {
+  margin: 8px 0 6px;
+}
+
+.m-ops-status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--primary-50) 80%, var(--surface) 20%), var(--surface));
+  border: 1px solid color-mix(in srgb, var(--primary-700) 22%, var(--border));
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--primary-700);
+}
+
 .m-impact-band h2,
 .m-impact-band p {
   color: #f8fafc;
@@ -1025,6 +1068,19 @@ img {
   border-radius: var(--radius-lg);
   background: var(--surface);
   box-shadow: var(--shadow-sm);
+}
+
+.m-stage-workflow .m-stage-surface,
+.m-stage-overview .m-flow-card,
+.m-stage-topology .m-stage-surface,
+.m-stage-outputs .m-output-card,
+.m-stage-outputs .m-shot-frame {
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+}
+
+.m-stage-workflow .m-stage-surface:first-child {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface) 80%, #dbeafe 20%), var(--surface));
 }
 
 .m-callout h3 {
@@ -1171,6 +1227,15 @@ img {
   grid-column: 1 / -1;
 }
 
+.m-lab-intro {
+  margin-top: 18px;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface) 88%, var(--primary-50) 12%), var(--surface));
+}
+
 .lane-card {
   border-color: color-mix(in srgb, var(--primary-700) 16%, var(--bdr, rgba(17, 24, 39, 0.08)));
   background:
@@ -1256,6 +1321,11 @@ img {
   .m-next-grid,
   .m-lab-wall {
     grid-template-columns: 1fr;
+  }
+
+  .m-ops-header {
+    flex-direction: column;
+    align-items: start;
   }
 
   .m-title {

--- a/site/assets/modernize.css
+++ b/site/assets/modernize.css
@@ -198,6 +198,20 @@ img {
   color: var(--neutral-900);
 }
 
+.m-cta-dominant {
+  background: linear-gradient(135deg, var(--accent-500), #fb923c);
+  color: var(--neutral-900);
+  box-shadow: 0 16px 30px rgba(249, 115, 22, 0.22);
+  padding: 16px 24px;
+  min-width: 156px;
+  font-size: 1rem;
+}
+
+.m-cta-dominant:hover {
+  background: linear-gradient(135deg, var(--accent-700), var(--accent-500));
+  color: #fff;
+}
+
 .m-section {
   padding: 40px 0 56px;
 }
@@ -246,6 +260,11 @@ img {
 .m-stage-next .m-card {
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--surface) 92%, var(--surface-soft) 8%), var(--surface));
+}
+
+.m-stage-impact .m-wrap,
+.m-stage-ops .m-wrap {
+  position: relative;
 }
 
 .m-hero {
@@ -317,6 +336,8 @@ img {
 
 .m-panel {
   overflow: hidden;
+  border-color: color-mix(in srgb, var(--primary-700) 18%, var(--border));
+  box-shadow: 0 26px 56px rgba(15, 23, 42, 0.14);
 }
 
 .m-panel-head {
@@ -327,6 +348,11 @@ img {
   letter-spacing: 0.06em;
   color: var(--text-soft);
   text-transform: uppercase;
+}
+
+.m-hero .m-panel-head {
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--primary-50) 78%, var(--surface) 22%), var(--surface));
 }
 
 .m-panel-body {
@@ -876,6 +902,123 @@ img {
   align-items: start;
 }
 
+.m-impact-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 22px;
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(circle at top right, rgba(20, 184, 166, 0.18), transparent 30%),
+    linear-gradient(135deg, #0b1220 0%, #111827 58%, #102235 100%);
+  box-shadow: var(--shadow-lg);
+  color: #f8fafc;
+}
+
+.m-impact-band .m-frame-body {
+  padding: 18px;
+}
+
+.m-card-kicker-invert {
+  color: var(--primary-300);
+}
+
+.m-impact-band h2,
+.m-impact-band p {
+  color: #f8fafc;
+}
+
+.m-impact-band .m-copy,
+.m-impact-band .m-frame-caption,
+.m-impact-point span {
+  color: #cbd5e1;
+}
+
+.m-impact-points {
+  display: grid;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.m-impact-point {
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.48);
+}
+
+.m-impact-point strong,
+.m-impact-point span {
+  display: block;
+}
+
+.m-impact-point span {
+  margin-top: 4px;
+  font-size: 0.94rem;
+}
+
+.m-impact-band .m-terminal {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: #08111f;
+}
+
+.m-frame-caption-invert {
+  color: #cbd5e1;
+}
+
+.m-ops-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.m-ops-card {
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface) 72%, var(--primary-50) 28%), var(--surface));
+  box-shadow: var(--shadow-md);
+}
+
+.m-ops-card:first-child {
+  grid-column: span 2;
+}
+
+.m-ops-card:first-child .m-ops-value {
+  font-size: clamp(1.9rem, 3.4vw, 2.8rem);
+}
+
+.m-ops-value {
+  font-family: var(--font-mono);
+  font-size: clamp(1.4rem, 2.6vw, 1.9rem);
+  color: var(--text);
+}
+
+.m-ops-value[data-status="pass"] {
+  color: var(--primary-700);
+}
+
+.m-ops-value[data-status="fail"] {
+  color: var(--accent-700);
+}
+
+.m-ops-label {
+  margin-top: 10px;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary-700);
+}
+
+.m-ops-copy {
+  margin-top: 8px;
+  color: var(--text-soft);
+  font-size: 0.92rem;
+}
+
 .m-callout {
   padding: 18px;
   border: 1px solid var(--border);
@@ -1017,6 +1160,34 @@ img {
   gap: 16px;
 }
 
+.m-lab-wall {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 20px;
+}
+
+.m-lab-wall .m-shot-frame:first-child {
+  grid-column: 1 / -1;
+}
+
+.lane-card {
+  border-color: color-mix(in srgb, var(--primary-700) 16%, var(--bdr, rgba(17, 24, 39, 0.08)));
+  background:
+    radial-gradient(circle at top right, rgba(20, 184, 166, 0.08), transparent 32%),
+    linear-gradient(145deg, rgba(7, 15, 28, 0.98), rgba(10, 19, 33, 0.94));
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.18);
+}
+
+.lane-card .card-ttl {
+  color: #eef2ff;
+}
+
+.lane-card .card-sub,
+.lane-card .lane-cta {
+  color: #cbd5e1;
+}
+
 @media (max-width: 1024px) {
   .m-hero-grid,
   .m-project-grid,
@@ -1028,12 +1199,15 @@ img {
   .m-gallery,
   .m-step-grid,
   .m-flow-grid,
+  .m-impact-band,
+  .m-ops-grid,
   .m-split-callout,
   .m-evidence-grid,
   .m-depth-grid,
   .m-artifact-grid,
   .m-packet-grid,
-  .m-next-grid {
+  .m-next-grid,
+  .m-lab-wall {
     grid-template-columns: 1fr 1fr;
   }
 
@@ -1072,12 +1246,15 @@ img {
   .m-gallery,
   .m-step-grid,
   .m-flow-grid,
+  .m-impact-band,
+  .m-ops-grid,
   .m-split-callout,
   .m-evidence-grid,
   .m-depth-grid,
   .m-artifact-grid,
   .m-packet-grid,
-  .m-next-grid {
+  .m-next-grid,
+  .m-lab-wall {
     grid-template-columns: 1fr;
   }
 
@@ -1092,6 +1269,10 @@ img {
   .m-cta {
     padding: 12px 14px;
     font-size: 0.95rem;
+  }
+
+  .m-cta-dominant {
+    min-width: 0;
   }
 
   .m-proof-strip {
@@ -1127,5 +1308,10 @@ img {
   .m-packet-step,
   .m-evidence-note {
     padding: 18px;
+  }
+
+  .m-ops-card:first-child,
+  .m-lab-wall .m-shot-frame:first-child {
+    grid-column: auto;
   }
 }

--- a/site/case-study-autosoc.html
+++ b/site/case-study-autosoc.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <html lang="en">
 <head>
-<title>HawkinsOps | AutoSOC Case Study</title>
-<meta name="description" content="AutoSOC pipeline case study: architecture, rootcheck tuning, and repo-backed incident pack outputs with reproducible proof links.">
+<title>HawkinsOps | TriageLoop Case Study</title>
+<meta name="description" content="TriageLoop pipeline case study: architecture, workflow, decision logic, and repo-backed incident pack outputs with reproducible proof links.">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#07070b">
 <link rel="canonical" href="https://hawkinsops.com/case-study-autosoc">
 <meta property="og:type" content="article">
-<meta property="og:title" content="AutoSOC Case Study | Closed-Loop Alert Pipeline">
-<meta property="og:description" content="What AutoSOC is, how the pipeline is wired, rootcheck tuning results, and artifact outputs linked to proof lanes.">
+<meta property="og:title" content="TriageLoop Case Study | Closed-Loop Alert Pipeline">
+<meta property="og:description" content="What TriageLoop is, how the pipeline is wired, and how its outputs connect to proof lanes.">
 <meta property="og:url" content="https://hawkinsops.com/case-study-autosoc">
 <meta property="og:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
 <meta property="og:image:width" content="1600">
 <meta property="og:image:height" content="900">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="AutoSOC Case Study | Closed-Loop Alert Pipeline">
-<meta name="twitter:description" content="Architecture, rootcheck tuning, and repo-backed incident pack outputs for AutoSOC.">
+<meta name="twitter:title" content="TriageLoop Case Study | Closed-Loop Alert Pipeline">
+<meta name="twitter:description" content="Architecture, workflow, and repo-backed incident pack outputs for TriageLoop.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
 <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
@@ -43,20 +43,20 @@
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
       <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Case Study</a></li>
+      <li><a href="/case-study-autosoc">TriageLoop Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
       <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read AutoSOC</a>
+    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read TriageLoop</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
   <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">AutoSOC Case Study</a>
+  <a href="/case-study-autosoc">TriageLoop Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
@@ -69,15 +69,22 @@
   <div class="m-wrap m-rail-layout">
     <div>
       <div class="m-eyebrow">Flagship case study</div>
-      <h1 class="m-title" style="font-size: clamp(2.3rem, 4vw, 3.9rem);">AutoSOC: alert ingestion to escalation artifacts</h1>
+      <h1 class="m-title" style="font-size: clamp(2.3rem, 4vw, 3.9rem);">TriageLoop: alert ingestion to escalation artifacts</h1>
       <p class="m-outcome">A SOAR-style Tier-1 triage workflow for Wazuh alerts with policy-based dispositions, mandatory redaction, and evidence packs that end as reviewable GitHub escalation artifacts.</p>
       <div class="m-actions">
-        <a class="m-cta m-cta-primary" href="/proof">Review proof</a>
-        <a class="m-cta m-cta-accent" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open repo</a>
+        <a class="m-cta m-cta-dominant" href="/modernize/demo.html">Run Demo</a>
+        <a class="m-cta m-cta-primary" href="/proof">Review Proof</a>
+        <a class="m-cta m-cta-accent" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
         <a class="m-cta m-cta-secondary" href="/projects">Browse projects</a>
       </div>
+      <div class="m-hero-signals">
+        <span class="m-hero-signal">Overview</span>
+        <span class="m-hero-signal">Workflow</span>
+        <span class="m-hero-signal">Outputs</span>
+        <span class="m-hero-signal">Proof</span>
+      </div>
 
-      <div class="m-kpi-grid" aria-label="AutoSOC proof metrics">
+      <div class="m-kpi-grid" aria-label="TriageLoop proof metrics">
         <article class="m-kpi">
           <div class="m-kpi-value"><span data-verified="detections">139</span></div>
           <div class="m-kpi-label">Detection context</div>
@@ -96,7 +103,7 @@
         <article class="m-kpi">
           <div class="m-kpi-value"><span data-verified-date>02-26-2026</span></div>
           <div class="m-kpi-label">Last verified</div>
-          <p class="m-kpi-copy">Counts and proof links stay tied to the same repository verification model used elsewhere on the site.</p>
+        <p class="m-kpi-copy">Counts and proof links stay tied to the same repository verification model used elsewhere on the site.</p>
         </article>
       </div>
     </div>
@@ -146,7 +153,7 @@
       <article class="m-flow-card">
         <div class="m-flow-step">2</div>
         <h3>System response</h3>
-        <p class="m-copy">AutoSOC applies disposition logic, runs a mandatory redaction gate, and packages the result as reviewable evidence.</p>
+        <p class="m-copy">TriageLoop applies disposition logic, runs a mandatory redaction gate, and packages the result as reviewable evidence.</p>
       </article>
       <article class="m-flow-card">
         <div class="m-flow-step">3</div>
@@ -160,34 +167,46 @@
 <section class="m-section m-stage m-stage-topology">
   <div class="m-wrap">
     <div class="m-divider-title">
-      <div class="m-card-kicker">Topology + workflow</div>
+      <div class="m-card-kicker">Topology / architecture</div>
     </div>
     <div class="m-evidence-note" style="margin-bottom:18px;">
       <div class="m-card-kicker">Inspection stage</div>
-      <h3>Separate environment from sequence</h3>
-      <p>The first surface explains the environment and control points. The second shows the alert-to-artifact sequence. Keeping those jobs separate makes the system feel denser and easier to inspect.</p>
+      <h3>Start with the system map</h3>
+      <p>This stage exists to explain the environment and control points before the page asks the reviewer to think about movement, logic, or outputs.</p>
     </div>
-    <div class="m-evidence-grid">
-      <div class="m-diagram-frame">
-        <div class="m-frame-head">
-          <span class="m-frame-title">System relationships</span>
-          <span class="m-frame-tag">Architecture</span>
-        </div>
-        <div class="m-frame-body">
-          <img src="/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1" alt="AutoSOC architecture map showing sources, pipeline gates, and output controls" width="1600" height="900" loading="eager">
-          <p class="m-frame-caption">This view explains the environment and control points: where alerts enter, where policy gates apply, and where reviewable outputs are assembled.</p>
-        </div>
+    <div class="m-diagram-frame m-stage-surface">
+      <div class="m-frame-head">
+        <span class="m-frame-title">System relationships</span>
+        <span class="m-frame-tag">Architecture</span>
       </div>
+      <div class="m-frame-body">
+        <img src="/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1" alt="TriageLoop architecture map showing sources, pipeline gates, and output controls" width="1600" height="900" loading="eager">
+        <p class="m-frame-caption">This view explains the environment and control points: where alerts enter, where policy gates apply, and where reviewable outputs are assembled.</p>
+      </div>
+    </div>
+  </div>
+</section>
 
-      <div class="m-diagram-frame">
+<section class="m-section m-stage m-stage-workflow">
+  <div class="m-wrap">
+    <div class="m-divider-title">
+      <div class="m-card-kicker">Workflow</div>
+    </div>
+    <div class="m-grid-2 m-stage-stagegrid">
+      <div class="m-diagram-frame m-stage-surface">
         <div class="m-frame-head">
           <span class="m-frame-title">Workflow sequence</span>
           <span class="m-frame-tag">Pipeline</span>
         </div>
         <div class="m-frame-body">
-          <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg" alt="AutoSOC workflow diagram showing poll, triage, redact, pack, and pull request creation" width="1200" height="240" loading="lazy">
+          <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg" alt="TriageLoop workflow diagram showing poll, triage, redact, pack, and pull request creation" width="1200" height="240" loading="lazy">
           <p class="m-frame-caption">This narrower view reduces the workflow to the steps a reviewer needs to understand quickly: ingest, decide, redact, package, and escalate.</p>
         </div>
+      </div>
+      <div class="m-evidence-note m-stage-surface">
+        <div class="m-card-kicker">Inspection stage</div>
+        <h3>Then inspect movement</h3>
+        <p>This is the point where the page stops describing architecture and starts showing how alerts move through reviewable pipeline states. That separation is what turns the page into a packet instead of a document.</p>
       </div>
     </div>
   </div>
@@ -198,7 +217,7 @@
     <article class="m-callout">
       <div class="m-card-kicker">Decision logic</div>
       <h3>Deterministic dispositions</h3>
-      <p class="m-subtitle">AutoSOC uses explicit dispositions to keep triage behavior reviewable and reproducible.</p>
+      <p class="m-subtitle">TriageLoop uses explicit dispositions to keep triage behavior reviewable and reproducible.</p>
       <div style="overflow-x:auto;margin-top:14px">
         <table style="width:100%;border-collapse:collapse;font-size:.94rem">
           <thead>
@@ -253,7 +272,7 @@
           <h3>Named outputs, not generic artifacts</h3>
           <p>This is where the project becomes reviewable engineering work. The files, terminal output, and screenshot are presented as connected evidence from the same pipeline stage.</p>
         </div>
-        <div class="m-artifact-grid" aria-label="Representative AutoSOC artifact outputs">
+        <div class="m-artifact-grid" aria-label="Representative TriageLoop artifact outputs">
           <div class="m-artifact">
             <strong>00_one_pager.md</strong>
             <span>Label: intake summary. Purpose: orient the reviewer quickly. Pipeline relation: first output after triage and redaction.</span>
@@ -290,7 +309,7 @@ outcome: reduced false-positive pressure while preserving escalation path</pre>
         <span class="m-frame-tag">Screenshot</span>
       </div>
       <div class="m-frame-body">
-        <img src="/assets/pp_soc_integration/t3-workflow.png" alt="AutoSOC workflow screenshot from the project gallery" width="1334" height="750" loading="lazy">
+        <img src="/assets/pp_soc_integration/t3-workflow.png" alt="TriageLoop workflow screenshot from the project gallery" width="1334" height="750" loading="lazy">
         <p class="m-frame-caption">Label: workflow evidence capture. Purpose: give the reviewer a visual counterpart to the architecture and terminal output. Pipeline relation: demonstrates the operational surface that produces the named artifacts.</p>
       </div>
     </article>
@@ -336,7 +355,7 @@ outcome: reduced false-positive pressure while preserving escalation path</pre>
         </a>
         <a href="/projects" class="m-link-item">
           <strong>Return to projects</strong>
-          <span>Use AutoSOC as the flagship entry point, then compare it against the rest of the portfolio.</span>
+          <span>Use TriageLoop as the flagship entry point, then compare it against the rest of the portfolio.</span>
         </a>
         <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="m-link-item">
           <strong>Inspect the repository</strong>

--- a/site/case-study-autosoc.html
+++ b/site/case-study-autosoc.html
@@ -100,11 +100,11 @@
           <div class="m-kpi-label">Playbook coverage</div>
           <p class="m-kpi-copy">Escalation outputs are backed by documented IR procedures instead of undocumented analyst habit.</p>
         </article>
-        <article class="m-kpi">
-          <div class="m-kpi-value"><span data-verified-date>02-26-2026</span></div>
+      <article class="m-kpi">
+        <div class="m-kpi-value"><span data-verified-date>02-26-2026</span></div>
           <div class="m-kpi-label">Last verified</div>
         <p class="m-kpi-copy">Counts and proof links stay tied to the same repository verification model used elsewhere on the site.</p>
-        </article>
+      </article>
       </div>
     </div>
 
@@ -139,6 +139,17 @@
         </ul>
       </section>
     </aside>
+  </div>
+</section>
+
+<section class="m-section m-stage">
+  <div class="m-wrap">
+    <div class="m-evidence-note m-stage-surface">
+      <div class="m-card-kicker">Reliability / recovery</div>
+      <h3>Operational recovery is part of the project signal</h3>
+      <p>This workflow was also used to diagnose and recover a live ingestion outage. The investigation separated infrastructure reachability from application logic, restored polling, then fixed a reconciliation-path bug uncovered during retest. Final validation returned the pipeline to <span class="m-inline-code">SUCCESS</span> with strict reconciliation back to <span class="m-inline-code">MISMATCH_COUNT=0</span>.</p>
+      <p><a href="/proof" class="m-cta m-cta-secondary">Review proof path</a></p>
+    </div>
   </div>
 </section>
 

--- a/site/data/ops-metrics.js
+++ b/site/data/ops-metrics.js
@@ -1,0 +1,12 @@
+window.HAWKINSOPS_OPS_METRICS = {
+  generated_at_utc: "2026-03-04T21:32:56Z",
+  source_note: "Canonical OPS progress snapshot dated 03-04-2026.",
+  metrics: {
+    case_directories: 25167,
+    auto_closed_benign: 20942,
+    escalated: 2478,
+    reconciliation: "PASS",
+    coverage_ratio: "6/8",
+    coverage_status: "FAIL"
+  }
+};

--- a/site/index.html
+++ b/site/index.html
@@ -48,20 +48,20 @@
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
       <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Case Study</a></li>
+      <li><a href="/case-study-autosoc">TriageLoop Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
       <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read AutoSOC</a>
+    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read TriageLoop</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
   <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">AutoSOC Case Study</a>
+  <a href="/case-study-autosoc">TriageLoop Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
@@ -75,21 +75,26 @@
   <div class="m-wrap m-hero-grid">
     <div>
       <div class="m-badge">Evidence-first SOC portfolio</div>
-      <h1 class="m-title">AutoSOC proves practical SOC engineering.</h1>
-      <p class="m-outcome">Closed-loop alert triage, public proof, and a runnable demo path presented as one flagship engineering system.</p>
+      <h1 class="m-title">TriageLoop proves practical SOC engineering.</h1>
+      <p class="m-outcome">Closed-loop alert triage, public proof, and a runnable demo path presented as one flagship engineering system with visible operational consequence.</p>
       <div class="m-actions">
         <a class="m-cta m-cta-dominant" href="/modernize/demo.html">Run Demo</a>
         <a class="m-cta m-cta-primary" href="/proof">Review Proof</a>
         <a class="m-cta m-cta-secondary" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
       </div>
+      <div class="m-hero-signals">
+        <span class="m-hero-signal">Closed-loop triage</span>
+        <span class="m-hero-signal">Mandatory redaction gate</span>
+        <span class="m-hero-signal">Escalation packs</span>
+      </div>
       <p class="m-meta">Eligible to obtain clearance; willing to pursue sponsorship.</p>
     </div>
     <div class="m-panel">
-      <div class="m-panel-head">LCP candidate: system map</div>
+      <div class="m-panel-head">Flagship system surface</div>
       <div class="m-panel-body">
         <img class="m-hero-visual"
              src="/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1"
-             alt="AutoSOC system map showing workflow relationships, policy gates, and review outputs"
+             alt="TriageLoop system map showing workflow relationships, policy gates, and review outputs"
              width="1600" height="900" loading="eager">
       </div>
     </div>
@@ -102,7 +107,7 @@
       <div class="m-impact-copy">
         <div class="m-card-kicker m-card-kicker-invert">Workflow + proof</div>
         <h2>Live automation with visible consequences</h2>
-        <p>AutoSOC is running as a real system: ingest, triage, reconciliation, coverage gate, and curated publish lane. This band is here to make the workflow feel operational, not merely explained.</p>
+        <p>TriageLoop is running as a real system: ingest, triage, reconciliation, coverage gate, and curated publish lane. This band is here to make the workflow feel operational, not merely explained.</p>
         <div class="m-impact-points">
           <div class="m-impact-point">
             <strong>Ingest -> triage -> reconcile</strong>
@@ -126,7 +131,7 @@
           </div>
           <div class="m-frame-body">
             <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg"
-                 alt="AutoSOC workflow sequence showing poll, triage, redact, pack, and escalation steps"
+                 alt="TriageLoop workflow sequence showing poll, triage, redact, pack, and escalation steps"
                  width="1200" height="240" loading="lazy">
             <p class="m-frame-caption m-frame-caption-invert">The workflow sequence is intentionally promoted here so the first screen shows both the flagship system and the pipeline movement behind it.</p>
           </div>
@@ -148,7 +153,7 @@
       </div>
       <div class="m-proof-inline">
         <span>Verified <span data-verified-date>02-26-2026</span></span>
-        <a class="m-preview-link" href="/case-study-autosoc">Start with the flagship case study</a>
+        <a class="m-preview-link" href="/case-study-autosoc">Start with the TriageLoop case study</a>
       </div>
     </div>
   </div>
@@ -156,14 +161,19 @@
 
 <section class="m-section m-stage m-stage-ops">
   <div class="m-wrap">
-    <div class="m-divider-title">
-      <div class="m-card-kicker">Operational outcomes</div>
+    <div class="m-ops-header">
+      <div>
+        <div class="m-card-kicker">Operational outcomes</div>
+        <h2>TriageLoop is carrying live system load</h2>
+        <p class="m-copy">This band exists to prove operational consequence, not just rule-library depth. The numbers below come from the canonical March 4, 2026 OPS snapshot.</p>
+      </div>
+      <div class="m-ops-status-pill">Canonical snapshot: 03-04-2026</div>
     </div>
-    <div class="m-ops-grid" aria-label="Canonical AutoSOC operational outcomes">
+    <div class="m-ops-grid" aria-label="Canonical TriageLoop operational outcomes">
       <article class="m-ops-card">
         <div class="m-ops-value"><span data-ops="case_directories">25167</span></div>
         <div class="m-ops-label">Case directories</div>
-        <p class="m-ops-copy">Canonical OPS snapshot of the current AutoSOC case corpus.</p>
+        <p class="m-ops-copy">Canonical OPS snapshot of the current TriageLoop case corpus.</p>
       </article>
       <article class="m-ops-card">
         <div class="m-ops-value"><span data-ops="auto_closed_benign">20942</span></div>
@@ -221,7 +231,7 @@
     <div class="m-grid-3">
       <article class="m-card">
         <div class="m-card-kicker">Start here</div>
-        <h2>AutoSOC case study</h2>
+        <h2>TriageLoop case study</h2>
         <p>The shortest path for reviewers: what was built, why it matters, and how the pipeline turns alerts into reviewable evidence.</p>
         <div class="m-chip-row">
           <span class="m-chip">Pipeline: live</span>
@@ -262,12 +272,12 @@
       <article class="m-flow-card">
         <div class="m-flow-step">1</div>
         <h3>Understand the build</h3>
-        <p class="m-copy">The homepage frames AutoSOC as an engineering outcome first: what it does, how it is validated, and why it belongs in a SOC portfolio.</p>
+        <p class="m-copy">The homepage frames TriageLoop as an engineering outcome first: what it does, how it is validated, and why it belongs in a SOC portfolio.</p>
       </article>
       <article class="m-flow-card">
         <div class="m-flow-step">2</div>
         <h3>Inspect the flagship case study</h3>
-        <p class="m-copy">The AutoSOC page turns architecture, decision logic, and screenshots into one deliberate narrative instead of scattered proof fragments.</p>
+        <p class="m-copy">The TriageLoop page turns architecture, decision logic, and screenshots into one deliberate narrative instead of scattered proof fragments.</p>
       </article>
       <article class="m-flow-card">
         <div class="m-flow-step">3</div>
@@ -294,7 +304,7 @@
           </div>
           <div class="m-frame-body">
             <img src="/assets/pp_soc_integration/lab-architecture.svg"
-                 alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and AutoSOC pipeline boundaries"
+                 alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and TriageLoop pipeline boundaries"
                  width="1200" height="510" loading="lazy">
             <p class="m-frame-caption">Purpose: show where the workflow lives. Pipeline relation: the environment that produces telemetry, pivots, and evidence surfaces used throughout the case study.</p>
           </div>
@@ -306,7 +316,7 @@
           </div>
           <div class="m-frame-body">
             <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg"
-                 alt="AutoSOC workflow sequence showing poll, triage, redact, pack, and escalation steps"
+                 alt="TriageLoop workflow sequence showing poll, triage, redact, pack, and escalation steps"
                  width="1200" height="240" loading="lazy">
             <p class="m-frame-caption">Purpose: reduce the workflow to the steps a reviewer needs to understand quickly. Pipeline relation: alert intake to review-ready output.</p>
           </div>
@@ -321,8 +331,8 @@
         <div class="m-evidence-note">
           <div class="m-card-kicker">Next action</div>
           <h3>Go deeper</h3>
-          <p>Open the AutoSOC case study to inspect decision logic, evidence outputs, labeled screenshots, and the proof chain that connects the workflow to public artifacts.</p>
-          <a class="m-card-link" href="/case-study-autosoc">Read the AutoSOC case study</a>
+          <p>Open the TriageLoop case study to inspect decision logic, evidence outputs, labeled screenshots, and the proof chain that connects the workflow to public artifacts.</p>
+          <a class="m-card-link" href="/case-study-autosoc">Read the TriageLoop case study</a>
         </div>
       </div>
     </div>
@@ -342,7 +352,7 @@
         </div>
         <div class="m-frame-body">
           <img src="/assets/pp_soc_integration/lab-architecture.svg"
-               alt="SOC lab architecture showing Proxmox, Windows 11 endpoint, Wazuh, Splunk, and AutoSOC pipeline"
+               alt="SOC lab architecture showing Proxmox, Windows 11 endpoint, Wazuh, Splunk, and TriageLoop pipeline"
                width="1200" height="510" loading="lazy">
           <p class="m-frame-caption">Architecture diagrams are carrying real explanatory load here: where alerts originate, where pivots happen, and where evidence is packaged for review.</p>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -76,10 +76,10 @@
     <div>
       <div class="m-badge">Evidence-first SOC portfolio</div>
       <h1 class="m-title">AutoSOC proves practical SOC engineering.</h1>
-      <p class="m-outcome">Live pipeline story, public proof, and a reviewer-safe case-study path in one screen. No scrolling required to understand the point.</p>
+      <p class="m-outcome">Closed-loop alert triage, public proof, and a runnable demo path presented as one flagship engineering system.</p>
       <div class="m-actions">
-        <a class="m-cta m-cta-primary" href="/case-study-autosoc">View AutoSOC</a>
-        <a class="m-cta m-cta-accent" href="/proof">Review Proof</a>
+        <a class="m-cta m-cta-dominant" href="/modernize/demo.html">Run Demo</a>
+        <a class="m-cta m-cta-primary" href="/proof">Review Proof</a>
         <a class="m-cta m-cta-secondary" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
       </div>
       <p class="m-meta">Eligible to obtain clearance; willing to pursue sponsorship.</p>
@@ -91,6 +91,46 @@
              src="/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1"
              alt="AutoSOC system map showing workflow relationships, policy gates, and review outputs"
              width="1600" height="900" loading="eager">
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="m-section m-stage m-stage-impact">
+  <div class="m-wrap">
+    <div class="m-impact-band">
+      <div class="m-impact-copy">
+        <div class="m-card-kicker m-card-kicker-invert">Workflow + proof</div>
+        <h2>Live automation with visible consequences</h2>
+        <p>AutoSOC is running as a real system: ingest, triage, reconciliation, coverage gate, and curated publish lane. This band is here to make the workflow feel operational, not merely explained.</p>
+        <div class="m-impact-points">
+          <div class="m-impact-point">
+            <strong>Ingest -> triage -> reconcile</strong>
+            <span>Deterministic flow rather than a hand-run analyst demo.</span>
+          </div>
+          <div class="m-impact-point">
+            <strong>Coverage gate still bites</strong>
+            <span>Evidence stays honest when the system says `FAIL`, not only when it says `PASS`.</span>
+          </div>
+          <div class="m-impact-point">
+            <strong>Proof path stays one click away</strong>
+            <span>Demo, proof, and repository stay tied to the same operational story.</span>
+          </div>
+        </div>
+      </div>
+      <div class="m-impact-visual">
+        <div class="m-terminal">
+          <div class="m-terminal-head">
+            <span class="m-terminal-label">Pipeline movement</span>
+            <span class="m-frame-tag">Proof lane</span>
+          </div>
+          <div class="m-frame-body">
+            <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg"
+                 alt="AutoSOC workflow sequence showing poll, triage, redact, pack, and escalation steps"
+                 width="1200" height="240" loading="lazy">
+            <p class="m-frame-caption m-frame-caption-invert">The workflow sequence is intentionally promoted here so the first screen shows both the flagship system and the pipeline movement behind it.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -110,6 +150,41 @@
         <span>Verified <span data-verified-date>02-26-2026</span></span>
         <a class="m-preview-link" href="/case-study-autosoc">Start with the flagship case study</a>
       </div>
+    </div>
+  </div>
+</section>
+
+<section class="m-section m-stage m-stage-ops">
+  <div class="m-wrap">
+    <div class="m-divider-title">
+      <div class="m-card-kicker">Operational outcomes</div>
+    </div>
+    <div class="m-ops-grid" aria-label="Canonical AutoSOC operational outcomes">
+      <article class="m-ops-card">
+        <div class="m-ops-value"><span data-ops="case_directories">25167</span></div>
+        <div class="m-ops-label">Case directories</div>
+        <p class="m-ops-copy">Canonical OPS snapshot of the current AutoSOC case corpus.</p>
+      </article>
+      <article class="m-ops-card">
+        <div class="m-ops-value"><span data-ops="auto_closed_benign">20942</span></div>
+        <div class="m-ops-label">Benign auto-closures</div>
+        <p class="m-ops-copy">Operational volume that shows the system is closing repetitive noise, not just producing screenshots.</p>
+      </article>
+      <article class="m-ops-card">
+        <div class="m-ops-value"><span data-ops="escalated">2478</span></div>
+        <div class="m-ops-label">Escalations</div>
+        <p class="m-ops-copy">Cases preserved for deeper investigation and public proof continuity.</p>
+      </article>
+      <article class="m-ops-card">
+        <div class="m-ops-value" data-ops-status="reconciliation">PASS</div>
+        <div class="m-ops-label">Reconciliation</div>
+        <p class="m-ops-copy">Mismatch count is zero in the canonical March 4, 2026 OPS progress snapshot.</p>
+      </article>
+      <article class="m-ops-card">
+        <div class="m-ops-value"><span data-ops="coverage_ratio">6/8</span></div>
+        <div class="m-ops-label">Coverage</div>
+        <p class="m-ops-copy">Coverage gate currently fails at 6 of 8 required hosts, which is useful proof that the reporting is honest.</p>
+      </article>
     </div>
   </div>
 </section>
@@ -320,6 +395,7 @@
 <!-- @include:footer:end -->
 <script src="/assets/fetch-utils.js" defer></script>
 <script src="/data/counts.js" defer></script>
+<script src="/data/ops-metrics.js" defer></script>
 <script src="/assets/app.js" defer></script>
 </body>
 </html>

--- a/site/resume-content.md
+++ b/site/resume-content.md
@@ -19,6 +19,7 @@ SOC Analyst (T1/T2) candidate focused on detection engineering and security auto
 ### HawkinsOperations (Primary Portfolio Repo)
 - Built and maintain a detection and response library with verified inventory sourced from `PROOF_PACK/VERIFIED_COUNTS.md` via generated site data.
 - Implemented proof-first validation workflow (scripts + documentation + CI alignment) so reviewers can reproduce claims directly from repo artifacts.
+- Diagnosed and restored an AutoSOC ingestion outage by separating infrastructure reachability from application logic, then fixed reconciliation-path validation to return the pipeline to successful end-to-end operation.
 
 ### SOC Triage Simulator
 - Built an interactive triage workflow artifact to practice investigation steps, evidence review, and analyst decision flow.

--- a/site/resume.html
+++ b/site/resume.html
@@ -157,6 +157,7 @@
           <ul>
             <li>Built and maintain a detection and response library with verified inventory: <span data-verified="sigma">103</span> Sigma rules, <span data-verified="wazuh">28</span> Wazuh rule blocks (<span data-verified="wazuh_xml_files">24</span> XML files), <span data-verified="splunk">8</span> Splunk detections, and <span data-verified="ir">10</span> IR playbooks.</li>
             <li>Implemented proof-first validation workflow (scripts, documentation, CI alignment) so reviewers can reproduce claims directly from repo artifacts.</li>
+            <li>Diagnosed and restored an AutoSOC ingestion outage by separating infrastructure reachability from application logic, then fixed reconciliation-path validation to return the pipeline to successful end-to-end operation.</li>
           </ul>
         </div>
         <div class="resume-project">

--- a/site/resume.txt
+++ b/site/resume.txt
@@ -24,6 +24,9 @@ EXPERIENCE / PROJECTS
     Current verified counts: https://hawkinsops.com/proof (reproducible via CI).
   - Implemented proof-first validation workflow so reviewers can reproduce claims
     directly from repository artifacts.
+  - Diagnosed and restored an AutoSOC ingestion outage by separating infrastructure
+    reachability from application logic, then fixing reconciliation-path validation
+    to return the pipeline to successful end-to-end operation.
   - Proof: https://hawkinsops.com/proof
 
 - SOC Triage Simulator

--- a/site/soc-lab.html
+++ b/site/soc-lab.html
@@ -41,20 +41,20 @@
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
       <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Case Study</a></li>
+      <li><a href="/case-study-autosoc">TriageLoop Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
       <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read AutoSOC</a>
+    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read TriageLoop</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
   <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">AutoSOC Case Study</a>
+  <a href="/case-study-autosoc">TriageLoop Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
@@ -73,10 +73,10 @@
       If a detection can't survive messy reality, it doesn't belong in the repo.
     </p>
     <div class="g2">
-      <a class="card lane-card" href="/case-study-soc-integration" style="text-decoration:none" data-lane="fastest">
+      <a class="card lane-card" href="/case-study-autosoc" style="text-decoration:none" data-lane="fastest">
         <span class="lane-tag">FEATURED</span>
-        <div class="card-ttl">PP_SOC_Integration case study</div>
-        <div class="card-sub">Full SOC integration write-up: 15,052 alerts observed in 24h, CVE triaged and patched, verified closed.</div>
+        <div class="card-ttl">TriageLoop flagship case study</div>
+        <div class="card-sub">Walk the alert-ingest to escalation path, inspect outputs, and follow the proof chain without leaving the production site.</div>
         <div class="lane-cta" aria-hidden="true">Read case study <span>→</span></div>
       </a>
       <a class="card lane-card" href="/proof" style="text-decoration:none" data-lane="source">
@@ -150,6 +150,10 @@
     <div class="m-card m-stage-card">
       <h2>Actual redacted lab surfaces</h2>
       <p class="m-copy">These are embedded because the lab should feel inspectable, not described from a distance. Each surface is tied to the environment, alerting path, or evidence workflow that supports the rest of the site.</p>
+      <div class="m-lab-intro">
+        <div class="m-card-kicker">Inspection order</div>
+        <p class="m-copy">Environment first, then alert surface, then virtualization context, then command-driven evidence. That order makes the lab read like system support for TriageLoop rather than a detached screenshot pile.</p>
+      </div>
       <div class="m-lab-wall">
         <figure class="m-shot-frame">
           <div class="m-frame-head">
@@ -157,7 +161,7 @@
             <span class="m-frame-tag">Environment</span>
           </div>
           <div class="m-frame-body">
-            <img src="/assets/pp_soc_integration/lab-architecture.svg" alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and AutoSOC pipeline boundaries" width="1200" height="510" loading="lazy">
+            <img src="/assets/pp_soc_integration/lab-architecture.svg" alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and TriageLoop pipeline boundaries" width="1200" height="510" loading="lazy">
             <p class="m-frame-caption">Purpose: show the actual topology behind the detections and escalation workflow.</p>
           </div>
         </figure>

--- a/site/soc-lab.html
+++ b/site/soc-lab.html
@@ -30,6 +30,7 @@
   })();
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/modernize.css?v=03-09-2026-4">
 </head>
 <body>
 <!-- @include:nav:start -->
@@ -141,6 +142,60 @@
   </div>
 </section>
 
+<section class="m-section m-stage m-stage-topology">
+  <div class="m-wrap">
+    <div class="m-divider-title">
+      <div class="m-card-kicker">Embedded evidence</div>
+    </div>
+    <div class="m-card m-stage-card">
+      <h2>Actual redacted lab surfaces</h2>
+      <p class="m-copy">These are embedded because the lab should feel inspectable, not described from a distance. Each surface is tied to the environment, alerting path, or evidence workflow that supports the rest of the site.</p>
+      <div class="m-lab-wall">
+        <figure class="m-shot-frame">
+          <div class="m-frame-head">
+            <span class="m-frame-title">Lab topology diagram</span>
+            <span class="m-frame-tag">Environment</span>
+          </div>
+          <div class="m-frame-body">
+            <img src="/assets/pp_soc_integration/lab-architecture.svg" alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and AutoSOC pipeline boundaries" width="1200" height="510" loading="lazy">
+            <p class="m-frame-caption">Purpose: show the actual topology behind the detections and escalation workflow.</p>
+          </div>
+        </figure>
+        <figure class="m-shot-frame">
+          <div class="m-frame-head">
+            <span class="m-frame-title">Wazuh dashboard capture</span>
+            <span class="m-frame-tag">Alert surface</span>
+          </div>
+          <div class="m-frame-body">
+            <img src="/assets/howe01/02_threat_hunting_level12_filter.png" alt="Redacted Wazuh dashboard screenshot showing Level 12 threat hunting filter results" width="1600" height="900" loading="lazy">
+            <p class="m-frame-caption">Purpose: show the live alert lane used during triage and hunting workflows.</p>
+          </div>
+        </figure>
+        <figure class="m-shot-frame">
+          <div class="m-frame-head">
+            <span class="m-frame-title">Proxmox / VM layout</span>
+            <span class="m-frame-tag">Virtualization</span>
+          </div>
+          <div class="m-frame-body">
+            <img src="/assets/pp_soc_integration/t5-proxmox-redacted.png" alt="Redacted Proxmox interface screenshot showing VM layout for the SOC lab" width="1600" height="900" loading="lazy">
+            <p class="m-frame-caption">Purpose: show the host and VM surface where the lab is actually operated.</p>
+          </div>
+        </figure>
+        <figure class="m-shot-frame">
+          <div class="m-frame-head">
+            <span class="m-frame-title">Operational evidence output</span>
+            <span class="m-frame-tag">Artifacts</span>
+          </div>
+          <div class="m-frame-body">
+            <img src="/assets/pp_soc_integration/04_nodejs_patch_terminal.png" alt="Redacted terminal screenshot showing an operational command-driven workflow from the lab evidence set" width="1385" height="799" loading="lazy">
+            <p class="m-frame-caption">Purpose: show that the lab produces command-driven evidence surfaces, not only architecture images.</p>
+          </div>
+        </figure>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section>
   <div class="ctr">
     <div class="slbl">Network and Access</div>
@@ -234,22 +289,6 @@
         <img src="/assets/howe01/02_threat_hunting_level12_filter.png" alt="Redacted Wazuh dashboard screenshot showing Level 12 threat hunting filter results" style="display:block;width:100%;height:auto">
       </div>
     </div>
-
-    <div style="height:14px"></div>
-
-    <div class="g2" data-screenshot-gallery>
-      <div class="card" data-screenshot-card data-src="/assets/screenshots/detection_firing.png" hidden>
-        <div class="card-ttl">Detection firing (redacted example)</div>
-        <div class="card-sub">Validated alert sample from lab workflow.</div>
-        <img class="screenshot-img" data-screenshot-img alt="Redacted detection firing screenshot">
-      </div>
-      <div class="card" data-screenshot-card data-src="/assets/screenshots/splunk_pivot.png" hidden>
-        <div class="card-ttl">Splunk pivot (redacted example)</div>
-        <div class="card-sub">Investigation pivot sample from reproducible test run.</div>
-        <img class="screenshot-img" data-screenshot-img alt="Redacted Splunk pivot screenshot">
-      </div>
-    </div>
-    <p class="lupd" data-screenshot-fallback>Redacted examples available on request.</p>
 
     <div style="margin-top:18px;display:flex;flex-wrap:wrap;gap:10px">
       <a class="btn btn-p" href="/proof">Open proof pack</a>


### PR DESCRIPTION
## Summary

Renames the visible flagship project branding to TriageLoop and strengthens the homepage, case-study, and lab staging so the production site reads more like a layered engineering review packet.

## Technical Details

- kept the static `site/` architecture and stable routes, including `/case-study-autosoc`
- updated visible navigation, CTA, and case-study copy from AutoSOC to TriageLoop
- separated architecture and workflow stages on the flagship case-study page
- increased homepage and lab visual consequence through stronger HTML/CSS composition rather than framework churn or JS-heavy changes

## Testing

- `pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1`
- `python .\scripts\drift_scan.py`
- browser review of homepage and SOC lab layouts before commit

## Security Considerations

- no new dependencies
- no secrets in diff
- no route or deployment-model changes

## Portfolio Notes

- Run Demo remains the dominant CTA
- TriageLoop is now presented as the flagship system across the production reviewer flow
- SOC lab visuals are framed as supporting system evidence, not detached screenshots

## Checklist

- [x] Code follows project style guide
- [x] Documentation updated
- [x] No secrets in diff
- [x] Tested