### PR TITLE
fix: correct content/ prefix in generate-verified-counts.ps1

### DIFF
--- a/PROOF_PACK/VERIFIED_COUNTS.md
+++ b/PROOF_PACK/VERIFIED_COUNTS.md
@@ -8,15 +8,15 @@ This file is generated from live repository file counts.
 
 | Platform | Count | Location |
 |----------|-------|----------|
-| **Sigma** (YAML) | **0** rules | content/detection-rules/sigma/ |
-| **Splunk** (SPL) | **0** queries | content/detection-rules/splunk/ |
-| **Wazuh** (XML) | **0** files, **0** rule blocks | content/detection-rules/wazuh/rules/ |
+| **Sigma** (YAML) | **103** rules | content/detection-rules/sigma/ |
+| **Splunk** (SPL) | **8** queries | content/detection-rules/splunk/ |
+| **Wazuh** (XML) | **24** files, **28** rule blocks | content/detection-rules/wazuh/rules/ |
 
 ## Incident Response
 
 | Type | Count | Location |
 |------|-------|----------|
-| **IR Playbooks** (IR-*.md) | **0** playbooks | content/incident-response/playbooks/ |
+| **IR Playbooks** (IR-*.md) | **10** playbooks | content/incident-response/playbooks/ |
 
 ---
 

--- a/scripts/verify/generate-verified-counts.ps1
+++ b/scripts/verify/generate-verified-counts.ps1
@@ -6,10 +6,10 @@ param(
 $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
-$sigmaPath = Join-Path $repoRoot "detection-rules\sigma"
-$splunkPath = Join-Path $repoRoot "detection-rules\splunk"
-$wazuhPath = Join-Path $repoRoot "detection-rules\wazuh\rules"
-$playbookPath = Join-Path $repoRoot "incident-response\playbooks"
+$sigmaPath = Join-Path $repoRoot "content\detection-rules\sigma"
+$splunkPath = Join-Path $repoRoot "content\detection-rules\splunk"
+$wazuhPath = Join-Path $repoRoot "content\detection-rules\wazuh\rules"
+$playbookPath = Join-Path $repoRoot "content\incident-response\playbooks"
 $outPath = if ([System.IO.Path]::IsPathRooted($OutFile)) { $OutFile } else { Join-Path $repoRoot $OutFile }
 
 $sigmaYml = (Get-ChildItem -Recurse -Filter *.yml -Path $sigmaPath -ErrorAction SilentlyContinue).Count


### PR DESCRIPTION
## Summary

- Fixed `generate-verified-counts.ps1` path bug: used `detection-rules/sigma` but actual structure is `content/detection-rules/sigma`
- This caused VERIFIED_COUNTS.md to be written with all zeros, which broke drift-scan CI
- Regenerated VERIFIED_COUNTS.md with correct counts: 103 Sigma, 8 Splunk, 24 Wazuh files / 28 blocks, 10 IR playbooks

## Test plan

- [ ] `pwsh -File scripts/verify/generate-verified-counts.ps1` produces correct counts
- [ ] `python scripts/drift_scan.py` passes (verified locally: PASS)
- [ ] drift-scan CI job passes