### PR TITLE
Fix: update-site-data workflow Linux path compatibility

### DIFF
--- a/.github/workflows/update-site-data.yml
+++ b/.github/workflows/update-site-data.yml
@@ -31,13 +31,13 @@ jobs:
           node-version-file: ".node-version"
 
       - name: Regenerate site data files
-        shell: pwsh
+        shell: bash
         run: |
-          node .\scripts\generate-metrics.js
-          node .\scripts\generate-proof-lanes.js
-          python .\scripts\validate_metrics.py
-          node .\scripts\generate-site-data.js
-          node .\scripts\verify\site-runtime-contract.js
+          node ./scripts/generate-metrics.js
+          node ./scripts/generate-proof-lanes.js
+          python3 ./scripts/validate_metrics.py
+          node ./scripts/generate-site-data.js
+          node ./scripts/verify/site-runtime-contract.js
 
       - name: Check for changes
         id: diff


### PR DESCRIPTION
## Summary
- The `update-site-data.yml` regenerate step uses `shell: pwsh` with backslash paths (`.\scripts\...`) and `python`, but the self-hosted runner is Linux
- Switch to `shell: bash`, forward-slash paths, and `python3`
- Mirrors the pattern already used in `verify.yml`

## Test plan
- [ ] CI `regenerate` job passes on self-hosted Linux runner
- [x] Path syntax matches working `verify.yml` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)