### PR TITLE
Fix: patch 10 stale count references missed in PR #131

### DIFF
--- a/PROOF_PACK/TRUTH_MANIFEST.md
+++ b/PROOF_PACK/TRUTH_MANIFEST.md
@@ -153,7 +153,7 @@ The rate decreased because the case composition changed as the pipeline processe
 
 Every file that contains metric values. When a canonical value changes, these files must be checked and updated.
 
-### Detection Inventory (103 / 9 / 24 / 28 / 10 / 140)
+### Detection Inventory (103 / 79 / 24 / 28 / 10 / 210)
 
 | File | Type |
 |---|---|

--- a/content/case-studies/autosoc-pipeline-recovery/README.md
+++ b/content/case-studies/autosoc-pipeline-recovery/README.md
@@ -42,7 +42,7 @@ SignalFoundry is a bespoke Python-and-PowerShell SOC automation pipeline built b
 | Escalated cases | 8,574 | Locked authority snapshot |
 | Hosts monitored | 8 / 8 | Coverage check |
 | Hard mismatches | 0 | Reconciliation (strict categories) |
-| Detection inventory | 140 rules | `PROOF_PACK/VERIFIED_COUNTS.md` |
+| Detection inventory | 210 detections | `PROOF_PACK/VERIFIED_COUNTS.md` |
 | IR Playbooks | 10 | `PROOF_PACK/VERIFIED_COUNTS.md` |
 
 ---
@@ -54,7 +54,7 @@ SignalFoundry is a bespoke Python-and-PowerShell SOC automation pipeline built b
 - March 2-4 stress test window: 25,167 cases at 90.1% auto-close
 - Policy tuning cycle: Windows workstation FP suppression, Linux dpkg churn, Sysmon tiering hardening
 - Coverage-check host alias normalization fix
-- Detection inventory verification (140 rules, CI-enforced)
+- Detection inventory verification (210 detections, CI-enforced)
 
 ### Excluded
 - SignalFoundry source code (private repository; architecture and behavior documented)

--- a/content/case-studies/autosoc-pipeline-recovery/front_matter.yaml
+++ b/content/case-studies/autosoc-pipeline-recovery/front_matter.yaml
@@ -14,11 +14,12 @@ canonical_metrics:
   generated_at_utc: "2026-03-24T10:36:20+00:00"
   detection_counts:
     sigma: 103
-    splunk: 9
+    splunk_spl_files: 9
+    splunk: 79
     wazuh_xml_files: 24
     wazuh_rule_blocks: 28
     ir_playbooks: 10
-    total_detections: 140
+    total_detections: 210
   pipeline_snapshot:
     source: docs/SignalFoundry_Case_Study_March2026.md
     snapshot_date: "2026-03-25"

--- a/content/case-studies/autosoc-pipeline-recovery/reviewer_lanes.md
+++ b/content/case-studies/autosoc-pipeline-recovery/reviewer_lanes.md
@@ -20,7 +20,7 @@ case_study: autosoc-pipeline-recovery
 | Cases processed | 324,074 |
 | Auto-close rate | ~88% |
 | Escalated cases | 8,574 |
-| Detection rules | 140 (CI-verified) |
+| Detection rules | 210 (CI-verified) |
 | IR Playbooks | 10 |
 | Host coverage | 8/8 |
 

--- a/content/case-studies/autosoc-race-condition/front_matter.yaml
+++ b/content/case-studies/autosoc-race-condition/front_matter.yaml
@@ -14,11 +14,12 @@ canonical_metrics:
   source_file: PROOF_PACK/VERIFIED_COUNTS.md
   detection_counts:
     sigma: 103
-    splunk: 9
+    splunk_spl_files: 9
+    splunk: 79
     wazuh_xml_files: 24
     wazuh_rule_blocks: 28
     ir_playbooks: 10
