### PR TITLE
fix: ROI polish — dead charts, mobile responsive, OG meta, perf

### DIFF
--- a/site/assets/galaxy.css
+++ b/site/assets/galaxy.css
@@ -62,6 +62,7 @@ html body::before {
     67px 131px !important;
   opacity: var(--starfield-opacity) !important;
   animation: starfield-drift 180s linear infinite !important;
+  will-change: transform;
 }
 
 /* Layer 2: Sparse bright stars (blue-white) — far field, slower */
@@ -85,6 +86,7 @@ html body::after {
     211px 173px !important;
   opacity: 0.55 !important;
   animation: starfield-drift-deep 300s linear infinite !important;
+  will-change: transform;
 }
 
 @keyframes starfield-drift {
@@ -547,7 +549,95 @@ svg circle[stroke-dasharray] {
 
 
 /* ============================================
-   S16  TOUCH DEVICE ADJUSTMENTS
+   S16  MOBILE RESPONSIVENESS
+   Collapse multi-column grids on small screens.
+   ============================================ */
+
+@media (max-width: 768px) {
+  /* All inline grid layouts collapse to single column */
+  [style*="grid-template-columns: repeat(4"],
+  [style*="grid-template-columns:repeat(4"],
+  [style*="grid-template-columns: repeat(7"],
+  [style*="grid-template-columns:repeat(7"],
+  [style*="grid-template-columns: repeat(5"],
+  [style*="grid-template-columns:repeat(5"] {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+
+  [style*="grid-template-columns:280px"],
+  [style*="grid-template-columns: 280px"],
+  [style*="grid-template-columns:1fr 320px"],
+  [style*="grid-template-columns: 1fr 320px"],
+  [style*="grid-template-columns:1fr 1fr"],
+  [style*="grid-template-columns: 1fr 1fr"],
+  [style*="grid-template-columns:1fr auto 1fr"],
+  [style*="grid-template-columns: 1fr auto 1fr"] {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* KPI metrics grid */
+  .sf-metrics[style*="grid-template-columns:repeat(4"] {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+
+  /* Pipeline stage grid: 7 cols → 4 cols on tablet, handled below */
+  /* Funnel SVG: make scrollable */
+  .sf-panel svg[viewBox] {
+    min-width: 600px;
+  }
+
+  .sf-panel {
+    overflow-x: auto;
+  }
+
+  /* Resume grid */
+  .resume-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* Proof hero */
+  .proof-hero-inner {
+    padding: 0 1rem;
+  }
+
+  .proof-kpi-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+}
+
+@media (max-width: 480px) {
+  /* Single column everything on phone */
+  [style*="grid-template-columns: repeat(2"],
+  [style*="grid-template-columns:repeat(2"] {
+    grid-template-columns: 1fr !important;
+  }
+
+  .sf-metrics[style*="grid-template-columns"] {
+    grid-template-columns: 1fr !important;
+  }
+
+  .proof-kpi-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  .sf-route-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* Smaller hero text */
+  .sf-home h1 {
+    font-size: 1.6rem !important;
+  }
+
+  /* Pipeline stages: 2 columns */
+  [style*="grid-template-columns:repeat(7"] {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+}
+
+
+/* ============================================
+   S17  TOUCH DEVICE ADJUSTMENTS
    ============================================ */
 
 @media (hover: none) {

--- a/site/detections.html
+++ b/site/detections.html
@@ -228,15 +228,52 @@
       </div>
 
       <aside class="sf-library-stack">
-        <div class="panel-glass sf-chart-shell">
+        <div class="panel-glass sf-chart-shell" style="padding:20px;">
           <div class="section-intro">
-            <div class="kicker">Tag Distribution</div>
-            <h3>Tag concentration</h3>
-            <p>Current detection tags cluster around portable detection, SOC process, SIEM deployment, and hunting-oriented content.</p>
+            <div class="kicker">Platform Distribution</div>
+            <h3>Detection breakdown</h3>
           </div>
-          <div id="detectionsChart"></div>
-          <div id="securityTagMiniChart"></div>
-          <p id="mitre-tag-status" class="lupd"></p>
+          <!-- Sigma -->
+          <div style="margin-bottom:12px;">
+            <div style="display:flex;justify-content:space-between;font-size:0.82rem;margin-bottom:3px;">
+              <span style="color:#d4e0ec;font-weight:600;">Sigma</span>
+              <span style="font-family:'JetBrains Mono',monospace;color:#7ab8ff;font-weight:700;" data-verified="sigma">103</span>
+            </div>
+            <div style="height:6px;background:rgba(255,255,255,0.04);border-radius:3px;overflow:hidden;">
+              <div style="width:74%;height:100%;background:linear-gradient(90deg,rgba(122,184,255,0.5),rgba(122,184,255,0.2));border-radius:3px;"></div>
+            </div>
+          </div>
+          <!-- Wazuh -->
+          <div style="margin-bottom:12px;">
+            <div style="display:flex;justify-content:space-between;font-size:0.82rem;margin-bottom:3px;">
+              <span style="color:#d4e0ec;font-weight:600;">Wazuh</span>
+              <span style="font-family:'JetBrains Mono',monospace;color:#7ab8ff;font-weight:700;" data-verified="wazuh">28</span>
+            </div>
+            <div style="height:6px;background:rgba(255,255,255,0.04);border-radius:3px;overflow:hidden;">
+              <div style="width:20%;height:100%;background:linear-gradient(90deg,rgba(122,184,255,0.5),rgba(122,184,255,0.2));border-radius:3px;"></div>
+            </div>
+          </div>
+          <!-- IR -->
+          <div style="margin-bottom:12px;">
+            <div style="display:flex;justify-content:space-between;font-size:0.82rem;margin-bottom:3px;">
+              <span style="color:#d4e0ec;font-weight:600;">IR Playbooks</span>
+              <span style="font-family:'JetBrains Mono',monospace;color:#fbbf24;font-weight:700;" data-verified="ir">10</span>
+            </div>
+            <div style="height:6px;background:rgba(255,255,255,0.04);border-radius:3px;overflow:hidden;">
+              <div style="width:7%;height:100%;background:linear-gradient(90deg,rgba(251,191,36,0.5),rgba(251,191,36,0.2));border-radius:3px;"></div>
+            </div>
+          </div>
+          <!-- Splunk -->
+          <div style="margin-bottom:6px;">
+            <div style="display:flex;justify-content:space-between;font-size:0.82rem;margin-bottom:3px;">
+              <span style="color:#d4e0ec;font-weight:600;">Splunk <span style="font-size:0.68rem;opacity:0.5;">(lab)</span></span>
+              <span style="font-family:'JetBrains Mono',monospace;color:#4ade80;font-weight:700;" data-verified="splunk">8</span>
+            </div>
+            <div style="height:6px;background:rgba(255,255,255,0.04);border-radius:3px;overflow:hidden;">
+              <div style="width:6%;height:100%;background:linear-gradient(90deg,rgba(74,222,128,0.5),rgba(74,222,128,0.2));border-radius:3px;"></div>
+            </div>
+          </div>
+          <p style="font-size:0.68rem;color:var(--muted);margin-top:10px;opacity:0.5;">Total: <span data-verified="detections">139</span> detections</p>
         </div>
 
         <div class="panel-glass sf-library-status" data-security-kpis>

--- a/site/proof.html
+++ b/site/proof.html
@@ -5,6 +5,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="SignalFoundry proof surface: traceable metrics, reproducible artifacts, and verification commands for every public claim.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="SignalFoundry — Proof &amp; Verified Metrics">
+<meta property="og:description" content="49,774 cases processed. ~89% auto-close. 8/8 hosts. Reconciliation PASS. Every metric traced to source. Every claim reproducible.">
+<meta property="og:url" content="https://hawkinsops.com/proof">
+<meta property="og:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="SignalFoundry — Proof &amp; Verified Metrics">
+<meta name="twitter:description" content="49,774 cases processed. ~89% auto-close. 8/8 hosts. Every metric traced to source.">
+<meta name="twitter:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
 <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/start-here.html
+++ b/site/start-here.html
@@ -13,6 +13,8 @@
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="SignalFoundry | Start Here">
 <meta name="twitter:description" content="Fast reviewer path for SignalFoundry: proof, verified counts, case study, and reproduction commands.">
+<meta property="og:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
+<meta name="twitter:image" content="https://hawkinsops.com/assets/pp_soc_integration/autosoc-system-map.png?v=03-03-2026-1">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-24-2026-1">


### PR DESCRIPTION
## Summary

5 highest-ROI fixes in one pass:

1. **Dead chart containers fixed** (detections.html) — empty `#detectionsChart` and `#securityTagMiniChart` divs replaced with actual progress bar visualizations (data-verified bound)

2. **Mobile responsiveness** (galaxy.css) — breakpoints at 768px and 480px collapse multi-column grids, sidebar layouts, KPI grids, pipeline stages, and resume grids. SVG panels scroll horizontally.

3. **OG meta + social cards** (proof.html, start-here.html) — og:image and twitter:image added so LinkedIn/Slack shares show the system map preview

4. **Starfield GPU perf** (galaxy.css) — will-change:transform on pseudo-elements for hardware compositing

5. **All existing fixes preserved** — escalated fallback 2,478, provenance labels, AutoSOC cleanup

All 5 gates + pre-commit hooks pass.