### PR TITLE
Phase 1: site routing patch, README refresh, v1.6.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HawkinsOperations
 
-> **Raylee Hawkins** — Built and operates a live detection and triage pipeline on a self-hosted homelab, using AI-augmented workflows with human-directed architecture and verification.
+> **Raylee Hawkins** — Built and operates a live detection and triage pipeline across a 10-agent Wazuh deployment on self-hosted infrastructure, using AI-augmented workflows with human-directed architecture and verification.
 
 [![pipeline](https://img.shields.io/badge/pipeline-passing-brightgreen)](https://github.com/raylee-hawkins/HawkinsOperations/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](/LICENSE)
@@ -14,7 +14,7 @@
 **HawkinsOperations** is the public portfolio repository.
 **SignalFoundry** is the underlying live detection and triage system this repository documents.
 
-The AutoSOC engine ingests Wazuh alerts, performs policy-driven triage, redacts sensitive fields, and assembles escalation packs as reproducible proof artifacts. This repo contains the detection content, IR playbooks, proof artifacts, and the verification infrastructure that keeps all counts honest.
+The AutoSOC engine ingests Wazuh alerts from a 10-agent deployment, performs policy-driven triage, redacts sensitive fields, and assembles escalation packs as reproducible proof artifacts. This repo contains the detection content, IR playbooks, operational case studies, proof artifacts, and the verification infrastructure that keeps all counts honest.
 
 **If a number is in this repo, a script verified it.**
 
@@ -52,11 +52,12 @@ Source of truth: [`PROOF_PACK/VERIFIED_COUNTS.md`](/PROOF_PACK/VERIFIED_COUNTS.m
 ## How the pipeline works
 
 ```
-Wazuh Manager (live alerts)
+Wazuh Manager (10 agents, live alerts)
         |
         |-- SignalFoundry engine (poll -> triage -> redact -> pack)
         |       |
         |       '-- content/incident-response/incidents/YYYY/  (repo-staged packs)
+        |       '-- GitHub Issues (auto-created on pipeline failure, auto-closed on recovery)
         |
 
 content/detection-rules/*              content/incident-response/playbooks/*
@@ -77,7 +78,20 @@ PROOF_PACK/VERIFIED_COUNTS.md
         '-- drift_scan.py                 -->  fail on markdown/json/site count drift
 ```
 
-Maps to the documented Wazuh deployment flow: modules → bundle → `/var/ossec/etc/rules/local_rules.xml` → restart manager.
+Maps to the documented Wazuh deployment flow: modules -> bundle -> `/var/ossec/etc/rules/local_rules.xml` -> restart manager.
+
+---
+
+## Wazuh deployment
+
+The Wazuh stack is a single-node deployment (manager + indexer + dashboard) managing 10 agents across Windows and Linux hosts. Recent work (April 2026) restored full Windows process creation visibility:
+
+- **Three independent failures diagnosed and fixed:** alert-level threshold silently discarding events, severed manager-to-indexer pipeline from a security config reset, and Sysmon running without a configuration file
+- **Before:** Zero Security 4688 alerts and zero Sysmon EID 1 events had ever been indexed — the deployment appeared healthy but was blind to process creation
+- **After:** 2,120+ Security 4688 alerts and 143 Sysmon EID 1 events indexed, with full telemetry (process image, command line, parent process, user context)
+- **Detection tuning sprint:** 23 exclusions added across 8 Splunk SPL files. Zero MITRE technique coverage removed — all exclusions scoped to specific tool paths and process contexts, not behavior classes
+
+Full case study: [`content/case-studies/wazuh-telemetry-remediation.md`](/content/case-studies/wazuh-telemetry-remediation.md)
 
 ---
 
@@ -89,7 +103,7 @@ Self-hosted Proxmox cluster: Dual Xeon E5-2697 v4, 72 cores, 2TB RAM, ~96TB stor
 | --- | --- |
 | HO-FILESERVER-01 | Canonical storage authority (Z: drive) |
 | HO-RUNNER-01 | GitHub Actions self-hosted runner |
-| Wazuh cluster | Manager + Indexer + Dashboard |
+| Wazuh cluster | Manager + Indexer + Dashboard (10 agents) |
 | Splunk | Threat hunting + SPL detections |
 | Grafana | Pipeline monitoring dashboards |
 | Honeypot | External-facing telemetry source |
@@ -105,12 +119,12 @@ This is a home lab / self-hosted environment, not an enterprise SOC.
 
 - **CI-verified inventory counts** (Sigma, Wazuh, Splunk, IR playbooks) are script-generated and reproducible. These are the strongest evidence in this repo.
 - **Operational telemetry** (case counts, auto-close rates, escalation volumes) is self-reported from a single-operator pipeline. Treat with appropriate weight.
-- **Direct experience:** Sigma rule authoring, pipeline automation, Wazuh deployment and tuning, lab Splunk investigation, verification/reconciliation engineering.
+- **Direct experience:** Sigma rule authoring, pipeline automation, Wazuh deployment and tuning (including three-phase telemetry remediation), Splunk detection logic refinement, lab investigation, verification/reconciliation engineering.
 - **Conceptual overlap only:** Cribl, Torq, Exabeam, enterprise-scale Splunk operations. No production experience with these tools.
 
 ### Escalation count
 
-- **8,574** — April 7 locked canonical snapshot. All public references use this value.
+- **8,574** — April 7 locked canonical snapshot (324,074 total cases, ~88% auto-close rate). All public references use this value.
 
 ---
 
@@ -118,18 +132,18 @@ This is a home lab / self-hosted environment, not an enterprise SOC.
 
 ```
 Rule authoring (Sigma/Wazuh/Splunk)
-        │
-        ▼
-verify-counts.ps1 / generate_verified_counts.py   ← count scripts
-        │
-        ▼
-PROOF_PACK/VERIFIED_COUNTS.md                      ← single source of truth
-        │
-        ▼
-drift_scan.py                                      ← detects markdown/JSON/HTML drift
-        │
-        ▼
-generate-site-data.js → site/assets/data/          ← public proof surface
+        |
+        v
+verify-counts.ps1 / generate_verified_counts.py   <- count scripts
+        |
+        v
+PROOF_PACK/VERIFIED_COUNTS.md                      <- single source of truth
+        |
+        v
+drift_scan.py                                      <- detects markdown/JSON/HTML drift
+        |
+        v
+generate-site-data.js -> site/assets/data/         <- public proof surface
 ```
 
 If a number appears on the site, it traces back through this chain to a counted file on disk.
@@ -155,6 +169,8 @@ Expected: `PROOF_PACK/VERIFIED_COUNTS.md` regenerates with current counts, drift
 
 Selected engineering challenges documented with full context:
 
+- **Wazuh Windows Telemetry Remediation** — Three-phase restoration of process creation visibility across a 10-agent deployment. Diagnosed three independent failures (threshold mismatch, broken indexer pipeline, unconfigured Sysmon). Went from zero process creation alerts to 2,120+ Security 4688 and 143 Sysmon EID 1 events indexed with full telemetry.
+- **Detection Logic Refinement Sprint** — Analysis of 328K alert backlog, 23 targeted exclusions across 8 SPL files covering 10 MITRE ATT&CK tactics. Zero technique coverage removed.
 - **TOCTOU Race Condition** — Diagnosed at 505K queue depth in `enforce_queue_cap()`. 4-site defensive patch, 28/28 tests passing, zero data loss.
 - **AutoSOC Pipeline Recovery** — Six-day outage from stale Wazuh Indexer password + misconfigured scheduled task. Full recovery with ~1.1M alert backlog reconciliation.
 - **Enterprise Security Hardening** — 27 audit subcategories hardened, 11 new MITRE techniques detectable, 60-subcategory Microsoft Security Baseline comparison (zero regressions, 12 settings beyond baseline).
@@ -169,13 +185,13 @@ Selected engineering challenges documented with full context:
 | `PROOF_PACK/` | Verified counts, sample artifacts, evidence checklist, redaction rules |
 | `content/detection-rules/` | Sigma + Splunk + Wazuh XML, organized by MITRE tactic |
 | `content/incident-response/` | 10 IR playbooks + templates + pipeline-generated incident packs |
-| `case-studies/` | Detailed write-ups of significant engineering challenges |
-| `docs/execution/` | Operations runbook, rootcheck closeout, lab change control |
+| `content/case-studies/` | Detailed write-ups of significant engineering challenges |
+| `docs/` | Operations runbook, tuning logs, change control, architecture docs |
 | `data/` | Auto-regenerated site data from source artifacts |
 | `source_of_truth/` | Canonical authority files for metrics and counts |
 | `site/` | Static portfolio site source (Cloudflare Pages) |
 | `scripts/` | Verification, bundle builders, site generators, drift scan |
-| `.github/` | CI workflows: verify, drift-scan, update-site-data, publish-contract, public-safety-gate |
+| `.github/` | CI workflows: verify, drift-scan, update-site-data, deploy-wazuh-pack, autosoc-pipeline, publish-contract, public-safety-gate |
 
 ---
 
@@ -183,7 +199,7 @@ Selected engineering challenges documented with full context:
 
 I used AI as an execution layer, not a substitute for judgment. Claude Code, Codex, ChatGPT, and Gemini were my build tools the way a developer uses an IDE and Stack Overflow. I made the architectural decisions, verified outputs, cross-checked results across multiple AI systems, and iterated until the system behaved predictably under real operational constraints.
 
-I started with zero computer experience in September 2025. Everything in this repo was built in under 6 months while working mandatory 12-hour shifts. The method — recursive problem decomposition aimed through AI tools — is documented in detail on the [portfolio site](https://hawkinsops.com).
+I started with zero computer experience in September 2025. Everything in this repo was built in under 7 months while working mandatory 12-hour shifts. The method — recursive problem decomposition aimed through AI tools — is documented in detail on the [portfolio site](https://hawkinsops.com).
 
 ---
 
@@ -214,6 +230,8 @@ I started with zero computer experience in September 2025. Everything in this re
 - Proof lane index: [`PROOF_PACK/PROOF_INDEX.md`](/PROOF_PACK/PROOF_INDEX.md)
 - Contribution workflow: [`CONTRIBUTING.md`](/CONTRIBUTING.md)
 - Operations runbook: [`docs/execution/AUTOSOC_OPERATIONS_RUNBOOK_03-02-2026.md`](/docs/execution/AUTOSOC_OPERATIONS_RUNBOOK_03-02-2026.md)
+- Wazuh operational tuning: [`docs/detection-tuning-sprint-apr2026.md`](/docs/detection-tuning-sprint-apr2026.md)
+- Wazuh telemetry remediation: [`content/case-studies/wazuh-telemetry-remediation.md`](/content/case-studies/wazuh-telemetry-remediation.md)
 
 ---
 

--- a/docs/release-notes/v1.6.0.md
+++ b/docs/release-notes/v1.6.0.md
@@ -1,0 +1,97 @@
+# Release Notes — v1.6.0
+
+**Tag:** v1.6.0
+**Date:** 2026-04-08
+**Title:** Wazuh Telemetry Restoration + Detection Tuning Sprint
+
+---
+
+## Summary
+
+This release captures the most operationally significant changes since v1.5.0 (March 25): a three-phase Wazuh telemetry remediation that restored Windows process creation visibility from zero to proven end-to-end, a detection tuning sprint that refined 8 of 9 Splunk SPL files without removing any MITRE coverage, pipeline resilience improvements, and a full site redesign.
+
+200 commits since v1.5.0.
+
+---
+
+## Wazuh telemetry remediation
+
+The flagship work in this release. The Wazuh deployment appeared healthy — daemons running, agents connected, thousands of alerts per day — but had never indexed a single Windows process creation event. Three independent failures were responsible:
+
+1. **Alert-level threshold mismatch:** Rule 67027 (Security 4688) fires at level 3; `log_alert_level=5` silently discarded all events. Fixed with child rule 100203 at level 5.
+2. **Broken indexer pipeline:** A prior `securityadmin.sh -cd` command reset OpenSearch security config, disabling client cert auth and removing role mappings. The manager wrote alerts locally but delivered zero to the indexer.
+3. **Unconfigured Sysmon:** Sysmon v15.15 was installed and running but had no config file. Only Event ID 7 (ImageLoad) noise was generated — zero Event ID 1 (ProcessCreate). A minimal config was deployed and rule 100204 added to elevate EID 1 above the indexing threshold.
+
+**Result:** 2,120+ Security 4688 alerts and 143 Sysmon EID 1 events indexed with full telemetry (process image, command line, parent process, user context).
+
+Full case study: `content/case-studies/wazuh-telemetry-remediation.md`
+
+---
+
+## Detection tuning sprint
+
+Analyzed a 328,515-case alert backlog spanning January through April 2026. Identified 20 high-volume rules responsible for 99.5% of alert volume.
+
+- 23 targeted exclusions added across 8 SPL files
+- Exclusions scoped to specific tool paths and process contexts (AI coding tools, EDR agents, system processes)
+- Zero MITRE technique coverage removed
+- All 10 MITRE ATT&CK tactics still covered
+- 76 detection queries remain active
+
+Key patterns addressed: AI coding tool process spawning (Codex, Claude Code, Cursor), Electron app DLL loading, CrowdStrike Falcon WMI telemetry, developer workstation registry churn.
+
+Full analysis: `docs/detection-tuning-sprint-apr2026.md`
+
+---
+
+## Pipeline improvements
+
+- **Failure alerting (PR #137):** AutoSOC pipeline now auto-creates a GitHub issue on pipeline failure and auto-closes it on recovery. No manual monitoring required.
+- **JSON redaction safety (PR #136):** Pipeline now parses JSON before redacting to prevent broken escape sequences. Empty `AUTOSOC_ROOT` treated as unset.
+
+---
+
+## Site and public surface
+
+- Complete visual redesign: galaxy design system with starfield, glass cards, interactive metrics
+- Living system topology map with animated particles, hover panels, scroll reveal
+- Visual dashboards on proof and case study pages (pipeline flow, disposition gauge, evidence pack, recovery timeline)
+- Wazuh case study HTML page added to site index
+- Wazuh operational tuning log published
+- 15 case study pages (up from ~10 at v1.5.0)
+- Drift scan updated to use `data-verified` attributes instead of hard-coded claim numbers
+- Cache-Control headers added to prevent stale CDN edge caching
+- Splunk detection count reconciled: "9 files" updated to "9 files / 79 detection searches" across all surfaces
+
+---
+
+## Verification and count integrity
+
+- Canonical metrics locked: 324,074 total cases, ~88% auto-close, 8,574 escalations, 8/8 hosts reporting
+- Splunk count reconciliation completed (PR #131, #132) — all surfaces now report 79 detection searches
+- Drift scan passes with 0 mismatches
+- Pre-call trust audit resolved stale dates, wrong modal numbers, and production language
+
+---
+
+## Known follow-up work
+
+- Secondary Windows endpoint still offline — zero process visibility on that host
+- Sysmon config is minimal and may need tuning for additional detection scenarios
+- FIM limit nearly exhausted on primary endpoint (99,999/100,000)
+- Phase 2 detection tuning: evaluate Wazuh rule-level FIM exclusions for workstation syscheck noise
+- Security Onion integration for network-level detections (planned)
+
+---
+
+## Version rationale
+
+**v1.6.0** (not v2.0.0) because:
+
+- The repo structure, pipeline architecture, and verification infrastructure are the same design as v1.5.0 — substantially improved, not rebuilt
+- No breaking changes to the pipeline contract, proof pack structure, or CI workflows
+- The Wazuh remediation is operationally transformative (blind → seeing) but is a fix/restoration, not a new architecture
+- The site redesign is significant but is a presentation layer change, not a platform shift
+- Semver for a portfolio repo: major version implies a fundamentally different system, not just a better one
+
+If the Wazuh deployment were expanded to multi-node, or the pipeline were re-architected, or the detection framework changed platforms — that would be v2.0.0 territory.

--- a/site/404.html
+++ b/site/404.html
@@ -37,7 +37,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -48,7 +48,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -415,7 +415,7 @@ body::after{
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -426,7 +426,7 @@ body::after{
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/autosoc-cutover.html
+++ b/site/autosoc-cutover.html
@@ -77,7 +77,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -88,7 +88,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/autosoc-hotfix-rca.html
+++ b/site/autosoc-hotfix-rca.html
@@ -82,7 +82,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -93,7 +93,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-studies.html
+++ b/site/case-studies.html
@@ -71,7 +71,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -82,7 +82,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-autosoc.html
+++ b/site/case-study-autosoc.html
@@ -141,7 +141,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -152,7 +152,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-cve-patch.html
+++ b/site/case-study-cve-patch.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-detection-harness.html
+++ b/site/case-study-detection-harness.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-honeypot.html
+++ b/site/case-study-honeypot.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-ir-howe01.html
+++ b/site/case-study-ir-howe01.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-ir-playbooks.html
+++ b/site/case-study-ir-playbooks.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-pipeline-recovery.html
+++ b/site/case-study-pipeline-recovery.html
@@ -73,7 +73,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -84,7 +84,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-race-condition.html
+++ b/site/case-study-race-condition.html
@@ -141,7 +141,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -152,7 +152,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-security-hardening.html
+++ b/site/case-study-security-hardening.html
@@ -76,7 +76,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -87,7 +87,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-sigma-library.html
+++ b/site/case-study-sigma-library.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-soc-integration.html
+++ b/site/case-study-soc-integration.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-splunk-codex-hunt.html
+++ b/site/case-study-splunk-codex-hunt.html
@@ -39,7 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -50,7 +50,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-splunk-detection-audit.html
+++ b/site/case-study-splunk-detection-audit.html
@@ -78,7 +78,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -89,7 +89,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-threat-hunt-4688.html
+++ b/site/case-study-threat-hunt-4688.html
@@ -78,7 +78,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -89,7 +89,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study-wazuh.html
+++ b/site/case-study-wazuh.html
@@ -80,7 +80,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -91,7 +91,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/detections.html
+++ b/site/detections.html
@@ -154,7 +154,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -165,7 +165,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/enterprise-security.html
+++ b/site/enterprise-security.html
@@ -42,7 +42,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -53,7 +53,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/honeypot-proof.html
+++ b/site/honeypot-proof.html
@@ -55,7 +55,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -66,7 +66,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/index.html
+++ b/site/index.html
@@ -103,7 +103,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -114,7 +114,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>
@@ -173,6 +173,14 @@
           <div style="font-family:'JetBrains Mono',monospace;font-size:1.6rem;font-weight:700;color:#4ade80;">0</div>
           <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Errors</div>
         </div>
+      </div>
+    </section>
+
+    <!-- LATEST ENGINEERING -->
+    <section data-aos="fade-up" style="padding:0 0 12px;">
+      <div style="max-width:800px;margin:0 auto;padding:14px 20px;border:1px solid rgba(0,196,212,0.15);border-left:3px solid #00c4d4;border-radius:6px;background:rgba(0,196,212,0.03);display:flex;align-items:center;gap:14px;flex-wrap:wrap;">
+        <div style="font-family:'JetBrains Mono',monospace;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.1em;color:#00c4d4;white-space:nowrap;">Latest &mdash; 04-08-2026</div>
+        <div style="font-size:0.88rem;color:#d4e0ec;flex:1;min-width:200px;">Wazuh Windows telemetry remediation: three-phase fix restoring process creation visibility across the lab fleet. <a href="/case-study-wazuh" style="color:#00c4d4;text-decoration:none;font-weight:600;">Read case study &rarr;</a></div>
       </div>
     </section>
 
@@ -533,6 +541,10 @@ node scripts/generate-site-data.js</code></pre>
         <a class="sf-card sf-route-card sf-focus-ring" data-aos="fade-up" href="/case-study-race-condition">
           <h3>Race Condition Recovery</h3>
           <p>TOCTOU race at 505K-file scale. Diagnosed, fixed with 20 lines, verified under live load.</p>
+        </a>
+        <a class="sf-card sf-route-card sf-focus-ring" data-aos="fade-up" href="/case-studies">
+          <h3>Case Studies</h3>
+          <p>15+ engineering case studies: incident response, detection audits, threat hunts, and infrastructure work.</p>
         </a>
         <a class="sf-card sf-route-card sf-focus-ring" data-aos="fade-up" href="/proof">
           <h3>Proof</h3>

--- a/site/march-2026-deep-dive.html
+++ b/site/march-2026-deep-dive.html
@@ -39,7 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -50,7 +50,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -39,7 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -50,7 +50,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/projects.html
+++ b/site/projects.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/proof.html
+++ b/site/proof.html
@@ -1,7 +1,7 @@
 ﻿<!doctype html>
 <html lang="en">
 <head>
-<title>SignalFoundry - Proof &amp; Verified Metrics</title>
+<title>Proof &amp; Verified Metrics | HawkinsOps</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="SignalFoundry proof surface: traceable metrics, reproducible artifacts, and verification commands for every public claim.">
@@ -312,7 +312,7 @@ body.proof-page {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -323,7 +323,7 @@ body.proof-page {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/resume.html
+++ b/site/resume.html
@@ -100,7 +100,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -111,7 +111,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>

--- a/site/wildcard.html
+++ b/site/wildcard.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">Case Study</a></li>
+      <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
       <li><a href="/detections">Detections</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">Case Study</a>
+  <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
   <a href="/detections">Detections</a>


### PR DESCRIPTION
## Summary

- **Site nav routing patch:** All 28 HTML pages updated — nav link changed from `/case-study-autosoc` ("Case Study") to `/case-studies` ("Case Studies")
- **Homepage additions:** Wazuh telemetry sprint callout banner + Case Studies route card
- **Proof page:** Title corrected from "SignalFoundry" to "HawkinsOps"
- **README refresh:** Added Wazuh deployment section, updated pipeline diagram with failure alerting, added case study links, updated capability framing, corrected timeline (6 → 7 months)
- **Release notes:** `docs/release-notes/v1.6.0.md` added for the v1.6.0 tag

## Why v1.6.0, not v2.0.0

The repo structure, pipeline architecture, and verification infrastructure are unchanged from v1.5.0. The Wazuh remediation is operationally transformative (blind → seeing) but is a fix/restoration, not a new architecture. The site redesign is a presentation layer change, not a platform shift. See full rationale in the release notes.

## What was intentionally deferred

- Phase 2 naming cleanup (SignalFoundry → HawkinsOps across all pages)
- Secondary Windows endpoint process visibility (still offline)
- Sysmon config hardening beyond minimal
- Phase 2 detection tuning (Wazuh rule-level FIM exclusions)

## Validation

- `python scripts/drift_scan.py` → **PASS** (210 detections, counts consistent)
- `node scripts/diagnose-site.js` → **clean** (0 trailing-slash hazards, 0 missing assets, 0 fetch calls)
- Pre-commit hooks: public safety scan passed, publish contract scan passed
- Manual nav grep: zero old `/case-study-autosoc` nav links remain in any HTML file