### PR TITLE
feat: continuous detection validation + quality scorecard lanes

### DIFF
--- a/.github/workflows/update-site-data.yml
+++ b/.github/workflows/update-site-data.yml
@@ -6,8 +6,13 @@ on:
     paths:
       - "PROOF_PACK/verified_counts.json"
       - "proof/autosoc/latest/**"
+      - "proof/grafana/**"
+      - "content/lab/proxmox/vms/104/splunk/exports/**"
       - "scripts/generate-metrics.js"
+      - "scripts/generate-proof-lanes.js"
       - "scripts/generate-site-data.js"
+  schedule:
+    - cron: "17 */6 * * *"
   workflow_dispatch:
 
 jobs:
@@ -29,6 +34,7 @@ jobs:
         shell: pwsh
         run: |
           node .\scripts\generate-metrics.js
+          node .\scripts\generate-proof-lanes.js
           python .\scripts\validate_metrics.py
           node .\scripts\generate-site-data.js
           node .\scripts\verify\site-runtime-contract.js
@@ -37,7 +43,7 @@ jobs:
         id: diff
         shell: bash
         run: |
-          git diff --quiet data/metrics.json data/metrics.json.sha256 site/data/ site/assets/data/ site/assets/verified-counts.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+          git diff --quiet data/metrics.json data/metrics.json.sha256 proof/validation/ proof/quality/ site/proof/validation/ site/proof/quality/ site/data/ site/assets/data/ site/assets/verified-counts.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Commit and push updated site data
         if: steps.diff.outputs.changed == 'true'
@@ -45,6 +51,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/metrics.json data/metrics.json.sha256 site/data/ site/assets/data/ site/assets/verified-counts.json
+          git add data/metrics.json data/metrics.json.sha256 proof/validation/ proof/quality/ site/proof/validation/ site/proof/quality/ site/data/ site/assets/data/ site/assets/verified-counts.json
           git commit -m "chore(site): auto-regenerate site data from source artifacts"
           git push

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,6 +30,7 @@ jobs:
         shell: pwsh
         run: |
           node .\scripts\generate-metrics.js
+          node .\scripts\generate-proof-lanes.js
           python .\scripts\validate_metrics.py
           node .\scripts\generate-site-data.js
           node .\scripts\generate-site-content.js

--- a/proof/quality/latest.json
+++ b/proof/quality/latest.json
@@ -1,0 +1,54 @@
+{
+  "generated_utc": "2026-03-20T16:37:27.292Z",
+  "scorecard_window": "lifetime_runtime_snapshot",
+  "source_metrics": "data/metrics.json",
+  "totals": {
+    "total_cases": 49774,
+    "auto_closed_benign": 20942,
+    "known_fp": 18366,
+    "escalated": 2478,
+    "review": 7795,
+    "staged_pending": 193
+  },
+  "scorecard": {
+    "status": "PASS",
+    "metrics": [
+      {
+        "id": "auto_close_benign_pct",
+        "value": 42.07,
+        "target": ">= 35",
+        "status": "PASS"
+      },
+      {
+        "id": "known_fp_pct",
+        "value": 36.9,
+        "target": "<= 45",
+        "status": "PASS"
+      },
+      {
+        "id": "escalation_pct",
+        "value": 4.98,
+        "target": ">= 3",
+        "status": "PASS"
+      },
+      {
+        "id": "review_backlog_pct",
+        "value": 15.66,
+        "target": "<= 20",
+        "status": "PASS"
+      },
+      {
+        "id": "staged_pending_pct",
+        "value": 0.39,
+        "target": "<= 1",
+        "status": "PASS"
+      },
+      {
+        "id": "reconciliation_mismatch_count",
+        "value": 0,
+        "target": "0",
+        "status": "PASS"
+      }
+    ]
+  }
+}