-    total_detections: 140
+    total_detections: 210
   pipeline_snapshot:
     snapshot_date: "2026-04-01"
     total_cases: 321351

--- a/docs/SignalFoundry_Case_Study_March2026.md
+++ b/docs/SignalFoundry_Case_Study_March2026.md
@@ -26,7 +26,7 @@ The system demonstrates a core engineering thesis: that a single operator with a
 | Hosts monitored | 8 / 8 | Canonical snapshot, March 20 2026 |
 | Ledger-to-repo mismatches | 0 | Canonical snapshot, March 20 2026 |
 | Pipeline run duration | ~5.4 seconds | Latest heartbeat, March 23 2026 |
-| Detection inventory | 140 rules across 3 platforms | VERIFIED_COUNTS.md |
+| Detection inventory | 210 detections across 3 platforms | VERIFIED_COUNTS.md |
 
 ### What Changed in the Past 14 Days and Why It Matters
 

--- a/site/case-study-pipeline-recovery.html
+++ b/site/case-study-pipeline-recovery.html
@@ -127,7 +127,7 @@ body {
           </div>
           <pre class="m-code">total_cases:       25,167
 escalated_cases:   2,478
-detection_rules:   140 (CI-verified)
+detection_rules:   210 (CI-verified)
 host_coverage:     8/8
 mismatch_count:    0</pre>
         </div>

--- a/site/data/truth/current-authority.json
+++ b/site/data/truth/current-authority.json
@@ -11,11 +11,12 @@
   "system_label": "SignalFoundry / AutoSOC",
   "detection_inventory": {
     "sigma_rules": 103,
-    "splunk_queries": 9,
+    "splunk_spl_files": 9,
+    "splunk_detection_searches": 79,
     "wazuh_xml_files": 24,
     "wazuh_rule_blocks": 28,
     "ir_playbooks": 10,
-    "total_detections": 140,
+    "total_detections": 210,
     "as_of": "2026-04-07",
     "source_file": "PROOF_PACK/VERIFIED_COUNTS.md",
     "claim_class": "Fully supported"

--- a/tools/og-generator.html
+++ b/tools/og-generator.html
@@ -163,7 +163,7 @@ body::after {
   </div>
   <div>
     <div class="stats">
-      <div class="stat"><div class="sv">140</div><div class="sl">Detections</div></div>
+      <div class="stat"><div class="sv">210</div><div class="sl">Detections</div></div>
       <div class="stat"><div class="sv">321,351+</div><div class="sl">Cases</div></div>
       <div class="stat green"><div class="sv">8/8</div><div class="sl">Hosts</div></div>
       <div class="stat green"><div class="sv">~88%</div><div class="sl">Auto-Close</div></div>


### PR DESCRIPTION
## Summary
- Audit found 10 stale references to `splunk: 9` and `total_detections: 140` that PR #131 missed
- 3 are public-facing (`current-authority.json`, `case-study-pipeline-recovery.html`, `og-generator.html`)
- 7 are internal docs (front matter YAMLs, reviewer lanes, case study READMEs, TRUTH_MANIFEST heading)

## Files changed
| File | Old | New |
|------|-----|-----|
| `site/data/truth/current-authority.json` | splunk_queries: 9, total: 140 | splunk_detection_searches: 79, total: 210 |
| `site/case-study-pipeline-recovery.html` | detection_rules: 140 | detection_rules: 210 |
| `tools/og-generator.html` | 140 Detections | 210 Detections |
| 2x `front_matter.yaml` | splunk: 9, total: 140 | splunk: 79, total: 210 |
| `reviewer_lanes.md` | 140 (CI-verified) | 210 (CI-verified) |
| `autosoc README.md` | 140 rules (x2) | 210 detections |
| `SignalFoundry_Case_Study_March2026.md` | 140 rules | 210 detections |
| `TRUTH_MANIFEST.md` heading | 103/9/.../140 | 103/79/.../210 |

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI verify + drift-scan pass