### PR TITLE
fix: resolve claim-integrity defects found in pre-interview audit (P0)

### DIFF
--- a/PROOF_PACK/ARCHITECTURE.md
+++ b/PROOF_PACK/ARCHITECTURE.md
@@ -33,7 +33,7 @@ privilege-escalation/  → T1055, T1068, T1078, T1134
 - **Format:** Splunk Search Processing Language (.spl files)
 - **Organization:** Grouped by MITRE ATT&CK tactics with multiple queries per file
 - **Strength:** Optimized for Splunk Enterprise Security and detection efficiency
-- **Use Case:** Production-ready searches for Splunk deployments
+- **Use Case:** Investigation-layer SPL queries developed against Wazuh-forwarded events in a home lab Splunk instance
 
 **Query Collections:**
 - Credential Access (LSASS dumps, Mimikatz, Kerberoasting, DCSync)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Source of truth: [`PROOF_PACK/VERIFIED_COUNTS.md`](PROOF_PACK/VERIFIED_COUNTS.md
 | Host coverage | 8/8 | All monitored agents reporting |
 | Reconciliation | 0 mismatches | Ledger vs. case directory audit |
 
+> **Escalation count context:** 2,545 is the promoted March 25 public benchmark (locked in `current-authority.json`). The lifetime ledger total including post-benchmark runtime is higher. The difference reflects cases processed after the public snapshot was locked.
+
 ---
 
 ## Quick verification

--- a/RELEASE_NOTES_2026-04-01.md
+++ b/RELEASE_NOTES_2026-04-01.md
@@ -39,6 +39,6 @@ Source: `PROOF_PACK/VERIFIED_COUNTS.md`
 
 ## Known limitations
 
-- Pipeline telemetry (55,665 cases, ~92% auto-close) is from the internal engine and not independently reproducible from this public repo alone. Detection rule and playbook counts are fully reproducible via `verify-counts.ps1`.
+- Pipeline telemetry (321,351 cases, ~88% auto-close) is from the internal engine and not independently reproducible from this public repo alone. Detection rule and playbook counts are fully reproducible via `verify-counts.ps1`.
 - Branch protection not yet enabled on `main`. Tracked for manual setup.
 - Enterprise hardening evidence pack references Splunk exports that are redacted snapshots, not live queries.

--- a/site/index.html
+++ b/site/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <title>Raylee Hawkins | SOC Analyst &amp; Detection Engineer | HawkinsOps</title>
-<meta name="description" content="Raylee Hawkins — SOC Analyst and Detection Engineer based in Huntsville, Alabama. Builder of SignalFoundry, a production-grade security automation pipeline.">
+<meta name="description" content="Raylee Hawkins — SOC Analyst and Detection Engineer based in Huntsville, Alabama. Builder of SignalFoundry, an automated security operations pipeline.">
 <meta name="author" content="Raylee Hawkins">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,7 +10,7 @@
 <link rel="canonical" href="https://hawkinsops.com/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Raylee Hawkins | SOC Analyst &amp; Detection Engineer | HawkinsOps">
-<meta property="og:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer based in Huntsville, Alabama. Builder of SignalFoundry, a production-grade security automation pipeline.">
+<meta property="og:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer based in Huntsville, Alabama. Builder of SignalFoundry, an automated security operations pipeline.">
 <meta property="og:url" content="https://hawkinsops.com/">
 <meta property="og:image" content="https://hawkinsops.com/assets/og-card.png">
 <meta property="og:image:width" content="1200">
@@ -18,7 +18,7 @@
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Raylee Hawkins | SOC Analyst &amp; Detection Engineer | HawkinsOps">
-<meta name="twitter:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer based in Huntsville, Alabama. Builder of SignalFoundry, a production-grade security automation pipeline.">
+<meta name="twitter:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer based in Huntsville, Alabama. Builder of SignalFoundry, an automated security operations pipeline.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og-card.png">
 <script type="application/ld+json">
 {
@@ -441,7 +441,7 @@
         <div class="sf-card sf-panel" data-aos="fade-up" style="padding:22px;">
           <div style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.1em;color:#fbbf24;margin-bottom:10px;">Manufacturing Operations</div>
           <ul style="margin:0;padding-left:16px;display:grid;gap:8px;font-size:0.9rem;color:var(--muted);">
-            <li><strong style="color:var(--text);">Fehrer Automotive</strong> &mdash; Team Lead, A/B/I lines. Mercedes, BMW, VW, Tesla. IATF 16949 / TISAX. Promoted in under 5 months.</li>
+            <li><strong style="color:var(--text);">Fehrer Automotive</strong> &mdash; Team Lead, A/B/I lines. Mercedes, BMW, VW, Tesla. IATF 16949 / TISAX. Promoted in under 3 months.</li>
             <li><strong style="color:var(--text);">Unipres Alabama</strong> &mdash; Team Lead Supervisor, hot stamp + laser for Nissan. Schuler 16,000 kN press. ISO 9001. Mandatory 12-hour shifts.</li>
             <li><strong style="color:var(--text);">Carrington Foods</strong> &mdash; Quality Control, Tier-1 U.S. Armed Forces supplier. SQF Ed. 9 "Excellent" / Platinum Award.</li>
           </ul>


### PR DESCRIPTION
## Summary

Surgical fixes for 5 claim-integrity defects identified during adversarial audit review. No structural changes, no new content, no redesign.

- **FIX 1:** Remove "production-grade" from 3 meta tags in `site/index.html` → "an automated security operations pipeline" (aligns with internal do-not-claim guidance)
- **FIX 2:** Fix Fehrer promotion timeline from "under 5 months" to "under 3 months" in `site/index.html` (matches `resume.html` and CLM-003 High-confidence source evidence)
- **FIX 3:** Add escalation count footnote to `README.md` explaining benchmark vs ledger lifetime total (preempts reviewer finding two different numbers)
- **FIX 4:** Update `RELEASE_NOTES_2026-04-01.md` known-limitations from stale March 25 numbers (55,665 / ~92%) to April 1 canonical (321,351 / ~88%)
- **FIX 5:** Fix `PROOF_PACK/ARCHITECTURE.md` Splunk description from "Production-ready searches for Splunk deployments" to "Investigation-layer SPL queries developed against Wazuh-forwarded events in a home lab Splunk instance"

## Verification

- [x] `verify-counts.ps1` passes (103 Sigma / 9 Splunk / 24 Wazuh / 28 blocks / 10 IR)
- [x] Zero occurrences of `production-grade` in site HTML
- [x] Zero occurrences of `under 5 months` in site HTML
- [x] Footnote present in README (`post-benchmark runtime`)
- [x] RELEASE_NOTES references 321,351
- [x] ARCHITECTURE.md has zero `Production-ready` occurrences
- [x] Pre-commit hooks passed (public safety scan + AutoSOC publish contract)

## Test plan

- [ ] Verify `site/index.html` meta tags render correctly (OG/Twitter card previews)
- [ ] Verify `README.md` footnote renders cleanly on GitHub
- [ ] Verify no drift scan regressions
- [ ] Visual check that Fehrer line reads correctly on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)