### PR TITLE
Fix: add Cache-Control headers to prevent stale CDN caching

### DIFF
--- a/site/_headers
+++ b/site/_headers
@@ -4,6 +4,13 @@
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Cache-Control: public, max-age=0, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/data/*
+  Cache-Control: public, max-age=0, must-revalidate
 
 /resume.txt
   Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
## Summary
- Root cause of live site serving stale 140/9 values despite PRs #131-133 merging correctly
- `site/_headers` had **no Cache-Control directive** — Cloudflare edge nodes cached HTML with default long TTLs
- Adds explicit cache headers: `max-age=0, must-revalidate` for HTML/data, `max-age=1yr, immutable` for static assets

## Test plan
- [ ] Verify Cloudflare Pages build succeeds
- [ ] Verify live pages serve correct 210/79 values after deployment propagates
- [ ] Verify response headers include Cache-Control on HTML pages