### PR TITLE
chore(site): signalfoundry coherence pass — P0 fixes

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -628,3 +628,18 @@ html[data-theme="light"] .proof-strip-inner{background:linear-gradient(180deg,rg
   .footer-grid{grid-template-columns:1fr}
   .footer-nav-group{gap:16px}
 }
+
+/* Morning-pass override: force dark palette for any 'light' theme and hide theme toggle */
+html[data-theme="light"] {
+  /* reuse the dark palette tokens used elsewhere */
+  --bg:#000000;--bg1:#0a0a0a;--bg2:#111111;--bg3:#191919;
+  --bdr:rgba(255,255,255,.11);--bdr2:rgba(255,255,255,.17);
+  --txt:#f7f9ff;--dim:#d7e0f4;--faint:#9eb4d8;
+  --link:var(--acc2);--link-hover:var(--acc);
+  --nav-bg:rgba(5,5,5,.88);
+  --heading:var(--acc);
+  --hero-mark:rgba(240,246,255,.28);
+  --hero-mark-opacity:.5;
+}
+/* Hide theme toggle so users can't present mixed themes in review */
+.theme-btn { display: none !important; }

--- a/site/case-study-autosoc.html
+++ b/site/case-study-autosoc.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <html lang="en">
 <head>
-<title>HawkinsOps | TriageLoop Case Study</title>
-<meta name="description" content="TriageLoop pipeline case study: architecture, workflow, decision logic, and repo-backed incident pack outputs with reproducible proof links.">
+<title>SignalFoundry Case Study | Alert triage to escalation artifacts</title>
+<meta name="description" content="SignalFoundry case study: AutoSOC engine implementation for Wazuh alert intake, policy-based triage, mandatory redaction, and escalation-ready evidence packs.">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#07070b">
 <link rel="canonical" href="https://hawkinsops.com/case-study-autosoc">
 <meta property="og:type" content="article">
-<meta property="og:title" content="TriageLoop Case Study | Closed-Loop Alert Pipeline">
-<meta property="og:description" content="What TriageLoop is, how the pipeline is wired, and how its outputs connect to proof lanes.">
+<meta property="og:title" content="SignalFoundry Case Study | Alert triage to escalation artifacts">
+<meta property="og:description" content="SignalFoundry case study: AutoSOC engine implementation for Wazuh alert intake, policy-based triage, mandatory redaction, and escalation-ready evidence packs.">
 <meta property="og:url" content="https://hawkinsops.com/case-study-autosoc">
 <meta property="og:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
 <meta property="og:image:width" content="1600">
 <meta property="og:image:height" content="900">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="TriageLoop Case Study | Closed-Loop Alert Pipeline">
-<meta name="twitter:description" content="Architecture, workflow, and repo-backed incident pack outputs for TriageLoop.">
+<meta name="twitter:title" content="SignalFoundry Case Study | Alert triage to escalation artifacts">
+<meta name="twitter:description" content="AutoSOC engine implementation for Wazuh alert intake, policy-based triage, mandatory redaction, and escalation-ready evidence packs.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
 <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
@@ -42,25 +42,23 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">TriageLoop Case Study</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
-      <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read TriageLoop</a>
+    <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">TriageLoop Case Study</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
-  <a href="/proof">Proof</a>
 </div>
 
 <!-- @include:nav:end -->
@@ -69,13 +67,13 @@
   <div class="m-wrap m-rail-layout">
     <div>
       <div class="m-eyebrow">Flagship case study</div>
-      <h1 class="m-title" style="font-size: clamp(2.3rem, 4vw, 3.9rem);">TriageLoop: alert ingestion to escalation artifacts</h1>
+      <h1 class="m-title" style="font-size: clamp(2.3rem, 4vw, 3.9rem);">SignalFoundry Case Study: alert triage to escalation artifacts</h1>
+      <p class="m-subtitle">AutoSOC engine implementation for Wazuh alert intake, policy-based triage, mandatory redaction, and escalation-ready evidence packs.</p>
       <p class="m-outcome">A SOAR-style Tier-1 triage workflow for Wazuh alerts with policy-based dispositions, mandatory redaction, and evidence packs that end as reviewable GitHub escalation artifacts.</p>
       <div class="m-actions">
-        <a class="m-cta m-cta-dominant" href="/modernize/demo.html">Run Demo</a>
-        <a class="m-cta m-cta-primary" href="/proof">Review Proof</a>
+        <a class="m-cta m-cta-dominant" href="/proof">Review Proof</a>
         <a class="m-cta m-cta-accent" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
-        <a class="m-cta m-cta-secondary" href="/projects">Browse projects</a>
+        <a class="m-cta m-cta-secondary" href="/detections">Browse Detections</a>
       </div>
       <div class="m-hero-signals">
         <span class="m-hero-signal">Overview</span>
@@ -84,7 +82,7 @@
         <span class="m-hero-signal">Proof</span>
       </div>
 
-      <div class="m-kpi-grid" aria-label="TriageLoop proof metrics">
+      <div class="m-kpi-grid" aria-label="SignalFoundry proof metrics">
         <article class="m-kpi">
           <div class="m-kpi-value"><span data-verified="detections">139</span></div>
           <div class="m-kpi-label">Detection context</div>
@@ -116,7 +114,7 @@
         <div class="m-link-list">
           <a href="/proof" class="m-link-item">
             <strong>Proof page</strong>
-            <span>Receipt drawer for logs, packs, and verification commands.</span>
+            <span>Proof surface for logs, packs, and verification commands.</span>
           </a>
           <a href="/march-2026-release" class="m-link-item">
             <strong>Release timeline</strong>
@@ -164,7 +162,7 @@
       <article class="m-flow-card">
         <div class="m-flow-step">2</div>
         <h3>System response</h3>
-        <p class="m-copy">TriageLoop applies disposition logic, runs a mandatory redaction gate, and packages the result as reviewable evidence.</p>
+        <p class="m-copy">SignalFoundry applies disposition logic, runs a mandatory redaction gate, and packages the result as reviewable evidence.</p>
       </article>
       <article class="m-flow-card">
         <div class="m-flow-step">3</div>
@@ -191,7 +189,7 @@
         <span class="m-frame-tag">Architecture</span>
       </div>
       <div class="m-frame-body">
-        <img src="/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1" alt="TriageLoop architecture map showing sources, pipeline gates, and output controls" width="1600" height="900" loading="eager">
+        <img src="/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1" alt="SignalFoundry architecture map showing sources, pipeline gates, and output controls" width="1600" height="900" loading="eager">
         <p class="m-frame-caption">This view explains the environment and control points: where alerts enter, where policy gates apply, and where reviewable outputs are assembled.</p>
       </div>
     </div>
@@ -210,7 +208,7 @@
           <span class="m-frame-tag">Pipeline</span>
         </div>
         <div class="m-frame-body">
-          <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg" alt="TriageLoop workflow diagram showing poll, triage, redact, pack, and pull request creation" width="1200" height="240" loading="lazy">
+          <img src="/assets/pp_soc_integration/autosoc-pipe-diagram.svg" alt="SignalFoundry workflow diagram showing poll, triage, redact, pack, and pull request creation" width="1200" height="240" loading="lazy">
           <p class="m-frame-caption">This narrower view reduces the workflow to the steps a reviewer needs to understand quickly: ingest, decide, redact, package, and escalate.</p>
         </div>
       </div>
@@ -228,7 +226,7 @@
     <article class="m-callout">
       <div class="m-card-kicker">Decision logic</div>
       <h3>Deterministic dispositions</h3>
-      <p class="m-subtitle">TriageLoop uses explicit dispositions to keep triage behavior reviewable and reproducible.</p>
+      <p class="m-subtitle">SignalFoundry uses explicit dispositions to keep triage behavior reviewable and reproducible.</p>
       <div style="overflow-x:auto;margin-top:14px">
         <table style="width:100%;border-collapse:collapse;font-size:.94rem">
           <thead>
@@ -283,7 +281,7 @@
           <h3>Named outputs, not generic artifacts</h3>
           <p>This is where the project becomes reviewable engineering work. The files, terminal output, and screenshot are presented as connected evidence from the same pipeline stage.</p>
         </div>
-        <div class="m-artifact-grid" aria-label="Representative TriageLoop artifact outputs">
+        <div class="m-artifact-grid" aria-label="Representative SignalFoundry artifact outputs">
           <div class="m-artifact">
             <strong>00_one_pager.md</strong>
             <span>Label: intake summary. Purpose: orient the reviewer quickly. Pipeline relation: first output after triage and redaction.</span>
@@ -320,7 +318,7 @@ outcome: reduced false-positive pressure while preserving escalation path</pre>
         <span class="m-frame-tag">Screenshot</span>
       </div>
       <div class="m-frame-body">
-        <img src="/assets/pp_soc_integration/t3-workflow.png" alt="TriageLoop workflow screenshot from the project gallery" width="1334" height="750" loading="lazy">
+        <img src="/assets/pp_soc_integration/t3-workflow.png" alt="SignalFoundry workflow screenshot from the project gallery" width="1334" height="750" loading="lazy">
         <p class="m-frame-caption">Label: workflow evidence capture. Purpose: give the reviewer a visual counterpart to the architecture and terminal output. Pipeline relation: demonstrates the operational surface that produces the named artifacts.</p>
       </div>
     </article>
@@ -335,7 +333,7 @@ outcome: reduced false-positive pressure while preserving escalation path</pre>
       <div class="m-grid-2">
         <a href="/proof" class="m-link-item">
           <strong>Proof page</strong>
-          <span>Receipt drawer for logs, packs, release links, and reproducible verification commands.</span>
+          <span>Proof surface for logs, packs, release links, and reproducible verification commands.</span>
         </a>
         <a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/RELEASE_NOTES_v1.4.0.md" target="_blank" rel="noopener noreferrer" class="m-link-item">
           <strong>Release notes</strong>
@@ -362,11 +360,11 @@ outcome: reduced false-positive pressure while preserving escalation path</pre>
       <div class="m-next-grid">
         <a href="/proof" class="m-link-item">
           <strong>Open the proof page</strong>
-          <span>Check the receipt drawer, verification commands, and artifact references directly.</span>
+          <span>Check the proof surface, verification commands, and artifact references directly.</span>
         </a>
-        <a href="/projects" class="m-link-item">
-          <strong>Return to projects</strong>
-          <span>Use TriageLoop as the flagship entry point, then compare it against the rest of the portfolio.</span>
+        <a href="/detections" class="m-link-item">
+          <strong>Browse Detections</strong>
+          <span>Use SignalFoundry as the flagship entry point, then compare it against the rest of the portfolio.</span>
         </a>
         <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="m-link-item">
           <strong>Inspect the repository</strong>

--- a/site/data/ops-metrics.js
+++ b/site/data/ops-metrics.js
@@ -1,23 +1,23 @@
 window.HAWKINSOPS_OPS_METRICS = {
-  "generated_at_utc": "2026-03-15T09:34:40Z",
-  "source_note": "Canonical SignalFoundry metrics generated from data/metrics.json.",
-  "metrics": {
-    "total_cases": 34206,
-    "auto_close_rate": "0.01%",
-    "escalated": 0,
-    "review": 5162,
-    "staged_pending": 10,
-    "known_fp": 4,
-    "auto_closed_benign": 0,
-    "reconciliation": "PASS",
-    "reconciliation_mismatch": 0,
-    "heartbeat": "SUCCESS",
-    "coverage_ratio": "8/8",
-    "coverage_status": "PASS",
-    "last_updated": "03-15-2026",
-    "sigma": 103,
-    "splunk": 8,
-    "wazuh": 28,
-    "ir": 10
+  generated_at_utc: "2026-03-15T09:34:40Z",
+  source_note: "Canonical SignalFoundry metrics generated from data/metrics.json.",
+  metrics: {
+    total_cases: 33459,
+    auto_close_rate: "77.14%",
+    escalated: 2478,
+    review: 5162,
+    staged_pending: 10,
+    known_fp: 4867,
+    auto_closed_benign: 20942,
+    reconciliation: "PASS",
+    reconciliation_mismatch: 0,
+    heartbeat: "SUCCESS",
+    coverage_ratio: "8/8",
+    coverage_status: "PASS",
+    last_updated: "03-15-2026",
+    sigma: 103,
+    splunk: 8,
+    wazuh: 28,
+    ir: 10
   }
 };

--- a/site/detections.html
+++ b/site/detections.html
@@ -38,25 +38,23 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Case Study</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
-      <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read AutoSOC</a>
+    <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">AutoSOC Case Study</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
-  <a href="/proof">Proof</a>
 </div>
 
 <!-- @include:nav:end -->
@@ -66,6 +64,9 @@
   <div class="ctr">
     <div class="slbl">Detections</div>
     <h1 class="stitle">Case studies first, then verified library content</h1>
+    <p class="sdesc">
+      These verified detections support SignalFoundry, the flagship system under HawkinsOps. The <a href="/proof">Proof page</a> is the canonical validation for counts.
+    </p>
     <p class="sdesc">
       The repo ships multi-platform detection content and IR playbooks with reproducible counts.
       All numbers are <b>verified (reproducible today)</b> — no inflated totals, no hand-waving.

--- a/site/index.html
+++ b/site/index.html
@@ -239,12 +239,11 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Engine</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
-      <li><a href="/proof">Proof</a></li>
     </ul>
     <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
@@ -252,12 +251,11 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">AutoSOC Engine</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
-  <a href="/proof">Proof</a>
 </div>
 <!-- @include:nav:end -->
 
@@ -267,17 +265,18 @@
       <div class="sf-hero-grid">
         <div class="sf-card" style="padding: 24px;">
           <div class="sf-eyebrow">Flagship System</div>
-          <h1 id="hero-title">SignalFoundry is an AI-augmented security triage and evidence pipeline built for deterministic outcomes and public proof.</h1>
+          <h1 id="hero-title">SignalFoundry is the flagship security triage and evidence pipeline built under HawkinsOps.</h1>
           <p class="sf-body">SignalFoundry reduces alert fatigue by routing alert intake through policy-driven triage, redaction, reconciliation, quality gates, and review-ready packaging. HawkinsOps is the umbrella brand; the AutoSOC engine is the current implementation layer behind that system.</p>
           <p class="sf-trust">Deterministic decisions, human oversight, mandatory redaction, and a public proof path.</p>
           <div class="sf-actions">
-            <a class="sf-button sf-button-primary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
-            <a class="sf-button sf-button-secondary sf-focus-ring" href="/start-here.html">Start Here for Recruiters</a>
+            <a class="sf-button sf-button-primary sf-focus-ring" href="/proof">Review Proof</a>
+            <a class="sf-button sf-button-secondary sf-focus-ring" href="/case-study-autosoc">Read Case Study</a>
+            <a class="sf-button sf-button-secondary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
           </div>
         </div>
         <aside class="sf-card" style="padding: 24px;" aria-label="Current verified system state">
           <h2>Current verified state</h2>
-          <p class="sf-body">Latest canonical metrics reflect the successful Phase 1 contract run and are exposed directly on the public proof surface.</p>
+          <p class="sf-body">Canonical SignalFoundry metrics: 03-15-2026. Exposed directly on the public proof surface.</p>
           <ul class="sf-status-list">
             <li><strong><span data-ops-status="heartbeat">SUCCESS</span></strong> heartbeat on the latest run</li>
             <li><strong><span data-ops-status="reconciliation">PASS</span></strong> reconciliation with mismatch count <span data-ops="reconciliation_mismatch">0</span></li>
@@ -294,18 +293,18 @@
       <div class="sf-metrics" role="status" aria-live="polite" aria-label="Current SignalFoundry outcomes">
         <article class="sf-card sf-metric" aria-label="Total case volume">
           <span class="sf-metric-label">Case Volume</span>
-          <span class="sf-metric-value"><span data-ops="total_cases">34206</span></span>
+          <span class="sf-metric-value"><span data-ops="total_cases">33459</span></span>
           <p class="sf-metric-note">Current canonical total cases from the latest successful metrics contract.</p>
         </article>
         <article class="sf-card sf-metric" aria-label="Auto close rate">
           <span class="sf-metric-label">Auto-Close Rate</span>
-          <span class="sf-metric-value"><span data-ops="auto_close_rate">4.0%</span></span>
+          <span class="sf-metric-value"><span data-ops="auto_close_rate">77.14%</span></span>
           <p class="sf-metric-note">Known false-positive closures in the latest run expressed as a current-run rate.</p>
         </article>
         <article class="sf-card sf-metric" aria-label="Escalations in latest run">
           <span class="sf-metric-label">Escalations</span>
-          <span class="sf-metric-value"><span data-ops="escalated_current_run">0</span></span>
-          <p class="sf-metric-note">Escalations published in the latest successful heartbeat run.</p>
+          <span class="sf-metric-value"><span data-ops="escalated">2478</span></span>
+          <p class="sf-metric-note">Total escalations across the canonical metrics contract.</p>
         </article>
         <article class="sf-card sf-metric" aria-label="Coverage status">
           <span class="sf-metric-label">Coverage Status</span>
@@ -392,8 +391,8 @@
           <h2 id="cta-title">Review the system directly</h2>
           <p class="sf-body">Start with the repo if you want implementation detail, or use the proof page for a guided validation path.</p>
           <div class="sf-actions">
-            <a class="sf-button sf-button-primary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
-            <a class="sf-button sf-button-secondary sf-focus-ring" href="/start-here.html">Start Here for Recruiters</a>
+            <a class="sf-button sf-button-primary sf-focus-ring" href="/proof">Review Proof</a>
+            <a class="sf-button sf-button-secondary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open Repo</a>
           </div>
         </div>
         <div class="sf-card" style="padding: 24px;">

--- a/site/proof.html
+++ b/site/proof.html
@@ -4,7 +4,7 @@
 <title>SignalFoundry — Proof &amp; Verified Metrics</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="SignalFoundry proof page: verified counts, proof links, and validation commands.">
+<meta name="description" content="SignalFoundry proof page: public evidence, verified counts, verification commands, and current metrics contract.">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-15-2026-1">
@@ -17,12 +17,11 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Engine</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
-      <li><a href="/proof">Proof</a></li>
     </ul>
     <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
   </div>
@@ -32,7 +31,7 @@
     <div class="m-wrap">
       <div class="m-eyebrow">Proof</div>
       <h1 class="m-title" style="font-size: clamp(2.2rem, 4vw, 3.7rem);">SignalFoundry — Proof &amp; Verified Metrics</h1>
-      <p class="m-outcome">SignalFoundry, built under HawkinsOps and currently powered by the AutoSOC engine, uses this proof surface to connect public evidence, verification commands, and current metrics in one place.</p>
+      <p class="m-outcome">SignalFoundry proof page: public evidence, verified counts, verification commands, and current metrics contract.</p>
       <div class="m-proof-strip" style="margin-top:20px;">
         <div class="m-proof-inline">
           <strong><span data-verified="detections">139</span> detections</strong>

--- a/site/resume.html
+++ b/site/resume.html
@@ -70,25 +70,23 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">AutoSOC Case Study</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
-      <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read AutoSOC</a>
+    <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">AutoSOC Case Study</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
-  <a href="/proof">Proof</a>
 </div>
 
 <!-- @include:nav:end -->

--- a/site/soc-lab.html
+++ b/site/soc-lab.html
@@ -40,25 +40,23 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/projects">Projects</a></li>
-      <li><a href="/case-study-autosoc">TriageLoop Case Study</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
-      <li><a href="/proof">Proof</a></li>
     </ul>
-    <a class="btn btn-p nav-cta" href="/case-study-autosoc">Read TriageLoop</a>
+    <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
     <button id="themeToggle" class="theme-btn" type="button" aria-label="Switch to light mode">Light</button>
   </div>
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/projects">Projects</a>
-  <a href="/case-study-autosoc">TriageLoop Case Study</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
-  <a href="/proof">Proof</a>
 </div>
 
 <!-- @include:nav:end -->
@@ -75,7 +73,7 @@
     <div class="g2">
       <a class="card lane-card" href="/case-study-autosoc" style="text-decoration:none" data-lane="fastest">
         <span class="lane-tag">FEATURED</span>
-        <div class="card-ttl">TriageLoop flagship case study</div>
+        <div class="card-ttl">SignalFoundry flagship case study</div>
         <div class="card-sub">Walk the alert-ingest to escalation path, inspect outputs, and follow the proof chain without leaving the production site.</div>
         <div class="lane-cta" aria-hidden="true">Read case study <span>→</span></div>
       </a>
@@ -83,7 +81,7 @@
         <span class="lane-tag">VERIFY</span>
         <div class="card-ttl">Run the verification yourself</div>
         <div class="card-sub">Clone the repo and run the verify script. All counts are reproducible commands against public artifacts.</div>
-        <div class="lane-cta" aria-hidden="true">Open proof pack <span>→</span></div>
+        <div class="lane-cta" aria-hidden="true">Review Proof <span>→</span></div>
       </a>
     </div>
   </div>
@@ -152,7 +150,7 @@
       <p class="m-copy">These are embedded because the lab should feel inspectable, not described from a distance. Each surface is tied to the environment, alerting path, or evidence workflow that supports the rest of the site.</p>
       <div class="m-lab-intro">
         <div class="m-card-kicker">Inspection order</div>
-        <p class="m-copy">Environment first, then alert surface, then virtualization context, then command-driven evidence. That order makes the lab read like system support for TriageLoop rather than a detached screenshot pile.</p>
+        <p class="m-copy">Environment first, then alert surface, then virtualization context, then command-driven evidence. That order makes the lab read like system support for SignalFoundry rather than a detached screenshot pile.</p>
       </div>
       <div class="m-lab-wall">
         <figure class="m-shot-frame">
@@ -161,7 +159,7 @@
             <span class="m-frame-tag">Environment</span>
           </div>
           <div class="m-frame-body">
-            <img src="/assets/pp_soc_integration/lab-architecture.svg" alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and TriageLoop pipeline boundaries" width="1200" height="510" loading="lazy">
+            <img src="/assets/pp_soc_integration/lab-architecture.svg" alt="SOC lab topology showing Proxmox, Windows endpoint, Wazuh, Splunk, and SignalFoundry pipeline boundaries" width="1200" height="510" loading="lazy">
             <p class="m-frame-caption">Purpose: show the actual topology behind the detections and escalation workflow.</p>
           </div>
         </figure>
@@ -295,7 +293,7 @@
     </div>
 
     <div style="margin-top:18px;display:flex;flex-wrap:wrap;gap:10px">
-      <a class="btn btn-p" href="/proof">Open proof pack</a>
+      <a class="btn btn-p" href="/proof">Review Proof</a>
       <a class="btn btn-g" href="/case-study-soc-integration">Read SOC integration case study</a>
       <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">Browse repository</a>
     </div>


### PR DESCRIPTION
## Summary

Freeze a single naming/nav/CTA/metrics/visual story for the live public site:

- **HawkinsOps** = umbrella brand
- **SignalFoundry** = flagship public system
- **AutoSOC engine** = internal implementation (subtitles/technical bullets only)
- **TriageLoop** = retired from public chrome

### Changes (P0 — 8 files)

| File | Change |
|---|---|
| `site/index.html` | Universal nav, hero H1 → SignalFoundry, CTAs → Review Proof / Read Case Study / Open Repo, metrics → Phase 3 canonical (33459 / 77.14% / 2478 / 8/8) |
| `site/proof.html` | Nav normalized, description updated |
| `site/case-study-autosoc.html` | Title/meta/H1 → SignalFoundry Case Study, subtitle added, TriageLoop → SignalFoundry throughout, Run Demo/Browse projects → Review Proof/Browse Detections, receipt drawer → proof surface |
| `site/soc-lab.html` | Nav normalized, featured card → SignalFoundry, Open proof pack → Review Proof, TriageLoop → SignalFoundry |
| `site/detections.html` | Nav normalized, leading sentence tying detections to SignalFoundry |
| `site/resume.html` | Nav normalized (resume content untouched) |
| `site/data/ops-metrics.js` | Replaced with canonical Phase 3 SignalFoundry payload |
| `site/assets/styles.css` | Appended dark-theme override for light mode + hidden theme toggle |

### Verification

**Banned naming scan** (zero results — PASS):
```
rg -n "TriageLoop|Read TriageLoop|Read AutoSOC|AutoSOC Case Study|AutoSOC Engine" site/*.html
```

**Stale numbers** (zero results — PASS):
```
rg -n "34206|4\.0%|25167|03-04-2026|6/8" site/index.html site/data/ops-metrics.js
```

**Canonical metrics present** (confirmed in index.html and ops-metrics.js — PASS):
```
rg -n "33459|77.14%|2478|8/8|PASS|SUCCESS|03-15-2026" site/index.html site/data/ops-metrics.js
```

**CSS overrides present** (confirmed — PASS):
```
rg -n 'html\[data-theme="light"\]|\.theme-btn' site/assets/styles.css
```

**Co-author trailer check** (zero results — PASS)

### Smoke Test Checklist

- [ ] `/` — Home: hero, CTAs, metrics grid
- [ ] `/proof` — Proof page: title, description
- [ ] `/case-study-autosoc` — Case Study: title, H1, subtitle, CTAs
- [ ] `/soc-lab` — Lab: featured card, proof CTA
- [ ] `/detections` — Detections: leading sentence, nav
- [ ] `/resume` — Resume: nav only, content untouched

### P1 (not in this PR)

- `metrics_pipeline/origin_main/data/metrics.json` sync
- `site/assets/app.js` JSON fetch adoption
- `site/assets/data/ops-metrics.json` creation