--- a/proof/quality/latest.md
+++ b/proof/quality/latest.md
@@ -1,0 +1,26 @@
+# Alert Quality Scorecard
+
+- Generated (UTC): 2026-03-20T16:37:27.292Z
+- Window: lifetime_runtime_snapshot
+- Overall status: PASS
+- Source: `data/metrics.json`
+
+## Totals
+
+- Total cases: 49774
+- Auto-closed benign: 20942
+- Known false positive: 18366
+- Escalated: 2478
+- Review backlog: 7795
+- Staged pending: 193
+
+## Scorecard
+
+| Metric | Value | Target | Status |
+|---|---:|---|---|
+| auto_close_benign_pct | 42.07 | >= 35 | PASS |
+| known_fp_pct | 36.9 | <= 45 | PASS |
+| escalation_pct | 4.98 | >= 3 | PASS |
+| review_backlog_pct | 15.66 | <= 20 | PASS |
+| staged_pending_pct | 0.39 | <= 1 | PASS |
+| reconciliation_mismatch_count | 0 | 0 | PASS |

--- a/proof/validation/latest.json
+++ b/proof/validation/latest.json
@@ -1,0 +1,51 @@
+{
+  "generated_utc": "2026-03-20T16:37:27.292Z",
+  "validation_window": "rolling_latest_artifacts",
+  "suite": "continuous-detection-validation",
+  "summary": {
+    "checks_total": 6,
+    "checks_passed": 6,
+    "checks_watch": 0,
+    "checks_failed": 0,
+    "pass_rate_pct": 100,
+    "overall_status": "PASS"
+  },
+  "checks": [
+    {
+      "id": "heartbeat",
+      "status": "PASS",
+      "value": "SUCCESS",
+      "source": "data/metrics.json"
+    },
+    {
+      "id": "reconciliation_mismatch",
+      "status": "PASS",
+      "value": 0,
+      "source": "proof/autosoc/latest/reconciliation_latest.json"
+    },
+    {
+      "id": "coverage_required_hosts",
+      "status": "PASS",
+      "value": "8/8",
+      "source": "data/metrics.json"
+    },
+    {
+      "id": "pipeline_last_status",
+      "status": "PASS",
+      "value": "SUCCESS",
+      "source": "proof/autosoc/latest/run_metrics_latest.json"
+    },
+    {
+      "id": "splunk_ingest_proof_present",
+      "status": "PASS",
+      "value": "content/lab/proxmox/vms/104/splunk/exports/WAZUH_SPLUNK_PIPELINE_PROOF_2026-03-20.md",
+      "source": "filesystem"
+    },
+    {
+      "id": "grafana_proof_present",
+      "status": "PASS",
+      "value": "proof/grafana/latest.md",
+      "source": "filesystem"
+    }
+  ]
+}

--- a/proof/validation/latest.md
+++ b/proof/validation/latest.md
@@ -1,0 +1,17 @@
+# Continuous Detection Validation
+
+- Generated (UTC): 2026-03-20T16:37:27.292Z
+- Suite: continuous-detection-validation
+- Overall status: PASS
+- Checks passed: 6/6 (100%)
+
+## Checks
+
+| Check | Status | Value | Source |
+|---|---|---|---|
+| heartbeat | PASS | SUCCESS | `data/metrics.json` |
+| reconciliation_mismatch | PASS | 0 | `proof/autosoc/latest/reconciliation_latest.json` |
+| coverage_required_hosts | PASS | 8/8 | `data/metrics.json` |
+| pipeline_last_status | PASS | SUCCESS | `proof/autosoc/latest/run_metrics_latest.json` |
+| splunk_ingest_proof_present | PASS | content/lab/proxmox/vms/104/splunk/exports/WAZUH_SPLUNK_PIPELINE_PROOF_2026-03-20.md | `filesystem` |
+| grafana_proof_present | PASS | proof/grafana/latest.md | `filesystem` |

