### PR TITLE
proof: sync honeypot and grafana evidence artifacts

### DIFF
--- a/proof/grafana/latest.dashboard.json
+++ b/proof/grafana/latest.dashboard.json
@@ -1,0 +1,98 @@
+{
+  "uid": "honeypot-ops",
+  "title": "Honeypot Ops",
+  "schemaVersion": 38,
+  "version": 1,
+  "timezone": "browser",
+  "tags": ["honeypot", "cowrie", "wazuh"],
+  "time": { "from": "now-24h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Sessions Over Time",
+      "id": 1,
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "description": "Counts Cowrie-related events over time using rule.groups:cowrie.",
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "wazuh_indexer" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "rule.groups:cowrie",
+          "queryType": "lucene",
+          "metrics": [
+            { "id": "1", "type": "count" }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "date_histogram",
+              "field": "@timestamp",
+              "settings": { "interval": "auto" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Top Usernames",
+      "id": 2,
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "description": "Top usernames observed. Adjust field if your pipeline uses a different key.",
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "wazuh_indexer" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "rule.groups:cowrie",
+          "queryType": "lucene",
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "data.username.keyword",
+              "settings": { "size": 10, "order": "desc", "orderBy": "_count" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Top Commands",
+      "id": 3,
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "description": "Top commands observed. Adjust field if your pipeline uses a different key.",
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "wazuh_indexer" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "rule.groups:cowrie",
+          "queryType": "lucene",
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "data.command.keyword",
+              "settings": { "size": 10, "order": "desc", "orderBy": "_count" }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "templating": { "list": [] },
+  "annotations": { "list": [] }
+}

--- a/proof/grafana/latest.md
+++ b/proof/grafana/latest.md
@@ -1,0 +1,10 @@
+# Grafana Dashboard Proof (Sanitized Export)
+
+- Generated (UTC): 2026-03-20T05:57:56Z
+- Source: content/projects/lab/honeypot-grafana-wazuh/grafana/dashboards/honeypot_ops.json
+- SHA256: 067fe3c5fd1e59128c388e7a690db5a99b37c84e0f30666c20ece9ccf6f4ed29
+- Bytes: 2759
+
+Artifacts:
+- latest.dashboard.json
+- latest.meta.json

--- a/proof/grafana/latest.meta.json
+++ b/proof/grafana/latest.meta.json
@@ -1,0 +1,6 @@
+{
+  "generated_utc": "2026-03-20T05:57:56Z",
+  "source_path": "content/projects/lab/honeypot-grafana-wazuh/grafana/dashboards/honeypot_ops.json",
+  "sha256": "067fe3c5fd1e59128c388e7a690db5a99b37c84e0f30666c20ece9ccf6f4ed29",
+  "bytes": 2759
+}

--- a/proof/wazuh/honeypot/latest.json
+++ b/proof/wazuh/honeypot/latest.json
@@ -1,283 +1,112 @@
 [
   {
-    "ts": "2026-02-24T12:55:51.052+0000",
+    "ts": "03/19/2026 01:55:04",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "503",
-      "level": 3,
-      "desc": "Wazuh agent started."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T12:56:23.109+0000",
+    "ts": "03/19/2026 01:55:06",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5710",
-      "level": 5,
-      "desc": "sshd: Attempt to login using a non-existent user"
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T12:58:39.181+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5901",
-      "level": 8,
-      "desc": "New group added to the system."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T12:58:39.181+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5902",
-      "level": 8,
-      "desc": "New user added to the system."
+      "id": "2902",
+      "level": 7,
+      "desc": "New dpkg (Debian Package) installed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T12:58:57.219+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:06:17.126+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5760",
-      "level": 5,
-      "desc": "sshd: authentication failed."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:06:17.168+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5760",
-      "level": 5,
-      "desc": "sshd: authentication failed."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:07:35.148+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
+      "id": "2902",
+      "level": 7,
+      "desc": "New dpkg (Debian Package) installed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:07:35.148+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5715",
-      "level": 3,
-      "desc": "sshd: authentication success."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:07:35.170+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:07:35.211+0000",
+    "ts": "03/19/2026 01:55:16",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
+      "id": "2902",
+      "level": 7,
+      "desc": "New dpkg (Debian Package) installed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:07:45.156+0000",
+    "ts": "03/19/2026 02:02:52",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:21:53.226+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5715",
-      "level": 3,
-      "desc": "sshd: authentication success."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:21:53.243+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:21:53.243+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:22:11.232+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:23:03.247+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5405",
-      "level": 5,
-      "desc": "Unauthorized user attempted to use sudo."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:24:09.301+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5555",
-      "level": 3,
-      "desc": "PAM: User changed password."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:25:39.270+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:25:57.278+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5404",
+      "id": "23505",
       "level": 10,
-      "desc": "Three failed attempts to run sudo"
+      "desc": "CVE-2024-5138 affects snapd"
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:26:01.279+0000",
+    "ts": "03/19/2026 04:49:57",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
+      "id": "550",
+      "level": 7,
+      "desc": "Integrity checksum changed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:26:21.281+0000",
+    "ts": "03/19/2026 04:49:58",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5404",
-      "level": 10,
-      "desc": "Three failed attempts to run sudo"
+      "id": "550",
+      "level": 7,
+      "desc": "Integrity checksum changed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:26:39.283+0000",
+    "ts": "03/19/2026 04:49:59",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:26:53.284+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5404",
-      "level": 10,
-      "desc": "Three failed attempts to run sudo"
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:43.287+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5403",
-      "level": 4,
-      "desc": "First time user executed sudo."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:43.329+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:43.329+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:51.288+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "100110",
-      "level": 5,
-      "desc": "Honeypot deterministic demo alert (HONEY_DEMO)."
+      "id": "550",
+      "level": 7,
+      "desc": "Integrity checksum changed."
     },
     "has_srcip": false
   }
 ]
-

--- a/proof/wazuh/honeypot/latest.md
+++ b/proof/wazuh/honeypot/latest.md
@@ -1,39 +1,22 @@
 # Wazuh Honeypot Proof (Sanitized)
 
-- Last generated (UTC): 2026-02-24T13:34:35Z
+- Last generated (UTC): 2026-03-20T05:57:23Z
 - Agent: [REDACTED_HOST]
-- Exported alerts: 28
+- Exported alerts: 11
 
 Fields per alert: `ts`, `agent`, `rule.id`, `rule.level`, `rule.desc`, `has_srcip`
 
 ## Latest alerts
 
-- 2026-02-24T12:55:51.052+0000 | rule.id=503 | level=3 | Wazuh agent started.
-- 2026-02-24T12:56:23.109+0000 | rule.id=5710 | level=5 | sshd: Attempt to login using a non-existent user
-- 2026-02-24T12:58:39.181+0000 | rule.id=5901 | level=8 | New group added to the system.
-- 2026-02-24T12:58:39.181+0000 | rule.id=5902 | level=8 | New user added to the system.
-- 2026-02-24T12:58:57.219+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:06:17.126+0000 | rule.id=5760 | level=5 | sshd: authentication failed.
-- 2026-02-24T13:06:17.168+0000 | rule.id=5760 | level=5 | sshd: authentication failed.
-- 2026-02-24T13:07:35.148+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:07:35.148+0000 | rule.id=5715 | level=3 | sshd: authentication success.
-- 2026-02-24T13:07:35.170+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:07:35.211+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:07:45.156+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:21:53.226+0000 | rule.id=5715 | level=3 | sshd: authentication success.
-- 2026-02-24T13:21:53.243+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:21:53.243+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:22:11.232+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:23:03.247+0000 | rule.id=5405 | level=5 | Unauthorized user attempted to use sudo.
-- 2026-02-24T13:24:09.301+0000 | rule.id=5555 | level=3 | PAM: User changed password.
-- 2026-02-24T13:25:39.270+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:25:57.278+0000 | rule.id=5404 | level=10 | Three failed attempts to run sudo
-- 2026-02-24T13:26:01.279+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:26:21.281+0000 | rule.id=5404 | level=10 | Three failed attempts to run sudo
-- 2026-02-24T13:26:39.283+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:26:53.284+0000 | rule.id=5404 | level=10 | Three failed attempts to run sudo
-- 2026-02-24T13:27:43.287+0000 | rule.id=5403 | level=4 | First time user executed sudo.
-- 2026-02-24T13:27:43.329+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:27:43.329+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:27:51.288+0000 | rule.id=100110 | level=5 | Honeypot deterministic demo alert (HONEY_DEMO).
+- 03/19/2026 01:55:04 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:06 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:14 | rule.id=2902 | level=7 | New dpkg (Debian Package) installed.
+- 03/19/2026 01:55:14 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:14 | rule.id=2902 | level=7 | New dpkg (Debian Package) installed.
+- 03/19/2026 01:55:14 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:16 | rule.id=2902 | level=7 | New dpkg (Debian Package) installed.
+- 03/19/2026 02:02:52 | rule.id=23505 | level=10 | CVE-2024-5138 affects snapd
+- 03/19/2026 04:49:57 | rule.id=550 | level=7 | Integrity checksum changed.
+- 03/19/2026 04:49:58 | rule.id=550 | level=7 | Integrity checksum changed.
+- 03/19/2026 04:49:59 | rule.id=550 | level=7 | Integrity checksum changed.
 

--- a/proof/wazuh/honeypot/latest.meta.json
+++ b/proof/wazuh/honeypot/latest.meta.json
@@ -1,7 +1,6 @@
 {
-  "generated_utc": "2026-02-24T13:34:35Z",
-  "exported_count": 28,
+  "generated_utc": "2026-03-20T05:57:23Z",
+  "exported_count": 11,
   "agent_name": "[REDACTED_HOST]",
-  "last_rule_id": "100110"
+  "last_rule_id": "550"
 }
-

--- a/proof/wazuh/honeypot/latest.summary.json
+++ b/proof/wazuh/honeypot/latest.summary.json
@@ -1,46 +1,26 @@
 {
-  "generated_utc": "2026-02-24T13:34:35Z",
+  "generated_utc": "2026-03-20T05:57:23Z",
   "source_artifact": "latest.json",
-  "source_count": 28,
+  "source_count": 11,
   "top_rules": [
     {
-      "rule_id": "5501",
-      "desc": "PAM: Login session opened.",
-      "count": 5
-    },
-    {
-      "rule_id": "5502",
-      "desc": "PAM: Login session closed.",
+      "rule_id": "2904",
+      "desc": "Dpkg (Debian Package) half configured.",
       "count": 4
     },
     {
-      "rule_id": "5503",
-      "desc": "PAM: User login failed.",
-      "count": 4
-    },
-    {
-      "rule_id": "5404",
-      "desc": "Three failed attempts to run sudo",
+      "rule_id": "550",
+      "desc": "Integrity checksum changed.",
       "count": 3
     },
     {
-      "rule_id": "5715",
-      "desc": "sshd: authentication success.",
-      "count": 2
+      "rule_id": "2902",
+      "desc": "New dpkg (Debian Package) installed.",
+      "count": 3
     },
     {
-      "rule_id": "5760",
-      "desc": "sshd: authentication failed.",
-      "count": 2
-    },
-    {
-      "rule_id": "100110",
-      "desc": "Honeypot deterministic demo alert (HONEY_DEMO).",
-      "count": 1
-    },
-    {
-      "rule_id": "503",
-      "desc": "Wazuh agent started.",
+      "rule_id": "23505",
+      "desc": "CVE-2024-5138 affects snapd",
       "count": 1
     }
   ]

--- a/site/proof/grafana/latest.dashboard.json
+++ b/site/proof/grafana/latest.dashboard.json
@@ -1,0 +1,98 @@
+{
+  "uid": "honeypot-ops",
+  "title": "Honeypot Ops",
+  "schemaVersion": 38,
+  "version": 1,
+  "timezone": "browser",
+  "tags": ["honeypot", "cowrie", "wazuh"],
+  "time": { "from": "now-24h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Sessions Over Time",
+      "id": 1,
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "description": "Counts Cowrie-related events over time using rule.groups:cowrie.",
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "wazuh_indexer" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "rule.groups:cowrie",
+          "queryType": "lucene",
+          "metrics": [
+            { "id": "1", "type": "count" }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "date_histogram",
+              "field": "@timestamp",
+              "settings": { "interval": "auto" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Top Usernames",
+      "id": 2,
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "description": "Top usernames observed. Adjust field if your pipeline uses a different key.",
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "wazuh_indexer" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "rule.groups:cowrie",
+          "queryType": "lucene",
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "data.username.keyword",
+              "settings": { "size": 10, "order": "desc", "orderBy": "_count" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Top Commands",
+      "id": 3,
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "description": "Top commands observed. Adjust field if your pipeline uses a different key.",
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "wazuh_indexer" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "rule.groups:cowrie",
+          "queryType": "lucene",
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "data.command.keyword",
+              "settings": { "size": 10, "order": "desc", "orderBy": "_count" }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "templating": { "list": [] },
+  "annotations": { "list": [] }
+}

--- a/site/proof/grafana/latest.md
+++ b/site/proof/grafana/latest.md
@@ -1,0 +1,10 @@
+# Grafana Dashboard Proof (Sanitized Export)
+
+- Generated (UTC): 2026-03-20T05:57:56Z
+- Source: content/projects/lab/honeypot-grafana-wazuh/grafana/dashboards/honeypot_ops.json
+- SHA256: 067fe3c5fd1e59128c388e7a690db5a99b37c84e0f30666c20ece9ccf6f4ed29
+- Bytes: 2759
+
+Artifacts:
+- latest.dashboard.json
+- latest.meta.json

--- a/site/proof/grafana/latest.meta.json
+++ b/site/proof/grafana/latest.meta.json
@@ -1,0 +1,6 @@
+{
+  "generated_utc": "2026-03-20T05:57:56Z",
+  "source_path": "content/projects/lab/honeypot-grafana-wazuh/grafana/dashboards/honeypot_ops.json",
+  "sha256": "067fe3c5fd1e59128c388e7a690db5a99b37c84e0f30666c20ece9ccf6f4ed29",
+  "bytes": 2759
+}

--- a/site/proof/wazuh/honeypot/latest.json
+++ b/site/proof/wazuh/honeypot/latest.json
@@ -1,283 +1,112 @@
 [
   {
-    "ts": "2026-02-24T12:55:51.052+0000",
+    "ts": "03/19/2026 01:55:04",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "503",
-      "level": 3,
-      "desc": "Wazuh agent started."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T12:56:23.109+0000",
+    "ts": "03/19/2026 01:55:06",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5710",
-      "level": 5,
-      "desc": "sshd: Attempt to login using a non-existent user"
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T12:58:39.181+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5901",
-      "level": 8,
-      "desc": "New group added to the system."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T12:58:39.181+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5902",
-      "level": 8,
-      "desc": "New user added to the system."
+      "id": "2902",
+      "level": 7,
+      "desc": "New dpkg (Debian Package) installed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T12:58:57.219+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:06:17.126+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5760",
-      "level": 5,
-      "desc": "sshd: authentication failed."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:06:17.168+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5760",
-      "level": 5,
-      "desc": "sshd: authentication failed."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:07:35.148+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
+      "id": "2902",
+      "level": 7,
+      "desc": "New dpkg (Debian Package) installed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:07:35.148+0000",
+    "ts": "03/19/2026 01:55:14",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5715",
-      "level": 3,
-      "desc": "sshd: authentication success."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:07:35.170+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
+      "id": "2904",
+      "level": 7,
+      "desc": "Dpkg (Debian Package) half configured."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:07:35.211+0000",
+    "ts": "03/19/2026 01:55:16",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
+      "id": "2902",
+      "level": 7,
+      "desc": "New dpkg (Debian Package) installed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:07:45.156+0000",
+    "ts": "03/19/2026 02:02:52",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:21:53.226+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5715",
-      "level": 3,
-      "desc": "sshd: authentication success."
-    },
-    "has_srcip": true
-  },
-  {
-    "ts": "2026-02-24T13:21:53.243+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:21:53.243+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:22:11.232+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:23:03.247+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5405",
-      "level": 5,
-      "desc": "Unauthorized user attempted to use sudo."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:24:09.301+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5555",
-      "level": 3,
-      "desc": "PAM: User changed password."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:25:39.270+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:25:57.278+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5404",
+      "id": "23505",
       "level": 10,
-      "desc": "Three failed attempts to run sudo"
+      "desc": "CVE-2024-5138 affects snapd"
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:26:01.279+0000",
+    "ts": "03/19/2026 04:49:57",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
+      "id": "550",
+      "level": 7,
+      "desc": "Integrity checksum changed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:26:21.281+0000",
+    "ts": "03/19/2026 04:49:58",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5404",
-      "level": 10,
-      "desc": "Three failed attempts to run sudo"
+      "id": "550",
+      "level": 7,
+      "desc": "Integrity checksum changed."
     },
     "has_srcip": false
   },
   {
-    "ts": "2026-02-24T13:26:39.283+0000",
+    "ts": "03/19/2026 04:49:59",
     "agent": "[REDACTED_HOST]",
     "rule": {
-      "id": "5503",
-      "level": 5,
-      "desc": "PAM: User login failed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:26:53.284+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5404",
-      "level": 10,
-      "desc": "Three failed attempts to run sudo"
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:43.287+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5403",
-      "level": 4,
-      "desc": "First time user executed sudo."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:43.329+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5501",
-      "level": 3,
-      "desc": "PAM: Login session opened."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:43.329+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "5502",
-      "level": 3,
-      "desc": "PAM: Login session closed."
-    },
-    "has_srcip": false
-  },
-  {
-    "ts": "2026-02-24T13:27:51.288+0000",
-    "agent": "[REDACTED_HOST]",
-    "rule": {
-      "id": "100110",
-      "level": 5,
-      "desc": "Honeypot deterministic demo alert (HONEY_DEMO)."
+      "id": "550",
+      "level": 7,
+      "desc": "Integrity checksum changed."
     },
     "has_srcip": false
   }
 ]
-

--- a/site/proof/wazuh/honeypot/latest.md
+++ b/site/proof/wazuh/honeypot/latest.md
@@ -1,39 +1,22 @@
 # Wazuh Honeypot Proof (Sanitized)
 
-- Last generated (UTC): 2026-02-24T13:34:35Z
+- Last generated (UTC): 2026-03-20T05:57:23Z
 - Agent: [REDACTED_HOST]
-- Exported alerts: 28
+- Exported alerts: 11
 
 Fields per alert: `ts`, `agent`, `rule.id`, `rule.level`, `rule.desc`, `has_srcip`
 
 ## Latest alerts
 
-- 2026-02-24T12:55:51.052+0000 | rule.id=503 | level=3 | Wazuh agent started.
-- 2026-02-24T12:56:23.109+0000 | rule.id=5710 | level=5 | sshd: Attempt to login using a non-existent user
-- 2026-02-24T12:58:39.181+0000 | rule.id=5901 | level=8 | New group added to the system.
-- 2026-02-24T12:58:39.181+0000 | rule.id=5902 | level=8 | New user added to the system.
-- 2026-02-24T12:58:57.219+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:06:17.126+0000 | rule.id=5760 | level=5 | sshd: authentication failed.
-- 2026-02-24T13:06:17.168+0000 | rule.id=5760 | level=5 | sshd: authentication failed.
-- 2026-02-24T13:07:35.148+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:07:35.148+0000 | rule.id=5715 | level=3 | sshd: authentication success.
-- 2026-02-24T13:07:35.170+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:07:35.211+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:07:45.156+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:21:53.226+0000 | rule.id=5715 | level=3 | sshd: authentication success.
-- 2026-02-24T13:21:53.243+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:21:53.243+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:22:11.232+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:23:03.247+0000 | rule.id=5405 | level=5 | Unauthorized user attempted to use sudo.
-- 2026-02-24T13:24:09.301+0000 | rule.id=5555 | level=3 | PAM: User changed password.
-- 2026-02-24T13:25:39.270+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:25:57.278+0000 | rule.id=5404 | level=10 | Three failed attempts to run sudo
-- 2026-02-24T13:26:01.279+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:26:21.281+0000 | rule.id=5404 | level=10 | Three failed attempts to run sudo
-- 2026-02-24T13:26:39.283+0000 | rule.id=5503 | level=5 | PAM: User login failed.
-- 2026-02-24T13:26:53.284+0000 | rule.id=5404 | level=10 | Three failed attempts to run sudo
-- 2026-02-24T13:27:43.287+0000 | rule.id=5403 | level=4 | First time user executed sudo.
-- 2026-02-24T13:27:43.329+0000 | rule.id=5501 | level=3 | PAM: Login session opened.
-- 2026-02-24T13:27:43.329+0000 | rule.id=5502 | level=3 | PAM: Login session closed.
-- 2026-02-24T13:27:51.288+0000 | rule.id=100110 | level=5 | Honeypot deterministic demo alert (HONEY_DEMO).
+- 03/19/2026 01:55:04 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:06 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:14 | rule.id=2902 | level=7 | New dpkg (Debian Package) installed.
+- 03/19/2026 01:55:14 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:14 | rule.id=2902 | level=7 | New dpkg (Debian Package) installed.
+- 03/19/2026 01:55:14 | rule.id=2904 | level=7 | Dpkg (Debian Package) half configured.
+- 03/19/2026 01:55:16 | rule.id=2902 | level=7 | New dpkg (Debian Package) installed.
+- 03/19/2026 02:02:52 | rule.id=23505 | level=10 | CVE-2024-5138 affects snapd
+- 03/19/2026 04:49:57 | rule.id=550 | level=7 | Integrity checksum changed.
+- 03/19/2026 04:49:58 | rule.id=550 | level=7 | Integrity checksum changed.
+- 03/19/2026 04:49:59 | rule.id=550 | level=7 | Integrity checksum changed.
 

--- a/site/proof/wazuh/honeypot/latest.meta.json
+++ b/site/proof/wazuh/honeypot/latest.meta.json
@@ -1,7 +1,6 @@
 {
-  "generated_utc": "2026-02-24T13:34:35Z",
-  "exported_count": 28,
+  "generated_utc": "2026-03-20T05:57:23Z",
+  "exported_count": 11,
   "agent_name": "[REDACTED_HOST]",
-  "last_rule_id": "100110"
+  "last_rule_id": "550"
 }
-

--- a/site/proof/wazuh/honeypot/latest.summary.json
+++ b/site/proof/wazuh/honeypot/latest.summary.json
@@ -1,46 +1,26 @@
 {
-  "generated_utc": "2026-02-24T13:34:35Z",
+  "generated_utc": "2026-03-20T05:57:23Z",
   "source_artifact": "latest.json",
-  "source_count": 28,
+  "source_count": 11,
   "top_rules": [
     {
-      "rule_id": "5501",
-      "desc": "PAM: Login session opened.",
-      "count": 5
-    },
-    {
-      "rule_id": "5502",
-      "desc": "PAM: Login session closed.",
+      "rule_id": "2904",
+      "desc": "Dpkg (Debian Package) half configured.",
       "count": 4
     },
     {
-      "rule_id": "5503",
-      "desc": "PAM: User login failed.",
-      "count": 4
-    },
-    {
-      "rule_id": "5404",
-      "desc": "Three failed attempts to run sudo",
+      "rule_id": "550",
+      "desc": "Integrity checksum changed.",
       "count": 3
     },
     {
-      "rule_id": "5715",
-      "desc": "sshd: authentication success.",
-      "count": 2
+      "rule_id": "2902",
+      "desc": "New dpkg (Debian Package) installed.",
+      "count": 3
     },
     {
-      "rule_id": "5760",
-      "desc": "sshd: authentication failed.",
-      "count": 2
-    },
-    {
-      "rule_id": "100110",
-      "desc": "Honeypot deterministic demo alert (HONEY_DEMO).",
-      "count": 1
-    },
-    {
-      "rule_id": "503",
-      "desc": "Wazuh agent started.",
+      "rule_id": "23505",
+      "desc": "CVE-2024-5138 affects snapd",
       "count": 1
     }
   ]


### PR DESCRIPTION
## Summary
- sync updated honeypot proof artifacts into both proof and site/proof lanes
- add grafana proof artifacts in both proof and site/proof lanes
- keep this PR scoped to generated evidence artifacts only

## Paths
- proof/wazuh/honeypot/*
- site/proof/wazuh/honeypot/*
- proof/grafana/*
- site/proof/grafana/*