### PR TITLE
Add: Phase 1 SignalFoundry staging artifacts (clean)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,22 @@ Treat every file as if a hiring manager will read it.
 4. Confirm .gitignore covers Evidence-Raw/ and .obsidian/
 5. Get Raylee approval — never push without confirmation
 
+## PHASE 1 PREFLIGHT CHECKS
+
+Before opening or updating a rebrand staging PR, run all of the following:
+
+1. `python -m unittest`
+2. `python3 scripts/validate_metrics.py`
+3. `scripts/check-md-links.sh`
+
+If any preflight fails, stop and document the failure in a GitHub issue before asking for Phase 2 approval.
+
+## PUBLIC REPO SAFETY
+
+- Do not edit binary files unless the task explicitly requires it.
+- Never add secrets, tokens, credentials, raw internal identifiers, or private host data.
+- Required approver for rebrand and public proof changes: `raylee`
+
 ## COMMIT FORMAT
 
 Add: what you added
@@ -103,6 +119,5 @@ Evidence-Raw/ content of any kind
 Real IPs, hostnames, credentials, or internal identifiers
 Machine config files
 .obsidian/ folder
-
 
 

--- a/RENAMELOG.md
+++ b/RENAMELOG.md
@@ -1,0 +1,25 @@
+# RENAMELOG
+
+## Phase 1 Staging Artifacts
+
+This branch prepares the Phase 1 staging contract for the SignalFoundry rebrand without changing the production deployment.
+
+### Planned rename direction
+
+- Umbrella brand remains `HawkinsOps`
+- Flagship system name is `SignalFoundry`
+- Internal engine references remain `AutoSOC` where technical precision matters
+
+### Files changed in this phase
+
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\data\metrics.json`
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\data\metrics.json.sha256`
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\scripts\sign_metrics.sh`
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\scripts\validate_metrics.py`
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\scripts\check-md-links.sh`
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\AGENTS.md`
+- `C:\RH\OPS\10_Portfolio\HawkinsOperations\agents_activity.log`
+
+### Human gate
+
+Do not proceed to Phase 2 until Raylee reviews the Phase 1 PR and approves the contract, checks, and naming direction.

--- a/agents_activity.log
+++ b/agents_activity.log
@@ -2,3 +2,5 @@
 2026-03-15T09:45:00Z | BRANCH | Created staging branch rebrand/signalfoundry from codex/ops-depth-pass-20260309.
 2026-03-15T09:47:00Z | ARTIFACTS | Added data\metrics.json, signer, validator, markdown link checker, AGENTS preflight rules, and RENAMELOG.md.
 2026-03-15T09:48:43Z | VERIFY | python -m unittest passed; python .\scripts\validate_metrics.py passed; scripts/check-md-links.sh failed on missing Markdown targets in .github and docs\design surfaces.
+2026-03-15T09:49:39Z | COMMIT | Created commits fdc41c4 and 12b2994 on rebrand/signalfoundry for Phase 1 staging artifacts and action log.
+2026-03-15T09:50:47Z | BLOCKER | Remote publication blocked. git push failed with SEC_E_NO_CREDENTIALS and gh auth status reported an invalid token, so no GitHub issue or draft PR could be created in this session.

--- a/agents_activity.log
+++ b/agents_activity.log
@@ -4,3 +4,5 @@
 2026-03-15T09:48:43Z | VERIFY | python -m unittest passed; python .\scripts\validate_metrics.py passed; scripts/check-md-links.sh failed on missing Markdown targets in .github and docs\design surfaces.
 2026-03-15T09:49:39Z | COMMIT | Created commits fdc41c4 and 12b2994 on rebrand/signalfoundry for Phase 1 staging artifacts and action log.
 2026-03-15T09:50:47Z | BLOCKER | Remote publication blocked. git push failed with SEC_E_NO_CREDENTIALS and gh auth status reported an invalid token, so no GitHub issue or draft PR could be created in this session.
+2026-03-15T10:00:12Z | ISSUE | Created GitHub issue #69 for Phase 1 markdown link preflight failures: https://github.com/raylee-hawkins/HawkinsOperations/issues/69
+2026-03-15T10:00:15Z | PR | Created draft PR #70 for Phase 1 staging artifacts: https://github.com/raylee-hawkins/HawkinsOperations/pull/70