--- a/scripts/generate-proof-lanes.js
+++ b/scripts/generate-proof-lanes.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const root = process.cwd();
+const now = new Date().toISOString();
+
+const metricsPath = path.join(root, "data", "metrics.json");
+const runMetricsPath = path.join(root, "proof", "autosoc", "latest", "run_metrics_latest.json");
+const reconciliationPath = path.join(root, "proof", "autosoc", "latest", "reconciliation_latest.json");
+const coveragePath = path.join(root, "proof", "autosoc", "latest", "coverage_latest.json");
+
+const splunkProofPath = path.join(
+  root,
+  "content",
+  "lab",
+  "proxmox",
+  "vms",
+  "104",
+  "splunk",
+  "exports",
+  "WAZUH_SPLUNK_PIPELINE_PROOF_2026-03-20.md"
+);
+const grafanaProofPath = path.join(root, "proof", "grafana", "latest.md");
+
+const proofValidationJsonPath = path.join(root, "proof", "validation", "latest.json");
+const proofValidationMdPath = path.join(root, "proof", "validation", "latest.md");
+const siteValidationJsonPath = path.join(root, "site", "proof", "validation", "latest.json");
+const siteValidationMdPath = path.join(root, "site", "proof", "validation", "latest.md");
+
+const proofQualityJsonPath = path.join(root, "proof", "quality", "latest.json");
+const proofQualityMdPath = path.join(root, "proof", "quality", "latest.md");
+const siteQualityJsonPath = path.join(root, "site", "proof", "quality", "latest.json");
+const siteQualityMdPath = path.join(root, "site", "proof", "quality", "latest.md");
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing required input: ${path.relative(root, filePath)}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function ensureDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function pct(numerator, denominator) {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) return 0;
+  return Number(((numerator / denominator) * 100).toFixed(2));
+}
+
+function parseRatio(value) {
+  const match = String(value || "").trim().match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (!match) return { numerator: 0, denominator: 0 };
+  return { numerator: Number(match[1]), denominator: Number(match[2]) };
+}
+
+function writeJson(filePath, payload) {
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function writeText(filePath, text) {
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, text, "utf8");
+}
+
+function buildValidationLane() {
+  const metrics = readJson(metricsPath);
+  const runMetrics = readJson(runMetricsPath);
+  const reconciliation = readJson(reconciliationPath);
+  const coverage = readJson(coveragePath);
+
+  const coverageRatio = String(metrics.host_coverage || `${Number(coverage.present_hosts)}/${Number(coverage.required_hosts)}`);
+  const coverageParsed = parseRatio(coverageRatio);
+
+  const checks = [
+    {
+      id: "heartbeat",
+      status: metrics.heartbeat === "SUCCESS" ? "PASS" : "FAIL",
+      value: String(metrics.heartbeat || "UNKNOWN"),
+      source: "data/metrics.json"
+    },
+    {
+      id: "reconciliation_mismatch",
+      status: Number(reconciliation.mismatch_count) === 0 ? "PASS" : "FAIL",
+      value: Number(reconciliation.mismatch_count),
+      source: "proof/autosoc/latest/reconciliation_latest.json"
+    },
+    {
+      id: "coverage_required_hosts",
+      status: coverageParsed.denominator > 0 && coverageParsed.numerator >= coverageParsed.denominator ? "PASS" : "WATCH",
+      value: coverageRatio,
+      source: "data/metrics.json"
+    },
+    {
+      id: "pipeline_last_status",
+      status: String(runMetrics.status || "").toUpperCase() === "SUCCESS" ? "PASS" : "FAIL",
+      value: String(runMetrics.status || "UNKNOWN"),
+      source: "proof/autosoc/latest/run_metrics_latest.json"
+    },
+    {
+      id: "splunk_ingest_proof_present",
+      status: fs.existsSync(splunkProofPath) ? "PASS" : "FAIL",
+      value: path.relative(root, splunkProofPath).replaceAll("\\", "/"),
+      source: "filesystem"
+    },
+    {
+      id: "grafana_proof_present",
+      status: fs.existsSync(grafanaProofPath) ? "PASS" : "FAIL",
+      value: path.relative(root, grafanaProofPath).replaceAll("\\", "/"),
+      source: "filesystem"
+    }
+  ];
+
+  const passCount = checks.filter((check) => check.status === "PASS").length;
+  const failCount = checks.filter((check) => check.status === "FAIL").length;
+  const watchCount = checks.filter((check) => check.status === "WATCH").length;
+  const payload = {
+    generated_utc: now,
+    validation_window: "rolling_latest_artifacts",
+    suite: "continuous-detection-validation",
+    summary: {
+      checks_total: checks.length,
+      checks_passed: passCount,
+      checks_watch: watchCount,
+      checks_failed: failCount,
+      pass_rate_pct: pct(passCount, checks.length),
+      overall_status: failCount > 0 ? "FAIL" : watchCount > 0 ? "WATCH" : "PASS"
+    },
+    checks
+  };
+
+  const md = [
+    "# Continuous Detection Validation",
+    "",
+    `- Generated (UTC): ${payload.generated_utc}`,
+    `- Suite: ${payload.suite}`,
+    `- Overall status: ${payload.summary.overall_status}`,
+    `- Checks passed: ${payload.summary.checks_passed}/${payload.summary.checks_total} (${payload.summary.pass_rate_pct}%)`,
+    "",
+    "## Checks",
+    "",
+    "| Check | Status | Value | Source |",
+    "|---|---|---|---|",
+    ...checks.map((check) => `| ${check.id} | ${check.status} | ${check.value} | \`${check.source}\` |`)
+  ].join("\n");
+
+  return { payload, md };
+}
+
+function buildQualityLane() {
+  const metrics = readJson(metricsPath);
+  const totals = metrics.running_totals || {};
+  const totalCases = Number(totals.total_cases || 0);
+  const benign = Number(totals.auto_closed_benign || 0);
+  const knownFp = Number(totals.known_fp || 0);
+  const escalated = Number(totals.escalated || 0);
+  const review = Number(totals.review || 0);
+  const stagedPending = Number(totals.staged_pending || 0);
+  const mismatch = Number(metrics.reconciliation_mismatch || 0);
+
+  const metricsList = [
+    { id: "auto_close_benign_pct", value: pct(benign, totalCases), target: ">= 35", status: pct(benign, totalCases) >= 35 ? "PASS" : "WATCH" },
+    { id: "known_fp_pct", value: pct(knownFp, totalCases), target: "<= 45", status: pct(knownFp, totalCases) <= 45 ? "PASS" : "WATCH" },
+    { id: "escalation_pct", value: pct(escalated, totalCases), target: ">= 3", status: pct(escalated, totalCases) >= 3 ? "PASS" : "WATCH" },
+    { id: "review_backlog_pct", value: pct(review, totalCases), target: "<= 20", status: pct(review, totalCases) <= 20 ? "PASS" : "WATCH" },
+    { id: "staged_pending_pct", value: pct(stagedPending, totalCases), target: "<= 1", status: pct(stagedPending, totalCases) <= 1 ? "PASS" : "WATCH" },
+    { id: "reconciliation_mismatch_count", value: mismatch, target: "0", status: mismatch === 0 ? "PASS" : "FAIL" }
+  ];
+
+  const watchOrFail = metricsList.filter((metric) => metric.status !== "PASS").length;
+  const payload = {
+    generated_utc: now,
+    scorecard_window: "lifetime_runtime_snapshot",
+    source_metrics: "data/metrics.json",
+    totals: {
+      total_cases: totalCases,
+      auto_closed_benign: benign,
+      known_fp: knownFp,
+      escalated,
+      review,
+      staged_pending: stagedPending
+    },
+    scorecard: {
+      status: watchOrFail === 0 ? "PASS" : "WATCH",
+      metrics: metricsList
+    }
+  };
+
+  const md = [
+    "# Alert Quality Scorecard",
+    "",
+    `- Generated (UTC): ${payload.generated_utc}`,
+    `- Window: ${payload.scorecard_window}`,
+    `- Overall status: ${payload.scorecard.status}`,
+    `- Source: \`${payload.source_metrics}\``,
+    "",
+    "## Totals",
+    "",
+    `- Total cases: ${totalCases}`,
+    `- Auto-closed benign: ${benign}`,
+    `- Known false positive: ${knownFp}`,
+    `- Escalated: ${escalated}`,
+    `- Review backlog: ${review}`,
+    `- Staged pending: ${stagedPending}`,
+    "",
+    "## Scorecard",
+    "",
+    "| Metric | Value | Target | Status |",
+    "|---|---:|---|---|",
+    ...metricsList.map((metric) => `| ${metric.id} | ${metric.value} | ${metric.target} | ${metric.status} |`)
+  ].join("\n");
+
+  return { payload, md };
+}
+
+function main() {
+  const validation = buildValidationLane();
+  writeJson(proofValidationJsonPath, validation.payload);
+  writeJson(siteValidationJsonPath, validation.payload);
+  writeText(proofValidationMdPath, `${validation.md}\n`);
+  writeText(siteValidationMdPath, `${validation.md}\n`);
+
+  const quality = buildQualityLane();
+  writeJson(proofQualityJsonPath, quality.payload);
+  writeJson(siteQualityJsonPath, quality.payload);
+  writeText(proofQualityMdPath, `${quality.md}\n`);
+  writeText(siteQualityMdPath, `${quality.md}\n`);
+
+  console.log(`Generated ${path.relative(root, proofValidationJsonPath)}`);
+  console.log(`Generated ${path.relative(root, proofValidationMdPath)}`);
+  console.log(`Generated ${path.relative(root, siteValidationJsonPath)}`);
+  console.log(`Generated ${path.relative(root, siteValidationMdPath)}`);
+  console.log(`Generated ${path.relative(root, proofQualityJsonPath)}`);
+  console.log(`Generated ${path.relative(root, proofQualityMdPath)}`);
+  console.log(`Generated ${path.relative(root, siteQualityJsonPath)}`);
+  console.log(`Generated ${path.relative(root, siteQualityMdPath)}`);
+}
+
+main();

