### PR TITLE
fix(site): separate SignalFoundry flagship page from Case Studies hub

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -37,6 +37,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -48,6 +49,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/_redirects
+++ b/site/_redirects
@@ -6,6 +6,8 @@
 /lab /soc-lab 301
 /triage /soc-lab 301
 /march-2026-release /march-2026-release.html 200
+/signalfoundry /case-study-autosoc 301
+/signalfoundry/ /case-study-autosoc 301
 /case-study-autosoc/ /case-study-autosoc 301
 /case-study-autosoc.html /case-study-autosoc 301
 /proof/honeypot /honeypot-proof.html 200

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -415,6 +415,7 @@ body::after{
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -426,6 +427,7 @@ body::after{
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/autosoc-cutover.html
+++ b/site/autosoc-cutover.html
@@ -77,6 +77,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -88,6 +89,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/autosoc-hotfix-rca.html
+++ b/site/autosoc-hotfix-rca.html
@@ -82,6 +82,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -93,6 +94,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-studies.html
+++ b/site/case-studies.html
@@ -71,6 +71,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -82,6 +83,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -95,6 +97,23 @@ body {
     <div class="m-eyebrow">Portfolio</div>
     <h1 class="m-title" style="font-size:clamp(2.2rem,4vw,3.5rem);">Case Studies</h1>
     <p class="m-subtitle" style="max-width:680px;">Technical case studies from the SignalFoundry project. Each documents what happened, what I did, what the evidence shows, and how a reviewer can verify the claims. No sanitized post-mortems &mdash; these are built from session logs and proof artifacts.</p>
+
+    <div class="cs-section-label">Flagship System</div>
+    <div class="cs-index-grid">
+
+      <a class="cs-card" href="/case-study-autosoc" style="border-top:2px solid #00c4d4;">
+        <div class="cs-card-type">Flagship System</div>
+        <div class="cs-card-title">SignalFoundry</div>
+        <div class="cs-card-desc">The 35-script Python pipeline behind HawkinsOps. Ingests Wazuh alerts, triages by policy, enforces redaction, and publishes gated evidence packs. 324,074 cases processed, ~88% auto-closed, 8,574 escalation packs. Architecture, triage logic, pipeline recovery, and system context.</div>
+        <div class="cs-card-meta">
+          <span class="cs-card-tag teal">Flagship</span>
+          <span class="cs-card-tag green">324,074 cases</span>
+          <span class="cs-card-tag green">~88% auto-close</span>
+        </div>
+        <div class="cs-card-arrow">View system page &rarr;</div>
+      </a>
+
+    </div>
 
     <div class="cs-section-label">Case Studies</div>
     <div class="cs-index-grid">
@@ -319,8 +338,8 @@ body {
       <p class="m-copy">The SignalFoundry project processes a live queue of Wazuh security alerts across a home lab environment. These case studies capture the operational and engineering decisions made while keeping that system running and improving its detection capability.</p>
       <div class="m-grid-2" style="margin-top:20px;">
         <a href="/case-study-autosoc" class="m-link-item">
-          <strong>SignalFoundry &mdash; Full Case Study</strong>
-          <span>Architecture, triage logic, and proof strips for the AutoSOC pipeline.</span>
+          <strong>SignalFoundry &mdash; Flagship System Page</strong>
+          <span>Architecture, triage logic, pipeline recovery, and system context for the SignalFoundry engine.</span>
         </a>
         <a href="/proof" class="m-link-item">
           <strong>Proof &amp; Verified Metrics</strong>

--- a/site/case-study-autosoc.html
+++ b/site/case-study-autosoc.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
-<title>Case Study: Pipeline Outage Recovery | SignalFoundry | HawkinsOps</title>
+<title>SignalFoundry — Flagship System | HawkinsOps</title>
 <meta name="description" content="Case study: March 13 SignalFoundry pipeline outage — diagnosed and restored in one session. Infrastructure reachability separated from application logic, reconciliation-path defect isolated, full recovery to SUCCESS.">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#07070b">
 <link rel="canonical" href="https://hawkinsops.com/case-study-autosoc">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Case Study: Pipeline Outage Recovery | SignalFoundry">
+<meta property="og:title" content="SignalFoundry — Flagship System | HawkinsOps">
 <meta property="og:description" content="March 13 pipeline outage — diagnosed and restored in one session. Reconciliation-path defect isolated. Full recovery to SUCCESS.">
 <meta property="og:url" content="https://hawkinsops.com/case-study-autosoc">
 <meta property="og:image" content="https://hawkinsops.com/assets/og-card.png">
@@ -16,7 +16,7 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Case Study: Pipeline Outage Recovery | SignalFoundry">
+<meta name="twitter:title" content="SignalFoundry — Flagship System | HawkinsOps">
 <meta name="twitter:description" content="March 13 pipeline outage — diagnosed and restored in one session. Reconciliation-path defect isolated.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og-card.png">
 <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
@@ -141,6 +141,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -152,6 +153,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -167,9 +169,9 @@
        SECTION 1: CASE STUDY HERO — Incident-first
        ════════════════════════════════════════════════════════ -->
   <div class="cs-hero">
-    <div class="cs-label incident">Case Study / Flagship Incident</div>
-    <h1 style="font-size:clamp(1.8rem,3.5vw,2.8rem);margin:0 0 10px;line-height:1.15;">Pipeline outage diagnosed and restored in one session</h1>
-    <p class="cs-sub">SignalFoundry ingestion went down. I separated infrastructure reachability from application logic, isolated a reconciliation-path defect, and restored full pipeline operation to SUCCESS.</p>
+    <div class="cs-label incident">SignalFoundry — Flagship System</div>
+    <h1 style="font-size:clamp(1.8rem,3.5vw,2.8rem);margin:0 0 10px;line-height:1.15;">SignalFoundry</h1>
+    <p class="cs-sub">The flagship pipeline behind HawkinsOps. 35-script Python system that ingests Wazuh alerts, triages by policy, enforces redaction, and publishes gated evidence packs. Below: the March 13 outage recovery that stress-tested the entire architecture.</p>
 
     <!-- Incident summary card -->
     <div class="cs-incident-card">
@@ -279,7 +281,7 @@
        ════════════════════════════════════════════════════════ -->
   <div class="cs-section" data-aos="fade-up" id="related-cases">
     <div class="cs-label">Related Cases</div>
-    <h2 class="cs-title">More cases from this system</h2>
+    <h2 class="cs-title">Engineering cases from SignalFoundry</h2>
     <div class="cs-case-grid">
       <a href="/case-study-race-condition" class="cs-case-card">
         <div class="cc-date">04-07-2026</div>
@@ -323,7 +325,7 @@
        SECTION 5: SUPPORTING SYSTEM CONTEXT
        ════════════════════════════════════════════════════════ -->
   <div class="cs-section alt" data-aos="fade-up">
-    <div class="cs-context-label">Supporting Context &mdash; The System Behind the Case</div>
+    <div class="cs-context-label">SignalFoundry System Context</div>
 
     <!-- Current system state -->
     <div class="cs-label">System State</div>

--- a/site/case-study-cve-patch.html
+++ b/site/case-study-cve-patch.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-detection-harness.html
+++ b/site/case-study-detection-harness.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-honeypot.html
+++ b/site/case-study-honeypot.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-ir-howe01.html
+++ b/site/case-study-ir-howe01.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-ir-playbooks.html
+++ b/site/case-study-ir-playbooks.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-pipeline-recovery.html
+++ b/site/case-study-pipeline-recovery.html
@@ -73,6 +73,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -84,6 +85,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-race-condition.html
+++ b/site/case-study-race-condition.html
@@ -141,6 +141,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -152,6 +153,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-security-hardening.html
+++ b/site/case-study-security-hardening.html
@@ -76,6 +76,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -87,6 +88,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-sigma-library.html
+++ b/site/case-study-sigma-library.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-soc-integration.html
+++ b/site/case-study-soc-integration.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-splunk-codex-hunt.html
+++ b/site/case-study-splunk-codex-hunt.html
@@ -39,6 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -50,6 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-splunk-detection-audit.html
+++ b/site/case-study-splunk-detection-audit.html
@@ -78,6 +78,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -89,6 +90,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-threat-hunt-4688.html
+++ b/site/case-study-threat-hunt-4688.html
@@ -78,6 +78,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -89,6 +90,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-wazuh.html
+++ b/site/case-study-wazuh.html
@@ -80,6 +80,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -91,6 +92,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/detections.html
+++ b/site/detections.html
@@ -154,6 +154,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -165,6 +166,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/enterprise-security.html
+++ b/site/enterprise-security.html
@@ -42,6 +42,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -53,6 +54,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/honeypot-proof.html
+++ b/site/honeypot-proof.html
@@ -55,6 +55,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -66,6 +67,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/index.html
+++ b/site/index.html
@@ -103,6 +103,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -114,6 +115,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -139,7 +141,7 @@
         <p class="sf-body" style="line-height:1.7;margin-bottom:14px;">I built and operate <a href="/case-study-autosoc" class="sf-inline-link">SignalFoundry</a> — a 35-script Python pipeline that ingests Wazuh alerts, performs policy-driven triage, and publishes redacted escalation packs. <span data-verified="detections">210</span> detection rules across Sigma, Wazuh, and Splunk, plus 10 IR playbooks. Every metric is CI-verified. Every claim is <a href="/proof" class="sf-inline-link">reproducible</a>.</p>
         <p class="sf-body" style="line-height:1.7;color:var(--muted);margin-bottom:20px;">Sept 2025: zero computer experience. Mar 2026: 324,074 verified cases processed, live pipeline processing on cadence. Previous career: production supervisor — 30+ operators, IATF audit compliance, mandatory 12-hour shifts. The domain changed. The discipline didn't.</p>
         <div class="sf-actions">
-          <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">SignalFoundry Case Study &rarr;</a>
+          <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">SignalFoundry &rarr;</a>
           <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Proof</a>
           <a class="sf-button sf-button-secondary sf-focus-ring" href="/resume">Resume</a>
         </div>
@@ -197,7 +199,7 @@
         <img src="/assets/autosoc-decision-flow.svg" alt="AutoSOC triage decision flow" loading="lazy" width="900" height="720" style="display:block;width:100%;height:auto;">
       </div>
       <div style="text-align:center;margin-top:20px;">
-        <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">Full Case Study &rarr;</a>
+        <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">SignalFoundry System Page &rarr;</a>
       </div>
     </section>
 

--- a/site/march-2026-deep-dive.html
+++ b/site/march-2026-deep-dive.html
@@ -39,6 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -50,6 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -39,6 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -50,6 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/projects.html
+++ b/site/projects.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/proof.html
+++ b/site/proof.html
@@ -312,6 +312,7 @@ body.proof-page {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -323,6 +324,7 @@ body.proof-page {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -388,7 +390,7 @@ body.proof-page {
       </ul>
 
       <div class="proof-hero-actions">
-        <a href="/case-study-autosoc" class="btn btn-p">Full Case Study &rarr;</a>
+        <a href="/case-study-autosoc" class="btn btn-p">SignalFoundry &rarr;</a>
         <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="btn btn-s">GitHub Repo</a>
       </div>
     </div>
@@ -669,7 +671,7 @@ body.proof-page {
           <h3>Full operational narrative</h3>
           <p class="m-copy">The SignalFoundry case study covers architecture, detection design, pipeline recovery, and the full operational context behind these metrics.</p>
           <ul class="m-list-tight" style="margin-top:10px;">
-            <li><a href="/case-study-autosoc" class="m-link-item"><strong>SignalFoundry / AutoSOC Case Study</strong><span> &mdash; full build narrative, architecture, and operational detail</span></a></li>
+            <li><a href="/case-study-autosoc" class="m-link-item"><strong>SignalFoundry — Flagship System Page</strong><span> &mdash; architecture, pipeline recovery, and operational detail</span></a></li>
             <li><a href="/detections" class="m-link-item"><strong>Detection library</strong><span> &mdash; Sigma, Wazuh, and Splunk rule browser</span></a></li>
           </ul>
         </article>

--- a/site/resume.html
+++ b/site/resume.html
@@ -100,6 +100,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -111,6 +112,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -452,7 +454,7 @@
           <h2>Additional</h2>
           <ul>
             <li>Eligible to obtain clearance; willing to pursue sponsorship.</li>
-            <li><a href="/case-study-autosoc">SignalFoundry Case Study &rarr;</a></li>
+            <li><a href="/case-study-autosoc">SignalFoundry &rarr;</a></li>
             <li><a href="/proof">Proof &amp; Verified Metrics &rarr;</a></li>
           </ul>
         </div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -8,7 +8,13 @@
   </url>
   <url>
     <loc>https://hawkinsops.com/case-study-autosoc</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://hawkinsops.com/signalfoundry</loc>
+    <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/site/wildcard.html
+++ b/site/wildcard.html
@@ -40,6 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
+      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,6 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
+  <a href="/case-study-autosoc">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>


### PR DESCRIPTION
## Summary

The site's information architecture conflated three roles into one page: `/case-study-autosoc` was simultaneously the flagship system page, the incident case study, and the stand-in for the entire case study category. This PR separates those concerns cleanly.

- **Nav across all 32 pages** updated to: `Home | SignalFoundry | Case Studies | Enterprise Security | Proof | Detections | Resume`
- **SignalFoundry** (`/case-study-autosoc`) repositioned as the flagship system page with updated title, hero, and section labels
- **Case Studies** (`/case-studies`) remains the hub/index, now features SignalFoundry prominently at top as flagship entry point
- **Home, Proof, Resume** CTAs updated to reflect the separation (no more "Case Study" labels for the system page)

## Slug decision

`/case-study-autosoc` **kept as canonical slug** for safety. A `/signalfoundry` → `/case-study-autosoc` 301 redirect was added for clean external sharing. All internal links still point to `/case-study-autosoc`. Sitemap updated with both URLs.

## AutoSOC references

Intentionally preserved where they describe the underlying engine name or historical context (e.g., "SignalFoundry / AutoSOC" in incident cards, "AutoSOC triage decision flow" in SVG alt text). Not mass-replaced. Only the top-level public-facing identity was changed.

## What was intentionally deferred

- Full slug migration to `/signalfoundry` as canonical (requires updating all internal links + validating no external links break)
- Updating the 7 legacy pages without standard nav (`career-intelligence.html`, `lab.html`, `march-2026-release.html`, `security.html`, `soc-lab.html`, `start-here.html`, `triage.html`)
- Broader "AutoSOC" cleanup beyond what was needed for this IA correction

## Validation

- `python scripts/drift_scan.py` → **PASS**
- `python scripts/validate_metrics.py` → **PASS**
- Pre-commit hooks (public-safety-scan, autosoc-publish-contract) → **PASS**
- Nav consistency verified: 32/32 nav-bearing pages have the correct 7-item nav

## Test plan

- [ ] Verify nav renders correctly on Home, SignalFoundry, Case Studies, Proof, Detections, Resume
- [ ] Verify `/signalfoundry` redirects to `/case-study-autosoc`
- [ ] Verify Case Studies hub shows SignalFoundry featured card at top
- [ ] Verify no broken internal links
- [ ] CI checks pass (drift-scan, verify)