--- a/agents_activity.log
+++ b/agents_activity.log
@@ -1,0 +1,4 @@
+2026-03-15T09:44:56Z | INIT | Started Phase 1 staging artifact prep from C:\RH\OPS\10_Portfolio\HawkinsOperations on existing dirty worktree.
+2026-03-15T09:45:00Z | BRANCH | Created staging branch rebrand/signalfoundry from codex/ops-depth-pass-20260309.
+2026-03-15T09:47:00Z | ARTIFACTS | Added data\metrics.json, signer, validator, markdown link checker, AGENTS preflight rules, and RENAMELOG.md.
+2026-03-15T09:48:43Z | VERIFY | python -m unittest passed; python .\scripts\validate_metrics.py passed; scripts/check-md-links.sh failed on missing Markdown targets in .github and docs\design surfaces.

--- a/data/metrics.json
+++ b/data/metrics.json
@@ -1,0 +1,35 @@
+{
+  "running_totals": {
+    "total_cases": 34206,
+    "auto_closed_benign": 0,
+    "known_fp": 4,
+    "escalated": 0,
+    "review": 5162,
+    "staged_pending": 10
+  },
+  "host_coverage": "8/8",
+  "reconciliation_mismatch": 0,
+  "heartbeat": "SUCCESS",
+  "last_updated": "2026-03-15T09:34:40Z",
+  "stress_test_window": {
+    "profile": "phase1_draft",
+    "baseline_window": "latest_successful_heartbeat_run",
+    "queue_backlog_target": 10000,
+    "latency_targets_ms": {
+      "per_event_under_load": 200,
+      "with_backlog": 500
+    },
+    "simulated_rule_pressure": {
+      "rule_60227_pct_increase": 200,
+      "rule_92151_pct_increase": 100,
+      "sysmon_module_load_noise_pct_increase": 300
+    }
+  },
+  "detection_inventory": {
+    "sigma": 103,
+    "wazuh_files": 24,
+    "wazuh_rule_blocks": 28,
+    "splunk": 8,
+    "ir_playbooks": 10
+  }
+}

--- a/data/metrics.json.sha256
+++ b/data/metrics.json.sha256
@@ -1,0 +1,1 @@
+\a77ad384c594e22adc09ec92df2eb2333e895bfe070c4863bf473b60072c2eb7 *C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\data\\metrics.json