--- a/site/proof.html
+++ b/site/proof.html
@@ -97,6 +97,8 @@
           <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/detection-rules/mappings/technique_map.csv" target="_blank" rel="noopener noreferrer">technique_map.csv</a></li>
           <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md" target="_blank" rel="noopener noreferrer">AUTOSOC_COVERAGE_TRUTH_SHIFT_SNIPPET_03-19-2026.md</a></li>
           <li><a href="/proof/grafana/latest.md" target="_blank" rel="noopener noreferrer">Grafana proof lane</a></li>
+          <li><a href="/proof/validation/latest.md" target="_blank" rel="noopener noreferrer">Continuous detection validation lane</a></li>
+          <li><a href="/proof/quality/latest.md" target="_blank" rel="noopener noreferrer">Alert quality scorecard lane</a></li>
           <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/scripts/check-md-links.sh" target="_blank" rel="noopener noreferrer">check-md-links.sh</a></li>
         </ul>
       </article>

--- a/site/proof/quality/latest.json
+++ b/site/proof/quality/latest.json
@@ -1,0 +1,54 @@
+{
+  "generated_utc": "2026-03-20T16:37:27.292Z",
+  "scorecard_window": "lifetime_runtime_snapshot",
+  "source_metrics": "data/metrics.json",
+  "totals": {
+    "total_cases": 49774,
+    "auto_closed_benign": 20942,
+    "known_fp": 18366,
+    "escalated": 2478,
+    "review": 7795,
+    "staged_pending": 193
+  },
+  "scorecard": {
+    "status": "PASS",
+    "metrics": [
+      {
+        "id": "auto_close_benign_pct",
+        "value": 42.07,
+        "target": ">= 35",
+        "status": "PASS"
+      },
+      {
+        "id": "known_fp_pct",
+        "value": 36.9,
+        "target": "<= 45",
+        "status": "PASS"
+      },
+      {
+        "id": "escalation_pct",
+        "value": 4.98,
+        "target": ">= 3",
+        "status": "PASS"
+      },
+      {
+        "id": "review_backlog_pct",
+        "value": 15.66,
+        "target": "<= 20",
+        "status": "PASS"
+      },
+      {
+        "id": "staged_pending_pct",
+        "value": 0.39,
+        "target": "<= 1",
+        "status": "PASS"
+      },
+      {
+        "id": "reconciliation_mismatch_count",
+        "value": 0,
+        "target": "0",
+        "status": "PASS"
+      }
+    ]
+  }
+}

