### PR TITLE
fix(site): align homepage with inner page design system

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -21,7 +21,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <main>

--- a/site/assets/coherence.css
+++ b/site/assets/coherence.css
@@ -28,10 +28,17 @@ html[data-theme="dark"] {
   --accent: #5fb3ff;
   --muted: #9eb4d8;
   --surface: #111827;
+  --surface-soft: #18212f;
   --text: #f8fafc;
+  --text-soft: #d4d4d8;
   --border: rgba(255, 255, 255, 0.12);
   --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.22);
   --shadow-md: 0 12px 28px rgba(0, 0, 0, 0.30);
+
+  /* Unify radius tokens — design-tokens (8px) vs modernize (4px) → 12px everywhere */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 12px;
 
   /* modernize.css primary palette: teal → blue/cyan */
   --primary-50: rgba(122, 184, 255, 0.08);
@@ -54,6 +61,9 @@ html[data-theme="light"] {
   --border: rgba(255, 255, 255, 0.12);
   --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.22);
   --shadow-md: 0 12px 28px rgba(0, 0, 0, 0.30);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 12px;
   --neutral-900: #111827;
   --primary-50: rgba(122, 184, 255, 0.08);
   --primary-100: rgba(122, 184, 255, 0.12);
@@ -90,9 +100,72 @@ body {
 }
 
 .sf-card {
-  background: linear-gradient(160deg, #111827 0%, #0d1420 100%);
-  border-color: rgba(255, 255, 255, 0.12);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.22);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+/* Homepage shell: match modernize .m-wrap width */
+.sf-shell {
+  max-width: 1200px;
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 0 0 64px;
+}
+
+/* Homepage section spacing: match .m-section */
+.sf-section {
+  padding: 40px 0 56px;
+}
+
+/* Homepage headings: match modernize heading rhythm */
+.sf-home h2 {
+  font-size: 1.5rem;
+  line-height: 1.2;
+  margin: 10px 0 10px;
+}
+
+@media (min-width: 1024px) {
+  .sf-home h2 {
+    font-size: 1.5rem;
+  }
+}
+
+/* Homepage metric cards: match .m-card padding */
+.sf-metric {
+  padding: 22px;
+}
+
+/* Homepage pipeline box: match card surface */
+.sf-pipeline {
+  background: var(--surface);
+  border-color: var(--border);
+  border-radius: var(--radius-lg);
+}
+
+/* Homepage buttons: match modernize link accent */
+.sf-button-primary {
+  background: #3b8fd9;
+  border-color: #3b8fd9;
+}
+
+.sf-button-secondary {
+  border-color: #3b8fd9;
+  color: #3b8fd9;
+}
+
+.sf-button-secondary:hover {
+  background: rgba(122, 184, 255, 0.08);
+}
+
+/* Homepage proof links: match .m-card-link color */
+.sf-proof-link strong {
+  color: var(--text);
+}
+
+.sf-proof-link:hover {
+  border-color: rgba(122, 184, 255, 0.28);
 }
 
 
@@ -146,6 +219,12 @@ body {
    Already overridden by §2 body rule with !important.
    This section covers the .modernize-shell teal tint if any.
    ═══════════════════════════════════════════════════════════════════ */
+
+/* .m-card surface: match .sf-card and .card gradient for uniformity */
+.m-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+}
 
 /* modernize.css badge/step/flow accent pills: teal → blue */
 .m-badge {

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-autosoc.html
+++ b/site/case-study-autosoc.html
@@ -28,7 +28,7 @@
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-09-2026-2">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-cve-patch.html
+++ b/site/case-study-cve-patch.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-detection-harness.html
+++ b/site/case-study-detection-harness.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-honeypot.html
+++ b/site/case-study-honeypot.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-ir-howe01.html
+++ b/site/case-study-ir-howe01.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-ir-playbooks.html
+++ b/site/case-study-ir-playbooks.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-sigma-library.html
+++ b/site/case-study-sigma-library.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study-soc-integration.html
+++ b/site/case-study-soc-integration.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/detections.html
+++ b/site/detections.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-09-2026-2">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/honeypot-proof.html
+++ b/site/honeypot-proof.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <style>
   .proof-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:16px; margin: 16px 0 22px; }
   .proof-meta { background: var(--bg2); border:1px solid var(--bdr); border-radius:16px; padding:18px; }

--- a/site/index.html
+++ b/site/index.html
@@ -30,7 +30,7 @@
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <style>
   .sf-home {
     font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;

--- a/site/lab.html
+++ b/site/lab.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,follow">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>
 <body>

--- a/site/march-2026-release.html
+++ b/site/march-2026-release.html
@@ -26,7 +26,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/projects.html
+++ b/site/projects.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/proof.html
+++ b/site/proof.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-09-2026-2">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <script>
   document.documentElement.setAttribute('data-theme', 'dark');
 </script>

--- a/site/resume.html
+++ b/site/resume.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-09-2026-2">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <style>
   .resume-shell{padding-top:110px}
   .resume-sheet{max-width:960px;margin:0 auto;background:var(--bg1);border:1px solid var(--bdr);border-radius:16px;padding:28px}

--- a/site/security.html
+++ b/site/security.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,follow">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>
 <body>

--- a/site/soc-lab.html
+++ b/site/soc-lab.html
@@ -26,7 +26,7 @@
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-09-2026-4">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->

--- a/site/start-here.html
+++ b/site/start-here.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>
 <body>

--- a/site/triage.html
+++ b/site/triage.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,follow">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>
 <body>

--- a/site/wildcard.html
+++ b/site/wildcard.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-2">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
 </head>
 <body>
 <!-- @include:nav:start -->


### PR DESCRIPTION
## Summary

- Unified homepage `sf-*` component styles to match modernize `m-*` system on inner pages
- Fixed card border-radius (4px → 12px), shell width (1100px → 1200px), section padding, button accent color, card shadows, and heading sizes
- Unified `--radius-sm`, `--radius-md`, `--radius-lg` tokens across all three CSS systems
- Bumped coherence.css cache-bust to v3 on all 24 pages

## Test plan

- [ ] Homepage cards, spacing, and buttons visually match inner pages
- [ ] Click from homepage → any inner page with no jarring visual shift
- [ ] `node scripts/diagnose-site.js` passes (verified: 0 issues)