### PR TITLE
Fix: tighten entry-surface naming and navigation

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -11,29 +11,7 @@
   const OPS_TIMEOUT_MS = 1500;
   const isLocalDebugHost = /^(localhost|127\.0\.0\.1)$/.test(window.location.hostname);
 
-  // Theme toggle (saved preference, otherwise system preference)
-  const themeToggle = $('#themeToggle');
-  const savedTheme = localStorage.getItem('rh-theme');
-  const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const startTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
-  html.setAttribute('data-theme', startTheme);
-
-  function updateThemeButton(theme) {
-    if (!themeToggle) return;
-    const next = theme === 'dark' ? 'light' : 'dark';
-    themeToggle.textContent = theme === 'dark' ? 'Light' : 'Dark';
-    themeToggle.setAttribute('aria-label', `Switch to ${next} mode`);
-  }
-  updateThemeButton(startTheme);
-  if (themeToggle) {
-    themeToggle.addEventListener('click', () => {
-      const current = html.getAttribute('data-theme') || 'dark';
-      const next = current === 'dark' ? 'light' : 'dark';
-      html.setAttribute('data-theme', next);
-      localStorage.setItem('rh-theme', next);
-      updateThemeButton(next);
-    });
-  }
+  html.setAttribute('data-theme', 'dark');
 
   // Mobile nav
   const mobBtn = $('#mobBtn');

--- a/site/index.html
+++ b/site/index.html
@@ -42,7 +42,7 @@
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
       <li><a href="/proof">Proof</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
@@ -53,7 +53,7 @@
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
   <a href="/proof">Proof</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-study-autosoc">SignalFoundry Case Study</a>
   <a href="/detections">Detections</a>
   <a href="/soc-lab">Lab</a>
   <a href="/resume">Resume</a>
@@ -73,10 +73,10 @@
         <span class="sf-role-tag">Detection Engineering</span>
         <span class="sf-role-tag">Security Automation</span>
       </div>
-      <p class="sf-body sf-body-lead">Evidence-first cybersecurity portfolio built around a live SOC triage and proof pipeline.</p>
+      <p class="sf-body sf-body-lead">Evidence-first cybersecurity portfolio built around a SOC triage and proof pipeline.</p>
       <p class="sf-body">Every public metric on this site is generated from repo artifacts and verified by CI. SignalFoundry ingests Wazuh alerts, applies policy-driven triage, enforces redaction, and publishes reviewable proof only after reconciliation and coverage checks pass.</p>
       <div class="sf-actions">
-        <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">Read Case Study</a>
+        <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">Read SignalFoundry Case Study</a>
         <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Review Proof</a>
         <a class="sf-button sf-button-secondary sf-focus-ring" href="/resume">Resume</a>
         <a class="sf-button sf-button-secondary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">GitHub</a>
@@ -126,7 +126,7 @@
             </svg>
           </div>
           <div class="sf-actions sf-actions-compact">
-            <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">Full Case Study</a>
+            <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">Full SignalFoundry Case Study</a>
             <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Proof Artifacts</a>
           </div>
         </div>
@@ -202,6 +202,7 @@
           <p class="sf-metric-note">Cases packaged with evidence and committed to the proof repository.</p>
         </article>
       </div>
+      <p class="sf-body sf-copy-gap-lg">These metrics reflect a controlled contract environment focused on detection validation and rule development rather than incident escalation volume.</p>
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════════
@@ -217,7 +218,7 @@
           <p>Fastest path through the strongest proof artifacts. Best first stop for most reviewers.</p>
         </a>
         <a class="sf-card sf-route-card sf-focus-ring" href="/case-study-autosoc">
-          <h3>AutoSOC Case Study</h3>
+          <h3>SignalFoundry Case Study</h3>
           <p>SignalFoundry walkthrough covering architecture, triage logic, outputs, and recovery work.</p>
         </a>
         <a class="sf-card sf-route-card sf-focus-ring" href="/proof">

--- a/site/start-here.html
+++ b/site/start-here.html
@@ -5,6 +5,14 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Fast reviewer path for SignalFoundry: proof, verified counts, case study, and reproduction commands.">
+<link rel="canonical" href="https://hawkinsops.com/start-here">
+<meta property="og:type" content="website">
+<meta property="og:title" content="SignalFoundry | Start Here">
+<meta property="og:description" content="Fast reviewer path for SignalFoundry: proof, verified counts, case study, and reproduction commands.">
+<meta property="og:url" content="https://hawkinsops.com/start-here">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="SignalFoundry | Start Here">
+<meta name="twitter:description" content="Fast reviewer path for SignalFoundry: proof, verified counts, case study, and reproduction commands.">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-15-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-15-2026-1">
@@ -20,7 +28,7 @@
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
       <li><a href="/proof">Proof</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry Case Study</a></li>
       <li><a href="/detections">Detections</a></li>
       <li><a href="/soc-lab">Lab</a></li>
       <li><a href="/resume">Resume</a></li>
@@ -28,6 +36,14 @@
     <a class="btn btn-p nav-cta" href="/proof">Review Proof</a>
   </div>
 </nav>
+<div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
+  <a href="/">Home</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">SignalFoundry Case Study</a>
+  <a href="/detections">Detections</a>
+  <a href="/soc-lab">Lab</a>
+  <a href="/resume">Resume</a>
+</div>
 <main class="sf-shell">
   <section class="sf-section">
     <div class="sf-eyebrow">Reviewer Path</div>
@@ -47,8 +63,8 @@
     </article>
     <article class="sf-card" style="padding:24px;">
       <h2>3. Implementation</h2>
-      <p>The AutoSOC engine case study explains the current implementation behind SignalFoundry.</p>
-      <p style="margin-top:16px;"><a class="sf-focus-ring" href="/case-study-autosoc">Open engine case study</a></p>
+      <p>The SignalFoundry case study explains the system architecture, while AutoSOC is the internal engine behind it.</p>
+      <p style="margin-top:16px;"><a class="sf-focus-ring" href="/case-study-autosoc">Open SignalFoundry case study</a></p>
     </article>
   </section>
   <section class="sf-section">


### PR DESCRIPTION
## Summary
- fix the dead mobile nav control on /start-here by adding the mobile menu container
- remove contradictory theme preference logic and keep the public site dark-only
- add social metadata to /start-here and normalize SignalFoundry naming on the entry surfaces
- add context under homepage metrics so controlled contract numbers read correctly
- remove the reintroduced live phrasing from the homepage hero

## Verification
- pwsh -NoProfile -File scripts/verify/verify-counts.ps1
- python scripts/drift_scan.py
- node scripts/verify/site-runtime-contract.js
- node scripts/diagnose-site.js --fail-on-issues