--- a/site/proof/quality/latest.md
+++ b/site/proof/quality/latest.md
@@ -1,0 +1,26 @@
+# Alert Quality Scorecard
+
+- Generated (UTC): 2026-03-20T16:37:27.292Z
+- Window: lifetime_runtime_snapshot
+- Overall status: PASS
+- Source: `data/metrics.json`
+
+## Totals
+
+- Total cases: 49774
+- Auto-closed benign: 20942
+- Known false positive: 18366
+- Escalated: 2478
+- Review backlog: 7795
+- Staged pending: 193
+
+## Scorecard
+
+| Metric | Value | Target | Status |
+|---|---:|---|---|
+| auto_close_benign_pct | 42.07 | >= 35 | PASS |
+| known_fp_pct | 36.9 | <= 45 | PASS |
+| escalation_pct | 4.98 | >= 3 | PASS |
+| review_backlog_pct | 15.66 | <= 20 | PASS |
+| staged_pending_pct | 0.39 | <= 1 | PASS |
+| reconciliation_mismatch_count | 0 | 0 | PASS |

--- a/site/proof/validation/latest.json
+++ b/site/proof/validation/latest.json
@@ -1,0 +1,51 @@
+{
+  "generated_utc": "2026-03-20T16:37:27.292Z",
+  "validation_window": "rolling_latest_artifacts",
+  "suite": "continuous-detection-validation",
+  "summary": {
+    "checks_total": 6,
+    "checks_passed": 6,
+    "checks_watch": 0,
+    "checks_failed": 0,
+    "pass_rate_pct": 100,
+    "overall_status": "PASS"
+  },
+  "checks": [
+    {
+      "id": "heartbeat",
+      "status": "PASS",
+      "value": "SUCCESS",
+      "source": "data/metrics.json"
+    },
+    {
+      "id": "reconciliation_mismatch",
+      "status": "PASS",
+      "value": 0,
+      "source": "proof/autosoc/latest/reconciliation_latest.json"
+    },
+    {
+      "id": "coverage_required_hosts",
+      "status": "PASS",
+      "value": "8/8",
+      "source": "data/metrics.json"
+    },
+    {
+      "id": "pipeline_last_status",
+      "status": "PASS",
+      "value": "SUCCESS",
+      "source": "proof/autosoc/latest/run_metrics_latest.json"
+    },
+    {
+      "id": "splunk_ingest_proof_present",
+      "status": "PASS",
+      "value": "content/lab/proxmox/vms/104/splunk/exports/WAZUH_SPLUNK_PIPELINE_PROOF_2026-03-20.md",
+      "source": "filesystem"
+    },
+    {
+      "id": "grafana_proof_present",
+      "status": "PASS",
+      "value": "proof/grafana/latest.md",
+      "source": "filesystem"
+    }
+  ]
+}

