### PR TITLE
fix(autosoc): prevent JSON corruption during redaction

### DIFF
--- a/scripts/auto-soc/common.py
+++ b/scripts/auto-soc/common.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-OPS_ROOT = Path(os.getenv("OPS_ROOT", r"C:\RH\OPS"))
-AUTOSOC_ROOT = Path(os.getenv("AUTOSOC_ROOT", str(OPS_ROOT / "30_Projects" / "Active" / "AutoSOC")))
+OPS_ROOT = Path(os.getenv("OPS_ROOT") or r"C:\RH\OPS")
+AUTOSOC_ROOT = Path(os.getenv("AUTOSOC_ROOT") or str(OPS_ROOT / "30_Projects" / "Active" / "AutoSOC"))
 BUILD_ROOT = AUTOSOC_ROOT / "Build"
 CONFIG_ROOT = BUILD_ROOT / "Config"
 QUEUE_ROOT = BUILD_ROOT / "Queue"

--- a/scripts/auto-soc/redact.py
+++ b/scripts/auto-soc/redact.py
@@ -27,6 +27,31 @@ def redact_text(text: str) -> str:
     return out
 
 
+def _redact_json_value(obj):
+    """Walk a parsed JSON structure and redact all string values."""
+    if isinstance(obj, str):
+        return redact_text(obj)
+    if isinstance(obj, list):
+        return [_redact_json_value(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _redact_json_value(v) for k, v in obj.items()}
+    return obj
+
+
+def redact_json_file(raw: str) -> str:
+    """Parse JSON, redact string values, re-serialize.
+
+    Operating on parsed values avoids breaking JSON escape sequences
+    (e.g. ``\\"`` inside paths) that raw regex replacement can corrupt.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Fallback to raw text redaction if JSON is already malformed.
+        return redact_text(raw)
+    return json.dumps(_redact_json_value(data), indent=2, ensure_ascii=False)
+
+
 def copy_and_redact(case_dir: Path, out_dir: Path) -> tuple[Dict[str, int], Path]:
     stats = {"files_total": 0, "files_text": 0, "files_binary": 0}
     if out_dir.exists():
@@ -48,7 +73,10 @@ def copy_and_redact(case_dir: Path, out_dir: Path) -> tuple[Dict[str, int], Path
         if src.suffix.lower() in TEXT_EXTS:
             stats["files_text"] += 1
             raw = src.read_text(encoding="utf-8", errors="ignore")
-            dst.write_text(redact_text(raw), encoding="utf-8")
+            if src.suffix.lower() == ".json":
+                dst.write_text(redact_json_file(raw), encoding="utf-8")
+            else:
+                dst.write_text(redact_text(raw), encoding="utf-8")
         else:
             stats["files_binary"] += 1
             shutil.copy2(src, dst)

--- a/scripts/auto-soc/render-triage-quality-chart.ps1
+++ b/scripts/auto-soc/render-triage-quality-chart.ps1
@@ -1,8 +1,13 @@
 param(
-    [string]$CsvPath = "C:\RH\OPS\50_System\Runs\Reports\autosoc-triage-quality-history.csv",
-    [string]$OutPath = "C:\RH\OPS\50_System\Runs\Reports\autosoc-triage-quality-trend.png",
+    [string]$CsvPath,
+    [string]$OutPath,
     [int]$LastN = 30
 )
+
+$OpsRoot = if ($env:OPS_ROOT) { $env:OPS_ROOT } else { "C:\RH\OPS" }
+$ReportsDir = Join-Path $OpsRoot "50_System/Runs/Reports"
+if (-not $CsvPath) { $CsvPath = Join-Path $ReportsDir "autosoc-triage-quality-history.csv" }
+if (-not $OutPath) { $OutPath = Join-Path $ReportsDir "autosoc-triage-quality-trend.png" }
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## Summary
Three fixes for autosoc-pipeline failures:

1. **`redact.py` — JSON corruption during redaction**
   - Path redaction regex operated on raw JSON text, consuming trailing backslashes from JSON escape sequences (e.g. `\"` inside Windows command-line paths)
   - Corrupted JSON → `assemble-pack.py` failed with `JSONDecodeError`
   - Fix: for `.json` files, parse first, redact string values via tree walk, then re-serialize with `json.dumps`

2. **`common.py` — empty `AUTOSOC_ROOT` treated as valid path**
   - Workflow sets `AUTOSOC_ROOT=''` (empty string) which `os.getenv` returns instead of the fallback
   - `Path('')` resolves to cwd, making all derived paths (CASES_ROOT, QUEUE_ROOT, etc.) wrong
   - Fix: use `os.getenv("AUTOSOC_ROOT") or default` so empty string falls back correctly

3. **`render-triage-quality-chart.ps1` — hardcoded `C:\RH\OPS` paths**
   - Default params pointed to Windows paths that don't exist on the Linux runner
   - Fix: read `OPS_ROOT` from environment, construct paths dynamically

## Test plan
- [ ] Merge and re-run autosoc-pipeline workflow
- [ ] Verify all 4 jobs pass (poll-alerts, triage, run-pipeline, heartbeat)
- [ ] Verify ESCALATED cases process through redact → assemble → create-pr without JSON errors