--- a/scripts/check-md-links.sh
+++ b/scripts/check-md-links.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+python - <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+repo_root = Path.cwd()
+pattern = re.compile(r'!\[[^\]]*\]\(([^)]+)\)|\[[^\]]+\]\(([^)]+)\)')
+errors: list[str] = []
+
+for md_path in repo_root.rglob("*.md"):
+    parts = md_path.parts
+    if ".git" in parts or "node_modules" in parts:
+        continue
+    text = md_path.read_text(encoding="utf-8", errors="ignore")
+    for match in pattern.finditer(text):
+        raw_target = match.group(1) or match.group(2) or ""
+        target = raw_target.strip()
+        if not target or target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        clean_target = target.split("#", 1)[0]
+        if clean_target.startswith("<") and clean_target.endswith(">"):
+            clean_target = clean_target[1:-1]
+        if not clean_target:
+            continue
+        resolved = (md_path.parent / clean_target).resolve()
+        if not resolved.exists():
+            errors.append(f"{md_path}: missing target {clean_target}")
+
+if errors:
+    print("markdown link check failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("markdown link check passed")
+PY

--- a/scripts/sign_metrics.sh
+++ b/scripts/sign_metrics.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+sha256sum data/metrics.json > data/metrics.json.sha256

--- a/scripts/validate_metrics.py
+++ b/scripts/validate_metrics.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+METRICS_PATH = REPO_ROOT / "data" / "metrics.json"
+
+
+def load_metrics() -> dict:
+    try:
+        return json.loads(METRICS_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"metrics file not found: {METRICS_PATH}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"metrics file is not valid JSON: {exc}")
+
+
+def expect_int(value: object, path: str, errors: list[str]) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        errors.append(f"{path} must be a non-negative integer")
+
+
+def expect_str(value: object, path: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{path} must be a non-empty string")
+
+
+def expect_mapping(value: object, path: str, errors: list[str]) -> dict:
+    if not isinstance(value, dict):
+        errors.append(f"{path} must be an object")
+        return {}
+    return value
+
+
+def validate_iso8601(value: str, path: str, errors: list[str]) -> None:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        errors.append(f"{path} must be an ISO-8601 timestamp")
+
+
+def main() -> int:
+    data = load_metrics()
+    errors: list[str] = []
+
+    running_totals = expect_mapping(data.get("running_totals"), "running_totals", errors)
+    for field in ("total_cases", "auto_closed_benign", "known_fp", "escalated"):
+        expect_int(running_totals.get(field), f"running_totals.{field}", errors)
+    for optional_field in ("review", "staged_pending"):
+        if optional_field in running_totals:
+            expect_int(running_totals.get(optional_field), f"running_totals.{optional_field}", errors)
+
+    host_coverage = data.get("host_coverage")
+    expect_str(host_coverage, "host_coverage", errors)
+    if isinstance(host_coverage, str) and not re.fullmatch(r"\d+/\d+", host_coverage):
+        errors.append("host_coverage must use the N/N format")
+
+    heartbeat = data.get("heartbeat")
+    expect_str(heartbeat, "heartbeat", errors)
+    if isinstance(heartbeat, str) and heartbeat not in {"SUCCESS", "FAIL", "WARN"}:
+        errors.append("heartbeat must be one of SUCCESS, FAIL, WARN")
+
+    expect_int(data.get("reconciliation_mismatch"), "reconciliation_mismatch", errors)
+
+    last_updated = data.get("last_updated")
+    expect_str(last_updated, "last_updated", errors)
+    if isinstance(last_updated, str):
+        validate_iso8601(last_updated, "last_updated", errors)
+
+    stress_test_window = expect_mapping(data.get("stress_test_window"), "stress_test_window", errors)
+    expect_str(stress_test_window.get("profile"), "stress_test_window.profile", errors)
+    expect_str(stress_test_window.get("baseline_window"), "stress_test_window.baseline_window", errors)
+    expect_int(stress_test_window.get("queue_backlog_target"), "stress_test_window.queue_backlog_target", errors)
+
+    latency_targets = expect_mapping(
+        stress_test_window.get("latency_targets_ms"),
+        "stress_test_window.latency_targets_ms",
+        errors,
+    )
+    expect_int(
+        latency_targets.get("per_event_under_load"),
+        "stress_test_window.latency_targets_ms.per_event_under_load",
+        errors,
+    )
+    expect_int(
+        latency_targets.get("with_backlog"),
+        "stress_test_window.latency_targets_ms.with_backlog",
+        errors,
+    )
+
+    simulated_pressure = expect_mapping(
+        stress_test_window.get("simulated_rule_pressure"),
+        "stress_test_window.simulated_rule_pressure",
+        errors,
+    )
+    for field in (
+        "rule_60227_pct_increase",
+        "rule_92151_pct_increase",
+        "sysmon_module_load_noise_pct_increase",
+    ):
+        expect_int(simulated_pressure.get(field), f"stress_test_window.simulated_rule_pressure.{field}", errors)
+
+    detection_inventory = expect_mapping(data.get("detection_inventory"), "detection_inventory", errors)
+    for field in ("sigma", "wazuh_files", "wazuh_rule_blocks", "splunk", "ir_playbooks"):
+        expect_int(detection_inventory.get(field), f"detection_inventory.{field}", errors)
+
+    if errors:
+        print("metrics validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"metrics validation passed: {METRICS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This replaces PR #70 with a clean Phase 1 branch built directly from `main`.

## Included artifacts
- `data/metrics.json`
- `data/metrics.json.sha256`
- `scripts/sign_metrics.sh`
- `scripts/validate_metrics.py`
- `scripts/check-md-links.sh`
- `AGENTS.md` preflight rules
- `RENAMELOG.md`
- `agents_activity.log`

## Verification
- `python -m unittest`: PASS
- `python .\\scripts\\validate_metrics.py`: PASS
- `scripts/check-md-links.sh`: FAIL

## Blocking issue
- #69 Phase 1 markdown link preflight failures

## Human gate
Do not proceed to Phase 2 until Raylee inspects and approves this clean Phase 1 PR.