--- a/site/proof/validation/latest.md
+++ b/site/proof/validation/latest.md
@@ -1,0 +1,17 @@
+# Continuous Detection Validation
+
+- Generated (UTC): 2026-03-20T16:37:27.292Z
+- Suite: continuous-detection-validation
+- Overall status: PASS
+- Checks passed: 6/6 (100%)
+
+## Checks
+
+| Check | Status | Value | Source |
+|---|---|---|---|
+| heartbeat | PASS | SUCCESS | `data/metrics.json` |
+| reconciliation_mismatch | PASS | 0 | `proof/autosoc/latest/reconciliation_latest.json` |
+| coverage_required_hosts | PASS | 8/8 | `data/metrics.json` |
+| pipeline_last_status | PASS | SUCCESS | `proof/autosoc/latest/run_metrics_latest.json` |
+| splunk_ingest_proof_present | PASS | content/lab/proxmox/vms/104/splunk/exports/WAZUH_SPLUNK_PIPELINE_PROOF_2026-03-20.md | `filesystem` |
+| grafana_proof_present | PASS | proof/grafana/latest.md | `filesystem` |


### PR DESCRIPTION
## Summary
- add generator for validation and quality proof lanes from committed artifacts
- publish lanes under both proof/ and site/proof/ for reviewer access
- wire lane generation into verify and update-site-data workflows
- add proof-page links to new lanes

## New artifacts
- proof/validation/latest.{json,md}
- proof/quality/latest.{json,md}
- site/proof/validation/latest.{json,md}
- site/proof/quality/latest.{json,md}

## Automation
- scripts/generate-proof-lanes.js
- update-site-data scheduled every 6 hours and lane-aware diff/commit scope