### PR TITLE
Fix: harden metrics generation path + add runtime-bound career narrative page

### DIFF
--- a/scripts/generate-site-data.js
+++ b/scripts/generate-site-data.js
@@ -14,6 +14,7 @@ const siteOpsJsonOutPath = path.join(root, "site", "assets", "data", "ops-metric
 const siteOpsJsOutPath = path.join(root, "site", "data", "ops-metrics.js");
 const detectionsDataPath = path.join(root, "site", "assets", "data", "detections.json");
 const withProofPack = process.argv.includes("--with-proof-pack");
+const regenerateMetricsFlag = process.argv.includes("--regenerate-metrics");
 
 function regenerateMetrics() {
   const result = childProcess.spawnSync(process.execPath, [path.join(root, "scripts", "generate-metrics.js")], {
@@ -254,7 +255,9 @@ if (!fs.existsSync(srcPath)) {
   process.exit(1);
 }
 
-regenerateMetrics();
+if (regenerateMetricsFlag) {
+  regenerateMetrics();
+}
 
 const src = fs.readFileSync(srcPath, "utf8");
 const parsed = parseVerifiedCountsJson(src);

--- a/site/_redirects
+++ b/site/_redirects
@@ -11,3 +11,6 @@
 /proof/honeypot /honeypot-proof.html 200
 /blog-python2-to-python3 /404 301
 /blog-python2-to-python3.html /404 301
+/case-study-splunk-codex-hunt/ /case-study-splunk-codex-hunt 301
+/operations-bridge/ /operations-bridge 301
+/career-intelligence/ /career-intelligence 301

--- a/site/assets/design-tokens.css
+++ b/site/assets/design-tokens.css
@@ -1,11 +1,11 @@
 :root {
-  --brand: #0b5fff;
-  --accent: #00a88a;
-  --muted: #666666;
-  --bg: #ffffff;
-  --surface: #f6f8fb;
-  --text: #1d2433;
-  --border: #d9e1ef;
+  --brand: #00c4d4;
+  --accent: #2e75b6;
+  --muted: #7a94aa;
+  --bg: #080c10;
+  --surface: #0d1219;
+  --text: #d4e0ec;
+  --border: rgba(122, 148, 170, 0.34);
   --max-width: 1100px;
   --radius-sm: 8px;
   --radius-md: 14px;

--- a/site/assets/modernize.css
+++ b/site/assets/modernize.css
@@ -1,22 +1,22 @@
 :root {
-  --primary-50: #f0fdf9;
-  --primary-100: #ccfbf1;
-  --primary-300: #5eead4;
-  --primary-500: #14b8a6;
-  --primary-700: #0f766e;
-  --primary-800: #115e59;
-  --neutral-0: #ffffff;
-  --neutral-50: #fafafa;
-  --neutral-100: #f4f4f5;
-  --neutral-200: #e4e4e7;
-  --neutral-300: #d4d4d8;
-  --neutral-500: #71717a;
-  --neutral-600: #52525b;
-  --neutral-700: #3f3f46;
-  --neutral-800: #27272a;
-  --neutral-900: #111827;
-  --accent-500: #f97316;
-  --accent-700: #c2410c;
+  --primary-50: #e6fbfd;
+  --primary-100: #c2f5fa;
+  --primary-300: #6be0ea;
+  --primary-500: #00c4d4;
+  --primary-700: #2e75b6;
+  --primary-800: #255c8f;
+  --neutral-0: #0d1219;
+  --neutral-50: #111821;
+  --neutral-100: #16202b;
+  --neutral-200: #223244;
+  --neutral-300: #334a61;
+  --neutral-500: #7a94aa;
+  --neutral-600: #9fb3c6;
+  --neutral-700: #b6c8d8;
+  --neutral-800: #d4e0ec;
+  --neutral-900: #eef6ff;
+  --accent-500: #e8a020;
+  --accent-700: #b77b12;
   --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.05);
   --shadow-md: 0 4px 12px rgba(16, 24, 40, 0.08);
   --shadow-lg: 0 12px 24px rgba(16, 24, 40, 0.12);
@@ -24,7 +24,7 @@
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 20px;
-  --font-sans: Inter, "Segoe UI", Arial, sans-serif;
+  --font-sans: "DM Sans", Inter, "Segoe UI", Arial, sans-serif;
   --font-mono: "Source Code Pro", "JetBrains Mono", Consolas, monospace;
   --bg: var(--neutral-50);
   --surface: var(--neutral-0);
@@ -35,12 +35,12 @@
 }
 
 html[data-theme="dark"] {
-  --bg: #09111c;
-  --surface: #111827;
-  --surface-soft: #18212f;
-  --text: #f8fafc;
-  --text-soft: #d4d4d8;
-  --border: rgba(255, 255, 255, 0.12);
+  --bg: #080c10;
+  --surface: #0d1219;
+  --surface-soft: #121920;
+  --text: #d4e0ec;
+  --text-soft: #9fb3c6;
+  --border: rgba(122, 148, 170, 0.34);
 }
 
 *,

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,28 +1,29 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap');
 
         *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
         :root{
-            --bg:#000000;--bg1:#0a0a0a;--bg2:#111111;--bg3:#191919;
-            --bdr:rgba(255,255,255,.11);--bdr2:rgba(255,255,255,.17);
-            --txt:#f7f9ff;--dim:#d7e0f4;--faint:#9eb4d8;
-            --acc:#7ab8ff;--acc2:#5fb3ff;--acc-rgb:122,184,255;--acc2-rgb:95,179,255;--acc-d:rgba(var(--acc-rgb),.14);--acc-g:rgba(var(--acc-rgb),.24);
+            --bg:#080c10;--bg1:#0d1219;--bg2:#121920;--bg3:#1a242f;
+            --bdr:rgba(122,148,170,.24);--bdr2:rgba(122,148,170,.34);
+            --txt:#d4e0ec;--dim:#9fb3c6;--faint:#7a94aa;
+            --acc:#00c4d4;--acc2:#2e75b6;--acc-rgb:0,196,212;--acc2-rgb:46,117,182;--acc-d:rgba(var(--acc-rgb),.14);--acc-g:rgba(var(--acc-rgb),.24);
             --red:#ff3b5c;--red-d:rgba(255,59,92,.1);
             --amb:#ffb020;--amb-d:rgba(255,176,32,.1);
             --blu:#7ab8ff;--pur:#7ab8ff;
             --mono:'JetBrains Mono','IBM Plex Mono','Consolas',monospace;
-            --sans:'Inter','Segoe UI',sans-serif;
-            --head:'Sora','Inter','Segoe UI',sans-serif;
-            --page-bg:radial-gradient(1100px 520px at 84% -10%,rgba(var(--acc-rgb),.10),transparent 70%),radial-gradient(900px 500px at -18% 110%,rgba(var(--acc2-rgb),.08),transparent 72%),linear-gradient(180deg,#000000 0%, #040404 58%, #080808 100%);
+            --sans:'DM Sans','Inter','Segoe UI',sans-serif;
+            --head:'DM Sans','Sora','Inter','Segoe UI',sans-serif;
+            --page-bg:radial-gradient(1100px 560px at 84% -10%,rgba(var(--acc-rgb),.12),transparent 70%),radial-gradient(900px 540px at -18% 110%,rgba(var(--acc2-rgb),.10),transparent 72%),linear-gradient(180deg,#070b10 0%, #0a1016 58%, #0d141d 100%);
             --grid-line:rgba(255,255,255,.0);
             --link:var(--acc2);--link-hover:var(--acc);
-            --nav-bg:rgba(5,5,5,.88);
+            --nav-bg:rgba(8,12,16,.88);
             --nav-hover-bg:rgba(var(--acc-rgb),.08);
             --nav-active-bg:rgba(var(--acc-rgb),.18);
             --nav-active-border:rgba(var(--acc-rgb),.40);
             --nav-active-shadow:0 8px 18px rgba(0,0,0,.22);
             --heading:var(--acc);
-            --panel-bg:linear-gradient(145deg,rgba(16,16,16,.88),rgba(9,9,9,.94));
+            --panel-bg:linear-gradient(145deg,rgba(13,18,25,.9),rgba(9,14,20,.95));
             --panel-shadow:0 14px 28px rgba(0,0,0,.34);
-            --term-bg:#0a0e14;--term-head:#0f1319;--term-txt:#e1e7f4;
+            --term-bg:#0b131d;--term-head:#0f1a25;--term-txt:#d8e7f5;
             --overlay-bg:rgba(6,8,12,.92);
             --hero-mark:rgba(240,246,255,.28);
             --hero-mark-opacity:.5;--stars-o:.18;
@@ -32,13 +33,13 @@
             --focus-ring:0 0 0 3px rgba(var(--acc-rgb),.20);
         }
         html[data-theme="dark"]{
-            --bg:#000000;--bg1:#0a0a0a;--bg2:#111111;--bg3:#191919;
-            --bdr:rgba(255,255,255,.11);--bdr2:rgba(255,255,255,.17);
-            --txt:#f7f9ff;--dim:#d7e0f4;--faint:#9eb4d8;
+            --bg:#080c10;--bg1:#0d1219;--bg2:#121920;--bg3:#1a242f;
+            --bdr:rgba(122,148,170,.24);--bdr2:rgba(122,148,170,.34);
+            --txt:#d4e0ec;--dim:#9fb3c6;--faint:#7a94aa;
             --link:var(--acc2);--link-hover:var(--acc);
-            --nav-bg:rgba(5,5,5,.88);
+            --nav-bg:rgba(8,12,16,.88);
             --heading:var(--acc);
-            --hero-mark:rgba(240,246,255,.28);
+            --hero-mark:rgba(212,224,236,.28);
             --hero-mark-opacity:.5;
         }
         html[data-theme="light"]{

--- a/site/career-intelligence.html
+++ b/site/career-intelligence.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+<title>HawkinsOps | Career Intelligence Narrative</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Operational systems intelligence narrative: production operations to security operations with evidence-backed metric bindings.">
+<link rel="canonical" href="https://hawkinsops.com/career-intelligence">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Career Intelligence Narrative">
+<meta property="og:description" content="One operational mindset applied first in manufacturing systems and now in SOC and detection engineering workflows.">
+<meta property="og:url" content="https://hawkinsops.com/career-intelligence">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Career Intelligence Narrative">
+<meta name="twitter:description" content="Operational systems intelligence across production and cybersecurity domains.">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/design-tokens.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/base.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
+<script>document.documentElement.setAttribute('data-theme', 'dark');</script>
+</head>
+<body>
+<nav>
+  <div class="nav-i">
+    <a class="logo" href="/"><span class="logo-monogram" aria-hidden="true">RH</span><b>Hawkins</b>Ops</a>
+    <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
+    <ul class="nav-l">
+      <li><a href="/">Home</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry Case Study</a></li>
+      <li><a href="/detections">Detections</a></li>
+      <li><a href="/soc-lab">Lab</a></li>
+      <li><a href="/resume">Resume</a></li>
+    </ul>
+    <a class="btn btn-p nav-cta" href="/start-here">Start Here</a>
+  </div>
+</nav>
+<div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
+  <a href="/">Home</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">SignalFoundry Case Study</a>
+  <a href="/detections">Detections</a>
+  <a href="/soc-lab">Lab</a>
+  <a href="/resume">Resume</a>
+</div>
+
+<main class="sf-shell">
+  <section class="sf-section">
+    <div class="sf-eyebrow">Career Intelligence</div>
+    <h1 style="font-size:clamp(2rem,4vw,3rem);margin:12px 0 16px;">Operational systems intelligence narrative</h1>
+    <p style="max-width:70ch;color:var(--muted);line-height:1.75;">
+      This page adapts the narrative map from the career packet into the public site with runtime metric bindings.
+      The framing is unchanged: the domain moved from physical production systems to digital security systems, but
+      the operating method remained the same.
+    </p>
+    <div style="margin-top:16px;padding:18px 22px;border-left:3px solid var(--accent,#3b82f6);background:#0f172a;border-radius:0 6px 6px 0">
+      <p style="margin:0;font-size:1rem;line-height:1.75;">
+        I did not switch from operations to systems thinking. I applied operational systems thinking in production environments first, then
+        translated it to SOC analysis, detection engineering, and security automation.
+      </p>
+    </div>
+  </section>
+
+  <section class="sf-section sf-grid" style="grid-template-columns:repeat(auto-fit,minmax(220px,1fr));">
+    <article class="sf-card" style="padding:22px;">
+      <h2 style="margin-bottom:8px;">Lifetime Processed</h2>
+      <p style="font-size:1.5rem;font-weight:700;"><span data-ops="lifetime_total_cases">-</span></p>
+      <p style="color:var(--muted);">Runtime snapshot</p>
+    </article>
+    <article class="sf-card" style="padding:22px;">
+      <h2 style="margin-bottom:8px;">Coverage</h2>
+      <p style="font-size:1.5rem;font-weight:700;"><span data-ops="coverage_ratio">-</span></p>
+      <p style="color:var(--muted);">Host coverage ratio</p>
+    </article>
+    <article class="sf-card" style="padding:22px;">
+      <h2 style="margin-bottom:8px;">Reconciliation Mismatch</h2>
+      <p style="font-size:1.5rem;font-weight:700;"><span data-ops="reconciliation_mismatch">-</span></p>
+      <p style="color:var(--muted);">Ledger vs repo drift</p>
+    </article>
+    <article class="sf-card" style="padding:22px;">
+      <h2 style="margin-bottom:8px;">Detection Inventory</h2>
+      <p style="line-height:1.65;color:var(--muted);">
+        Sigma: <strong><span data-verified="sigma">-</span></strong><br>
+        Wazuh Rule Blocks: <strong><span data-verified="wazuh">-</span></strong><br>
+        Splunk Detections: <strong><span data-verified="splunk">-</span></strong><br>
+        IR Playbooks: <strong><span data-verified="ir">-</span></strong>
+      </p>
+    </article>
+  </section>
+
+  <section class="sf-section">
+    <article class="sf-card" style="padding:24px;">
+      <h2>Production operations to security operations map</h2>
+      <div style="overflow:auto;margin-top:12px;">
+        <table style="width:100%;border-collapse:collapse;">
+          <thead>
+            <tr style="border-bottom:1px solid #1e293b;">
+              <th style="text-align:left;padding:10px 12px;">Production Operations</th>
+              <th style="text-align:left;padding:10px 12px;">Security Operations</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">Downtime Event</td><td style="padding:10px 12px;color:var(--muted);">Security Incident</td></tr>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">Defect / Nonconforming Part</td><td style="padding:10px 12px;color:var(--muted);">Alert / Detection Hit</td></tr>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">Escalation Path</td><td style="padding:10px 12px;color:var(--muted);">Tiered Triage Escalation</td></tr>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">SOP / Standardized Work</td><td style="padding:10px 12px;color:var(--muted);">IR Playbook</td></tr>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">Shift Handoff Documentation</td><td style="padding:10px 12px;color:var(--muted);">Case Notes / SOC Handoff</td></tr>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">Root Cause Analysis</td><td style="padding:10px 12px;color:var(--muted);">Post-Incident Analysis</td></tr>
+            <tr style="border-bottom:1px solid #1e293b;"><td style="padding:10px 12px;">4M Change Tracking</td><td style="padding:10px 12px;color:var(--muted);">Change Point Management</td></tr>
+            <tr><td style="padding:10px 12px;">Poka-Yoke Error-Proofing</td><td style="padding:10px 12px;color:var(--muted);">Detection Rules / Automated Controls</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </article>
+  </section>
+
+  <section class="sf-section">
+    <article class="sf-card" style="padding:24px;">
+      <h2>Timeline (condensed)</h2>
+      <div style="margin-top:12px;display:flex;flex-direction:column;gap:10px;line-height:1.7;">
+        <p><strong>Jan 2024 - Feb 2025:</strong> Team Lead promotion in under 3 months; led three lines with combined throughput up to <strong>5,400 parts/shift</strong>.</p>
+        <p><strong>Mar 2025 - Dec 2025:</strong> Production supervisor role in Tier 1 stamping and laser operations with documented fault trees and recovery procedures.</p>
+        <p><strong>Sep 2025:</strong> First personal computer; systems workflow translated from manufacturing notebooks to security tooling.</p>
+        <p><strong>Dec 2025 - Present:</strong> SignalFoundry operations with <strong><span data-ops="lifetime_total_cases">-</span></strong> processed, <strong><span data-ops="coverage_ratio">-</span></strong> coverage, and <strong><span data-ops="reconciliation_mismatch">-</span></strong> reconciliation mismatches.</p>
+      </div>
+    </article>
+  </section>
+
+  <section class="sf-section">
+    <article class="sf-card" style="padding:24px;">
+      <h2>OT lane fit</h2>
+      <p style="max-width:76ch;color:var(--muted);line-height:1.75;">
+        OT security is the highest-leverage intersection: production systems literacy plus SOC detection and triage execution.
+        The public story remains cyber-first, with manufacturing history used as evidence of pressure-tested operational judgment.
+      </p>
+      <div style="display:flex;gap:12px;flex-wrap:wrap;margin-top:16px;">
+        <a class="btn btn-p" href="/operations-bridge">Operations Bridge</a>
+        <a class="btn" href="/case-study-autosoc">SignalFoundry Case Study</a>
+        <a class="btn" href="/proof">Proof</a>
+      </div>
+    </article>
+  </section>
+</main>
+
+<footer>
+  <div class="ctr">
+    <p><b>Raylee Hawkins</b> &middot; Eligible to obtain clearance; willing to pursue sponsorship.</p>
+  </div>
+</footer>
+<script src="/data/counts.js" defer></script>
+<script src="/data/ops-metrics.js" defer></script>
+<script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -210,7 +210,7 @@
     <div style="display:flex;gap:12px;flex-wrap:wrap;padding-bottom:60px">
       <a class="btn btn-p" href="/career-intelligence">Career Intelligence Narrative</a>
       <a class="btn btn-p" href="/case-study-autosoc">SignalFoundry case study</a>
-      <a class="btn" href="/case-study-splunk-codex-hunt">Splunk hunt write-up</a>
+      <a class="btn" href="/career-intelligence">Career intelligence narrative</a>
       <a class="btn" href="/proof">Proof receipts</a>
       <a class="btn" href="/resume">Resume</a>
     </div>

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en">
+<head>
+<title>HawkinsOps | Operations-to-Cyber Bridge — Why I Build This Way</title>
+<meta name="description" content="I come from Tier 1 manufacturing where I managed production systems under pressure. My cybersecurity work is an extension of that same operational thinking applied to security monitoring, detection, and incident response.">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#07070b">
+<link rel="canonical" href="https://hawkinsops.com/operations-bridge">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Operations-to-Cyber Bridge — Why I Build This Way">
+<meta property="og:description" content="The correct framing is not factory worker turned hacker. It is the same cognitive operation — monitoring, fault isolation, escalation, repeatability under pressure — applied to a digital environment.">
+<meta property="og:url" content="https://hawkinsops.com/operations-bridge">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Operations-to-Cyber Bridge — Why I Build This Way">
+<meta name="twitter:description" content="Production operations and security operations are structurally identical. The failure modes are different. The thinking is the same.">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
+<script>document.documentElement.setAttribute('data-theme', 'dark');</script>
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/modernize.css?v=03-15-2026-1">
+<link rel="stylesheet" href="/assets/coherence.css?v=03-15-2026-3">
+</head>
+<body>
+<nav>
+  <div class="nav-i">
+    <a class="logo" href="/"><span class="logo-monogram" aria-hidden="true">RH</span><b>Hawkins</b>Ops</a>
+    <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
+    <ul class="nav-l">
+      <li><a href="/">Home</a></li>
+      <li><a href="/proof">Proof</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry Case Study</a></li>
+      <li><a href="/detections">Detections</a></li>
+      <li><a href="/soc-lab">Lab</a></li>
+      <li><a href="/resume">Resume</a></li>
+    </ul>
+    <a class="btn btn-p nav-cta" href="/start-here">Start Here</a>
+  </div>
+</nav>
+<div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
+  <a href="/">Home</a>
+  <a href="/proof">Proof</a>
+  <a href="/case-study-autosoc">SignalFoundry Case Study</a>
+  <a href="/detections">Detections</a>
+  <a href="/soc-lab">Lab</a>
+  <a href="/resume">Resume</a>
+</div>
+
+<main>
+<section style="padding-top:110px">
+  <div class="ctr" style="max-width:900px">
+
+    <div class="slbl">Background · Identity</div>
+    <h1 class="stitle">Operations-to-cyber bridge: why I build this way</h1>
+    <p class="sdesc" style="font-size:1.1rem;line-height:1.7;max-width:68ch">
+      I come from Tier 1 manufacturing where I managed production systems under pressure.
+      My cybersecurity work is an extension of that same operational thinking
+      applied to security monitoring, detection, and incident response.
+    </p>
+
+    <div style="height:24px"></div>
+
+    <!-- CORE FRAMING -->
+    <div class="card">
+      <h2 class="card-ttl">The correct framing</h2>
+      <div class="card-sub">
+        <p>The wrong framing is "factory worker turned hacker." That implies a discontinuity — that the manufacturing background is background noise and the security work is the real story starting from zero.</p>
+        <p style="margin-top:12px">The correct framing is this:</p>
+        <blockquote style="border-left:3px solid var(--accent,#3b82f6);padding:12px 16px;margin:16px 0;color:var(--muted);font-style:italic">
+          Production plants are deterministic systems with monitored environments that are failure-prone under load and dependent on alerting, response procedures, and uptime guarantees.
+          That description is structurally identical to a Security Operations Center.
+          I was not switching fields. I was running SOC-equivalent thinking in a physical environment first, and then translating it to a digital one.
+        </blockquote>
+        <p>The domain changed. The cognitive operation did not.</p>
+      </div>
+    </div>
+
+    <div style="height:14px"></div>
+
+    <!-- DOMAIN MAPPING TABLE -->
+    <div class="card">
+      <h2 class="card-ttl">Direct domain mapping</h2>
+      <div class="card-sub">
+        <p style="margin-bottom:16px">These are not analogies. Each row represents an operational task I performed in both domains — the physical version first, then the digital version after September 2025.</p>
+        <div style="overflow-x:auto">
+          <table style="width:100%;border-collapse:collapse;font-size:0.9rem">
+            <thead>
+              <tr style="border-bottom:1px solid #1e293b">
+                <th style="text-align:left;padding:10px 12px;color:var(--muted);font-weight:600;width:48%">Production domain</th>
+                <th style="text-align:left;padding:10px 12px;color:var(--muted);font-weight:600">Security operations domain</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Downtime event</td>
+                <td style="padding:10px 12px;color:#94a3b8">Security incident — system unavailability with measurable cost</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Defect / nonconforming part</td>
+                <td style="padding:10px 12px;color:#94a3b8">Security alert — deviation from known-good specification</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Escalation path (Team Lead → Supervisor)</td>
+                <td style="padding:10px 12px;color:#94a3b8">Triage escalation path (Tier 1 → Tier 2 analyst)</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">SOP / Standard Operating Procedure</td>
+                <td style="padding:10px 12px;color:#94a3b8">IR Playbook / Incident Response Procedure</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Shift handoff documentation</td>
+                <td style="padding:10px 12px;color:#94a3b8">SOC handoff — preserve case state across analyst transitions</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Quality control / defect validation</td>
+                <td style="padding:10px 12px;color:#94a3b8">Detection validation — confirming monitoring catches deviations</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Root cause analysis (RCA)</td>
+                <td style="padding:10px 12px;color:#94a3b8">Post-incident analysis — same methodology, different domain</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">4M Summary Board (Man/Machine/Material/Method)</td>
+                <td style="padding:10px 12px;color:#94a3b8">Change management tracking — environment change point documentation</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">LOTO / Lockout-Tagout procedures</td>
+                <td style="padding:10px 12px;color:#94a3b8">Isolation and containment procedures during active incident</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Die set-up verification / tooling audit</td>
+                <td style="padding:10px 12px;color:#94a3b8">Detection rule validation — confirming sensors are active and accurate</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Poka-yoke (error-proofing)</td>
+                <td style="padding:10px 12px;color:#94a3b8">Automated detection rules preventing analyst error</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Takt time (sub-minute cycle)</td>
+                <td style="padding:10px 12px;color:#94a3b8">Alert polling cycle (5-minute AutoSOC polling interval)</td>
+              </tr>
+              <tr style="border-bottom:1px solid #1e293b">
+                <td style="padding:10px 12px">Press fault tree (notebook documentation)</td>
+                <td style="padding:10px 12px;color:#94a3b8">Alert triage decision tree — same fault isolation logic</td>
+              </tr>
+              <tr>
+                <td style="padding:10px 12px">Production reporting / shift documentation</td>
+                <td style="padding:10px 12px;color:#94a3b8">Case management / evidence packaging</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div style="height:14px"></div>
+
+    <!-- WHAT THIS MEANS IN PRACTICE -->
+    <div class="card">
+      <h2 class="card-ttl">What this means in practice</h2>
+      <div class="card-sub">
+        <p>When I built the AutoSOC pipeline with mandatory quality gates, that was not a software engineering decision. It was the same decision I made on the production floor when I enforced IATF 16949 documentation requirements before a nonconforming part could be dispositioned. You do not skip the quality gate because the shift is running behind.</p>
+        <p style="margin-top:12px">When I wrote the <span data-verified="ir">10</span> IR playbooks with explicit escalation criteria and handoff steps, that was the same work I did writing pass-down meeting notes and shift-end documentation at Fehrer and Unipres. The analyst who takes a case mid-shift needs to know exactly where the previous person left off.</p>
+        <p style="margin-top:12px">When I run a triage queue and close known false positives automatically while escalating anything that crosses a threshold, that is the same discipline as managing a production line where you separate scrap from rework from good-part disposition. Not every alert is an incident. Not every defect is a shutdown event. The judgment is what matters, and the judgment has to be documented so it is reproducible.</p>
+        <p style="margin-top:12px">The proof artifacts on this site — verified counts, evidence packs, reconciliation gates, before/after comparisons — are not portfolio decoration. They are the same quality documentation I produced on a manufacturing floor before I owned a laptop.</p>
+      </div>
+    </div>
+
+    <div style="height:14px"></div>
+
+    <!-- TIMELINE ANCHOR -->
+    <div class="card">
+      <h2 class="card-ttl">The timeline that closes the argument</h2>
+      <div class="card-sub">
+        <p>This is not a claim about transferable skills. It is a description of what actually happened, with dates.</p>
+        <div style="margin-top:16px;display:flex;flex-direction:column;gap:12px">
+          <div style="display:flex;gap:14px;align-items:flex-start">
+            <div style="min-width:130px;font-size:0.8rem;font-weight:600;color:var(--muted);padding-top:2px">Aug 2025</div>
+            <div>Working as Team Leader in Hot Stamp operations at a Tier 1 Honda/Nissan stamping facility. Photographing equipment control panels, documenting fault trees in a notebook, annotating press machine component sequences. <em>Before the first personal computer existed.</em></div>
+          </div>
+          <div style="display:flex;gap:14px;align-items:flex-start">
+            <div style="min-width:130px;font-size:0.8rem;font-weight:600;color:var(--muted);padding-top:2px">Sep 2025</div>
+            <div>First personal computer. Zero prior exposure to software, networking, or security.</div>
+          </div>
+          <div style="display:flex;gap:14px;align-items:flex-start">
+            <div style="min-width:130px;font-size:0.8rem;font-weight:600;color:var(--muted);padding-top:2px">Oct–Nov 2025</div>
+            <div>HawkinsOps infrastructure deployed from scratch: Proxmox hypervisor, pfSense network segmentation, Wazuh SIEM stack.</div>
+          </div>
+          <div style="display:flex;gap:14px;align-items:flex-start">
+            <div style="min-width:130px;font-size:0.8rem;font-weight:600;color:var(--muted);padding-top:2px">Jan 2026</div>
+            <div><span data-verified="sigma">103</span> Sigma rules written. <span data-verified="ir">10</span> IR playbooks authored. CompTIA Security+ exam-ready.</div>
+          </div>
+          <div style="display:flex;gap:14px;align-items:flex-start">
+            <div style="min-width:130px;font-size:0.8rem;font-weight:600;color:var(--muted);padding-top:2px">Mar 2, 2026</div>
+            <div>SignalFoundry stress-tested in a 72-hour window; see the Proof page for the current runtime snapshot metrics and validation artifacts.</div>
+          </div>
+          <div style="display:flex;gap:14px;align-items:flex-start">
+            <div style="min-width:130px;font-size:0.8rem;font-weight:600;color:var(--muted);padding-top:2px">Mar 17, 2026</div>
+            <div>Live Splunk threat hunting session on own endpoint. Found AI coding tool spawning <code>pwsh.exe</code> 375 times — correctly classified as tool behavior using detection engineering methodology.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="height:24px"></div>
+
+    <div style="display:flex;gap:12px;flex-wrap:wrap;padding-bottom:60px">
+      <a class="btn btn-p" href="/career-intelligence">Career Intelligence Narrative</a>
+      <a class="btn btn-p" href="/case-study-autosoc">SignalFoundry case study</a>
+      <a class="btn" href="/case-study-splunk-codex-hunt">Splunk hunt write-up</a>
+      <a class="btn" href="/proof">Proof receipts</a>
+      <a class="btn" href="/resume">Resume</a>
+    </div>
+
+  </div>
+</section>
+</main>
+
+<footer>
+  <div class="ctr">
+    <p><b>Raylee Hawkins</b> &middot; North Alabama (Huntsville-adjacent)</p>
+    <div class="fl">
+      <a href="/resume">Resume</a>
+      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      <a href="mailto:raylee@hawkinsops.com">raylee@hawkinsops.com</a>
+    </div>
+    <p style="font-size:0.8rem;color:var(--muted);margin-top:6px">Eligible to obtain clearance; willing to pursue sponsorship.</p>
+  </div>
+</footer>
+
+<script src="/data/counts.js" defer></script>
+<script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/site/start-here.html
+++ b/site/start-here.html
@@ -49,6 +49,9 @@
     <div class="sf-eyebrow">Reviewer Path</div>
     <h1 style="font-size:clamp(2rem,4vw,3rem);margin:12px 0 16px;">Start here if you need to validate SignalFoundry fast.</h1>
     <p style="max-width:64ch;color:var(--muted);">This page is the shortest public path through the system story: what exists, what is verified, where the implementation lives, and how to reproduce the counts.</p>
+    <div style="margin-top:20px;padding:18px 22px;border-left:3px solid var(--accent,#3b82f6);background:#0f172a;border-radius:0 6px 6px 0">
+      <p style="margin:0;font-size:0.975rem;line-height:1.7">I come from Tier 1 manufacturing where I managed production systems under pressure. My cybersecurity work is an extension of that same operational thinking applied to security monitoring, detection, and incident response. <a href="/operations-bridge" style="color:var(--accent,#3b82f6);white-space:nowrap">Read the full bridge →</a></p>
+    </div>
     <div class="m-proof-strip" style="margin-top:18px;">
       <div class="m-proof-inline">
         <strong>Last verified <span data-verified-date>03-15-2026</span></strong>
@@ -59,6 +62,11 @@
     </div>
   </section>
   <section class="sf-section sf-grid" style="grid-template-columns:repeat(auto-fit,minmax(260px,1fr));">
+    <article class="sf-card" style="padding:24px;">
+      <h2>0. Career narrative</h2>
+      <p>Operations-to-cyber positioning page with runtime metric bindings and domain mapping.</p>
+      <p style="margin-top:16px;"><a class="sf-focus-ring" href="/career-intelligence">Open career intelligence narrative</a></p>
+    </article>
     <article class="sf-card" style="padding:24px;">
       <h2>1. Proof surface</h2>
       <p>Open the proof page for the curated artifact path and verification entry points.</p>
@@ -96,4 +104,3 @@ python .\scripts\validate_metrics.py</pre>
 <script src="/assets/app.js" defer></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Scope\nThis PR is intentionally frozen to the approved set only:\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\scripts\\generate-site-data.js\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\career-intelligence.html\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\start-here.html\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\operations-bridge.html\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\_redirects\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\assets\\styles.css\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\assets\\design-tokens.css\n- C:\\RH\\OPS\\10_Portfolio\\HawkinsOperations\\site\\assets\\modernize.css\n\n## Why this matters\nPrimary fix:\n- scripts/generate-site-data.js no longer silently regenerates data/metrics.json\n- explicit regeneration now requires --regenerate-metrics\n\nThis closes the downgrade path that could contaminate canonical metrics with stale runtime/proof artifacts during normal site-data generation.\n\n## Verification\nRan and passed:\n- 
ode .\\scripts\\verify\\site-runtime-contract.js\n- python .\\scripts\\validate_metrics.py\n- pwsh -NoProfile -File .\\scripts\\verify\\verify-counts.ps1\n- python .\\scripts\\drift_scan.py\n- python -m unittest\n- markdown link validation equivalent to scripts/check-md-links.sh logic\n\n## Runtime-binding proof for career page\nsite/career-intelligence.html contains runtime placeholders and loaders (data-ops, data-verified, /data/counts.js, /data/ops-metrics.js, /assets/app.js) and does not contain hardcoded active cyber metrics (no 33,459, 25,167, 4/9, or 