### PR TITLE
fix(site): canonicalize /signalfoundry as flagship URL

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -37,7 +37,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -49,7 +49,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/_redirects
+++ b/site/_redirects
@@ -6,10 +6,10 @@
 /lab /soc-lab 301
 /triage /soc-lab 301
 /march-2026-release /march-2026-release.html 200
-/signalfoundry /case-study-autosoc 301
-/signalfoundry/ /case-study-autosoc 301
-/case-study-autosoc/ /case-study-autosoc 301
-/case-study-autosoc.html /case-study-autosoc 301
+/case-study-autosoc /signalfoundry 301
+/case-study-autosoc/ /signalfoundry 301
+/case-study-autosoc.html /signalfoundry 301
+/signalfoundry/ /signalfoundry 301
 /proof/honeypot /honeypot-proof.html 200
 /blog-python2-to-python3 /404 301
 /blog-python2-to-python3.html /404 301

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -415,7 +415,7 @@ body::after{
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -427,7 +427,7 @@ body::after{
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/autosoc-cutover.html
+++ b/site/autosoc-cutover.html
@@ -77,7 +77,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -89,7 +89,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -231,7 +231,7 @@ freshness.status: PASS</pre>
               <strong>Hotfix RCA</strong>
               <span>Function-order bug that broke chart rendering — diagnosed and fixed same session.</span>
             </a>
-            <a href="/case-study-autosoc" class="m-link-item">
+            <a href="/signalfoundry" class="m-link-item">
               <strong>SignalFoundry case study</strong>
               <span>Full architecture, triage logic, and recovery model for the AutoSOC system.</span>
             </a>
@@ -256,7 +256,7 @@ freshness.status: PASS</pre>
           <strong>Hotfix RCA — Triage Quality Chart</strong>
           <span>Function-order bug: Assert-CanonicalPath called before declaration. EXIT=0 after fix. 104KB chart artifact confirmed.</span>
         </a>
-        <a href="/case-study-autosoc" class="m-link-item">
+        <a href="/signalfoundry" class="m-link-item">
           <strong>SignalFoundry — Full Case Study</strong>
           <span>Architecture, triage logic, proof strips, and the full operational story behind this pipeline.</span>
         </a>

--- a/site/autosoc-hotfix-rca.html
+++ b/site/autosoc-hotfix-rca.html
@@ -82,7 +82,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -94,7 +94,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -224,7 +224,7 @@ POINTS_RENDERED: 30</pre>
             <strong>Infrastructure Cutover</strong>
             <span>Production migration to canonical root — preflight gating and signed proof artifact.</span>
           </a>
-          <a href="/case-study-autosoc" class="m-link-item">
+          <a href="/signalfoundry" class="m-link-item">
             <strong>SignalFoundry case study</strong>
             <span>Full architecture, triage logic, and recovery model.</span>
           </a>
@@ -248,7 +248,7 @@ POINTS_RENDERED: 30</pre>
           <strong>Infrastructure Cutover</strong>
           <span>Production migration to canonical root. Preflight gate, five retargeted tasks, legacy ref count = 0. CUTOVER_READY=YES.</span>
         </a>
-        <a href="/case-study-autosoc" class="m-link-item">
+        <a href="/signalfoundry" class="m-link-item">
           <strong>SignalFoundry — Full Case Study</strong>
           <span>Architecture, triage logic, proof strips, and the full operational story behind this pipeline.</span>
         </a>

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-studies.html
+++ b/site/case-studies.html
@@ -71,7 +71,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -83,7 +83,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -101,7 +101,7 @@ body {
     <div class="cs-section-label">Flagship System</div>
     <div class="cs-index-grid">
 
-      <a class="cs-card" href="/case-study-autosoc" style="border-top:2px solid #00c4d4;">
+      <a class="cs-card" href="/signalfoundry" style="border-top:2px solid #00c4d4;">
         <div class="cs-card-type">Flagship System</div>
         <div class="cs-card-title">SignalFoundry</div>
         <div class="cs-card-desc">The 35-script Python pipeline behind HawkinsOps. Ingests Wazuh alerts, triages by policy, enforces redaction, and publishes gated evidence packs. 324,074 cases processed, ~88% auto-closed, 8,574 escalation packs. Architecture, triage logic, pipeline recovery, and system context.</div>
@@ -337,7 +337,7 @@ body {
       <p class="m-copy">These aren't sanitized post-mortems written weeks after the fact. They're documented from the session logs and proof artifacts that exist on-system from the actual work. The source material &mdash; preflight output, pipeline logs, scheduler metadata, Splunk queries &mdash; is real and reviewable.</p>
       <p class="m-copy">The SignalFoundry project processes a live queue of Wazuh security alerts across a home lab environment. These case studies capture the operational and engineering decisions made while keeping that system running and improving its detection capability.</p>
       <div class="m-grid-2" style="margin-top:20px;">
-        <a href="/case-study-autosoc" class="m-link-item">
+        <a href="/signalfoundry" class="m-link-item">
           <strong>SignalFoundry &mdash; Flagship System Page</strong>
           <span>Architecture, triage logic, pipeline recovery, and system context for the SignalFoundry engine.</span>
         </a>

--- a/site/case-study-cve-patch.html
+++ b/site/case-study-cve-patch.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -186,7 +186,7 @@ winget list --name "Node.js"</pre>
     <div class="hctas">
       <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence/public_images" target="_blank" rel="noopener noreferrer">View evidence artifacts (GitHub)</a>
       <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/PP_SOC_Integration/reports/IR_PATCH_REPORT_02-19-2026.md" target="_blank" rel="noopener noreferrer">Patch report (GitHub)</a>
-      <a class="btn btn-g" href="/case-study-autosoc">SignalFoundry case study</a>
+      <a class="btn btn-g" href="/signalfoundry">SignalFoundry case study</a>
     </div>
   </div>
 </section>

--- a/site/case-study-detection-harness.html
+++ b/site/case-study-detection-harness.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -209,7 +209,7 @@ Result: 0/3 PASS
     <div class="hctas">
       <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness" target="_blank" rel="noopener noreferrer">View project (GitHub)</a>
       <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md" target="_blank" rel="noopener noreferrer">Project run details</a>
-      <a class="btn btn-g" href="/case-study-autosoc">SignalFoundry case study</a>
+      <a class="btn btn-g" href="/signalfoundry">SignalFoundry case study</a>
     </div>
   </div>
 </section>

--- a/site/case-study-honeypot.html
+++ b/site/case-study-honeypot.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-ir-howe01.html
+++ b/site/case-study-ir-howe01.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -283,7 +283,7 @@ Get-Content "C:\Windows\System32\drivers\etc\hosts.ics"
     <div class="hctas">
       <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/incidents/2026/2026-01-25_howe01_r100052/evidence" target="_blank" rel="noopener noreferrer">View all 9 evidence artifacts</a>
       <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/incidents/2026/2026-01-25_howe01_r100052/2026-01-25__howe01__rule100052__hosts-ics-modified__benign.md" target="_blank" rel="noopener noreferrer">Full IR report (GitHub)</a>
-      <a class="btn btn-g" href="/case-study-autosoc">SignalFoundry case study</a>
+      <a class="btn btn-g" href="/signalfoundry">SignalFoundry case study</a>
     </div>
   </div>
 </section>

--- a/site/case-study-ir-playbooks.html
+++ b/site/case-study-ir-playbooks.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-pipeline-recovery.html
+++ b/site/case-study-pipeline-recovery.html
@@ -73,7 +73,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -85,7 +85,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -258,7 +258,7 @@ coverage.missing_hosts: 0</pre>
           <div class="m-card-kicker" data-aos="fade-up">Related</div>
           <h2>See also</h2>
           <div class="m-link-list">
-            <a href="/case-study-autosoc" class="m-link-item">
+            <a href="/signalfoundry" class="m-link-item">
               <strong>SignalFoundry case study</strong>
               <span>Full architecture and triage logic for the pipeline system.</span>
             </a>

--- a/site/case-study-race-condition.html
+++ b/site/case-study-race-condition.html
@@ -141,7 +141,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -153,7 +153,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-security-hardening.html
+++ b/site/case-study-security-hardening.html
@@ -76,7 +76,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -88,7 +88,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-sigma-library.html
+++ b/site/case-study-sigma-library.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-soc-integration.html
+++ b/site/case-study-soc-integration.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-splunk-codex-hunt.html
+++ b/site/case-study-splunk-codex-hunt.html
@@ -39,7 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -259,7 +259,7 @@ codex.exe -> git.exe                           (427 events)</pre>
 
     <div style="display:flex;gap:12px;flex-wrap:wrap;padding-bottom:60px">
       <a class="btn btn-p" href="/proof">Proof receipts</a>
-      <a class="btn" href="/case-study-autosoc">SignalFoundry case study</a>
+      <a class="btn" href="/signalfoundry">SignalFoundry case study</a>
       <a class="btn" href="/detections">Detection library</a>
       <a class="btn" href="/">Home</a>
     </div>

--- a/site/case-study-splunk-detection-audit.html
+++ b/site/case-study-splunk-detection-audit.html
@@ -78,7 +78,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -90,7 +90,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study-threat-hunt-4688.html
+++ b/site/case-study-threat-hunt-4688.html
@@ -78,7 +78,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -90,7 +90,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -225,7 +225,7 @@ body {
               <strong>Enterprise Security Hardening</strong>
               <span>The hardening that closed the gaps this hunt identified.</span>
             </a>
-            <a href="/case-study-autosoc" class="m-link-item">
+            <a href="/signalfoundry" class="m-link-item">
               <strong>SignalFoundry case study</strong>
               <span>Full pipeline architecture and triage logic.</span>
             </a>

--- a/site/case-study-wazuh.html
+++ b/site/case-study-wazuh.html
@@ -80,7 +80,7 @@ body {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -92,7 +92,7 @@ body {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/detections.html
+++ b/site/detections.html
@@ -154,7 +154,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -166,7 +166,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/enterprise-security.html
+++ b/site/enterprise-security.html
@@ -42,7 +42,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -54,7 +54,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -729,7 +729,7 @@ sourcetype="WinEventLog:Security" EventCode=4688
           <strong>Proof page</strong>
           <span>Proof surface for logs, packs, verification commands, and artifact references.</span>
         </a>
-        <a href="/case-study-autosoc" class="m-link-item">
+        <a href="/signalfoundry" class="m-link-item">
           <strong>SignalFoundry Case Study</strong>
           <span>The SOAR-style triage workflow that consumes events from the hardened pipeline.</span>
         </a>

--- a/site/honeypot-proof.html
+++ b/site/honeypot-proof.html
@@ -55,7 +55,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -67,7 +67,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/index.html
+++ b/site/index.html
@@ -103,7 +103,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -115,7 +115,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -138,10 +138,10 @@
           <span class="sf-role-tag typed-target"></span>
         </div>
         <p class="sf-body" style="line-height:1.7;margin-bottom:6px;font-weight:600;color:#71c7b8;">This is a working security operations system, not a static portfolio.</p>
-        <p class="sf-body" style="line-height:1.7;margin-bottom:14px;">I built and operate <a href="/case-study-autosoc" class="sf-inline-link">SignalFoundry</a> — a 35-script Python pipeline that ingests Wazuh alerts, performs policy-driven triage, and publishes redacted escalation packs. <span data-verified="detections">210</span> detection rules across Sigma, Wazuh, and Splunk, plus 10 IR playbooks. Every metric is CI-verified. Every claim is <a href="/proof" class="sf-inline-link">reproducible</a>.</p>
+        <p class="sf-body" style="line-height:1.7;margin-bottom:14px;">I built and operate <a href="/signalfoundry" class="sf-inline-link">SignalFoundry</a> — a 35-script Python pipeline that ingests Wazuh alerts, performs policy-driven triage, and publishes redacted escalation packs. <span data-verified="detections">210</span> detection rules across Sigma, Wazuh, and Splunk, plus 10 IR playbooks. Every metric is CI-verified. Every claim is <a href="/proof" class="sf-inline-link">reproducible</a>.</p>
         <p class="sf-body" style="line-height:1.7;color:var(--muted);margin-bottom:20px;">Sept 2025: zero computer experience. Mar 2026: 324,074 verified cases processed, live pipeline processing on cadence. Previous career: production supervisor — 30+ operators, IATF audit compliance, mandatory 12-hour shifts. The domain changed. The discipline didn't.</p>
         <div class="sf-actions">
-          <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">SignalFoundry &rarr;</a>
+          <a class="sf-button sf-button-primary sf-focus-ring" href="/signalfoundry">SignalFoundry &rarr;</a>
           <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Proof</a>
           <a class="sf-button sf-button-secondary sf-focus-ring" href="/resume">Resume</a>
         </div>
@@ -199,7 +199,7 @@
         <img src="/assets/autosoc-decision-flow.svg" alt="AutoSOC triage decision flow" loading="lazy" width="900" height="720" style="display:block;width:100%;height:auto;">
       </div>
       <div style="text-align:center;margin-top:20px;">
-        <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">SignalFoundry System Page &rarr;</a>
+        <a class="sf-button sf-button-primary sf-focus-ring" href="/signalfoundry">SignalFoundry System Page &rarr;</a>
       </div>
     </section>
 
@@ -474,7 +474,7 @@
             <li><strong style="color:var(--text);">Sept 2025:</strong> Zero computer experience.</li>
             <li><strong style="color:var(--text);">Dec 2025:</strong> Left Unipres. Started AI Model Evaluator role (detection, scripting, security reasoning).</li>
             <li><strong style="color:var(--text);">Mar 2026:</strong> Automated pipeline. Verified public benchmark. <span data-verified="detections">210</span> detection rules + 10 IR playbooks. Anthropic MCP + Claude API certified.</li>
-            <li><strong style="color:var(--text);">Result:</strong> <a href="/case-study-autosoc" class="sf-inline-link">SignalFoundry</a> &mdash; built during mandatory 12-hour shifts.</li>
+            <li><strong style="color:var(--text);">Result:</strong> <a href="/signalfoundry" class="sf-inline-link">SignalFoundry</a> &mdash; built during mandatory 12-hour shifts.</li>
           </ul>
         </div>
       </div>
@@ -536,7 +536,7 @@ node scripts/generate-site-data.js</code></pre>
           <h3>Enterprise Security</h3>
           <p>Audit policy hardening, lab infrastructure, baseline comparison, GPO deployment.</p>
         </a>
-        <a class="sf-card sf-route-card sf-focus-ring" data-aos="fade-up" href="/case-study-autosoc">
+        <a class="sf-card sf-route-card sf-focus-ring" data-aos="fade-up" href="/signalfoundry">
           <h3>SignalFoundry</h3>
           <p>Flagship system architecture, triage logic, outputs, and recovery model.</p>
         </a>

--- a/site/march-2026-deep-dive.html
+++ b/site/march-2026-deep-dive.html
@@ -39,7 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -276,7 +276,7 @@
 
   <!-- 7. NAVIGATION -->
   <div style="display:flex;gap:16px;flex-wrap:wrap;justify-content:center;">
-    <a class="sf-button sf-button-primary sf-focus-ring" href="/case-study-autosoc">SignalFoundry Overview</a>
+    <a class="sf-button sf-button-primary sf-focus-ring" href="/signalfoundry">SignalFoundry Overview</a>
     <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Proof &amp; Metrics</a>
     <a class="sf-button sf-button-secondary sf-focus-ring" href="/">Home</a>
     <a class="sf-button sf-button-secondary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">GitHub Repo</a>

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -39,7 +39,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -51,7 +51,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -219,7 +219,7 @@
 
     <div style="display:flex;gap:12px;flex-wrap:wrap;padding-bottom:60px">
       <a class="btn btn-p" href="/operations-bridge">Career Intelligence Narrative</a>
-      <a class="btn btn-p" href="/case-study-autosoc">SignalFoundry case study</a>
+      <a class="btn btn-p" href="/signalfoundry">SignalFoundry case study</a>
       <a class="btn" href="/operations-bridge">Career intelligence narrative</a>
       <a class="btn" href="/proof">Proof receipts</a>
       <a class="btn" href="/resume">Resume</a>

--- a/site/projects.html
+++ b/site/projects.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -79,7 +79,7 @@
     <h2 class="stitle">AutoSOC: automated SOC triage + evidence packs</h2>
     <p class="sdesc">Primary signal project: Wazuh alerts are triaged, sensitive data is redacted, evidence packs are generated, and high-signal cases are escalated.</p>
 
-    <a class="card lane-card" href="/case-study-autosoc" style="text-decoration:none" data-lane="fastest">
+    <a class="card lane-card" href="/signalfoundry" style="text-decoration:none" data-lane="fastest">
       <span class="lane-tag">FLAGSHIP</span>
       <div class="card-ttl">AutoSOC case study</div>
       <div class="card-sub">

--- a/site/proof.html
+++ b/site/proof.html
@@ -312,7 +312,7 @@ body.proof-page {
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -324,7 +324,7 @@ body.proof-page {
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -390,7 +390,7 @@ body.proof-page {
       </ul>
 
       <div class="proof-hero-actions">
-        <a href="/case-study-autosoc" class="btn btn-p">SignalFoundry &rarr;</a>
+        <a href="/signalfoundry" class="btn btn-p">SignalFoundry &rarr;</a>
         <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="btn btn-s">GitHub Repo</a>
       </div>
     </div>
@@ -671,7 +671,7 @@ body.proof-page {
           <h3>Full operational narrative</h3>
           <p class="m-copy">The SignalFoundry case study covers architecture, detection design, pipeline recovery, and the full operational context behind these metrics.</p>
           <ul class="m-list-tight" style="margin-top:10px;">
-            <li><a href="/case-study-autosoc" class="m-link-item"><strong>SignalFoundry — Flagship System Page</strong><span> &mdash; architecture, pipeline recovery, and operational detail</span></a></li>
+            <li><a href="/signalfoundry" class="m-link-item"><strong>SignalFoundry — Flagship System Page</strong><span> &mdash; architecture, pipeline recovery, and operational detail</span></a></li>
             <li><a href="/detections" class="m-link-item"><strong>Detection library</strong><span> &mdash; Sigma, Wazuh, and Splunk rule browser</span></a></li>
           </ul>
         </article>

--- a/site/resume.html
+++ b/site/resume.html
@@ -100,7 +100,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -112,7 +112,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>
@@ -292,7 +292,7 @@
         <h2>Summary</h2>
         <ul>
           <li>Transitioning from industrial operations leadership into security operations &mdash; not breaking into cyber, but applying the same process discipline, escalation rigor, and quality-gate thinking that drove outcomes on the factory floor.</li>
-          <li>Built and operate <a href="/case-study-autosoc">SignalFoundry</a>: a 7-stage triage pipeline (Wazuh &rarr; escalation artifacts) with verified public metrics, CI-gated proof, and reproducible evidence. <a href="/proof">Verified &rarr;</a></li>
+          <li>Built and operate <a href="/signalfoundry">SignalFoundry</a>: a 7-stage triage pipeline (Wazuh &rarr; escalation artifacts) with verified public metrics, CI-gated proof, and reproducible evidence. <a href="/proof">Verified &rarr;</a></li>
           <li>3 years Tier-1 automotive &amp; food manufacturing: team lead promotions, 30+ operator supervision, 24/7 shift operations, IATF 16949 / SQF / ISO 9001 compliance.</li>
         </ul>
       </div>
@@ -329,7 +329,7 @@
         <div class="resume-project" data-aos="fade-up">
           <h3>Detection Engineer / SOC Operations &mdash; HawkinsOps <span style="font-weight:400;color:var(--dim);">(Sep 2025 &ndash; Present)</span></h3>
           <ul>
-            <li>Built and operate <a href="/case-study-autosoc">SignalFoundry</a>: 7-stage pipeline from Wazuh alert ingest through policy-driven triage, mandatory redaction, evidence pack assembly, reconciliation, and gated publish.</li>
+            <li>Built and operate <a href="/signalfoundry">SignalFoundry</a>: 7-stage pipeline from Wazuh alert ingest through policy-driven triage, mandatory redaction, evidence pack assembly, reconciliation, and gated publish.</li>
             <li>Authored <span data-verified="sigma">103</span> Sigma detection rules, <span data-verified="wazuh">28</span> Wazuh rule blocks, <span data-verified="splunk">79</span> Splunk detection searches across 9 SPL files (home lab), and <span data-verified="ir">10</span> IR playbooks &mdash; <span data-verified="detections">210</span> detection rules + 10 IR playbooks mapped to MITRE ATT&amp;CK.</li>
             <li>Diagnosed and restored a pipeline ingestion outage by isolating infrastructure reachability from application logic, returning reconciliation to SUCCESS with 0 mismatches.</li>
             <li>Reduced Splunk EventID 4688 forwarder noise from 70% to 0%; correctly classified 375 process instances as expected tool behavior during independent threat hunt.</li>
@@ -454,7 +454,7 @@
           <h2>Additional</h2>
           <ul>
             <li>Eligible to obtain clearance; willing to pursue sponsorship.</li>
-            <li><a href="/case-study-autosoc">SignalFoundry &rarr;</a></li>
+            <li><a href="/signalfoundry">SignalFoundry &rarr;</a></li>
             <li><a href="/proof">Proof &amp; Verified Metrics &rarr;</a></li>
           </ul>
         </div>

--- a/site/signalfoundry.html
+++ b/site/signalfoundry.html
@@ -2,22 +2,22 @@
 <html lang="en">
 <head>
 <title>SignalFoundry — Flagship System | HawkinsOps</title>
-<meta name="description" content="Case study: March 13 SignalFoundry pipeline outage — diagnosed and restored in one session. Infrastructure reachability separated from application logic, reconciliation-path defect isolated, full recovery to SUCCESS.">
+<meta name="description" content="SignalFoundry: the flagship 35-script Python triage pipeline behind HawkinsOps. Ingests Wazuh alerts, triages by policy, enforces redaction, and publishes gated evidence packs. Architecture, incident recovery, and system context.">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#07070b">
-<link rel="canonical" href="https://hawkinsops.com/case-study-autosoc">
+<link rel="canonical" href="https://hawkinsops.com/signalfoundry">
 <meta property="og:type" content="article">
 <meta property="og:title" content="SignalFoundry — Flagship System | HawkinsOps">
-<meta property="og:description" content="March 13 pipeline outage — diagnosed and restored in one session. Reconciliation-path defect isolated. Full recovery to SUCCESS.">
-<meta property="og:url" content="https://hawkinsops.com/case-study-autosoc">
+<meta property="og:description" content="SignalFoundry: the flagship triage pipeline behind HawkinsOps. Architecture, incident recovery, and system context.">
+<meta property="og:url" content="https://hawkinsops.com/signalfoundry">
 <meta property="og:image" content="https://hawkinsops.com/assets/og-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="SignalFoundry — Flagship System | HawkinsOps">
-<meta name="twitter:description" content="March 13 pipeline outage — diagnosed and restored in one session. Reconciliation-path defect isolated.">
+<meta name="twitter:description" content="SignalFoundry: the flagship triage pipeline behind HawkinsOps. Architecture, incident recovery, and system context.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og-card.png">
 <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
@@ -141,7 +141,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -153,7 +153,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -7,12 +7,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://hawkinsops.com/case-study-autosoc</loc>
-    <lastmod>2026-04-08</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://hawkinsops.com/signalfoundry</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>

--- a/site/wildcard.html
+++ b/site/wildcard.html
@@ -40,7 +40,7 @@
     <button id="mobBtn" class="mob-btn" type="button" aria-expanded="false" aria-controls="mobMenu" aria-label="Toggle site navigation">Menu</button>
     <ul class="nav-l">
       <li><a href="/">Home</a></li>
-      <li><a href="/case-study-autosoc">SignalFoundry</a></li>
+      <li><a href="/signalfoundry">SignalFoundry</a></li>
       <li><a href="/case-studies">Case Studies</a></li>
       <li><a href="/enterprise-security">Enterprise Security</a></li>
       <li><a href="/proof">Proof</a></li>
@@ -52,7 +52,7 @@
 </nav>
 <div id="mobMenu" class="mob-menu" data-open="false" role="navigation" aria-label="Mobile site navigation">
   <a href="/">Home</a>
-  <a href="/case-study-autosoc">SignalFoundry</a>
+  <a href="/signalfoundry">SignalFoundry</a>
   <a href="/case-studies">Case Studies</a>
   <a href="/enterprise-security">Enterprise Security</a>
   <a href="/proof">Proof</a>


### PR DESCRIPTION
## Summary

Completes the slug migration that was intentionally deferred in PR #140. The prior IA split separated SignalFoundry from Case Studies but left `/case-study-autosoc` as the real file. This PR promotes `/signalfoundry` to the canonical flagship URL.

- **Renamed** `case-study-autosoc.html` → `signalfoundry.html`
- **Flipped redirects**: `/case-study-autosoc` now 301s to `/signalfoundry` (was the reverse)
- **Updated all 90 internal links** from `href="/case-study-autosoc"` → `href="/signalfoundry"` across 32 HTML files
- **Updated metadata**: canonical URL, og:url, meta/og/twitter descriptions in the flagship page
- **Sitemap**: single canonical `/signalfoundry` entry (removed duplicate)

## Legacy compatibility

All inbound links to `/case-study-autosoc` continue to work via 301 redirect:
- `/case-study-autosoc` → `/signalfoundry`
- `/case-study-autosoc/` → `/signalfoundry`
- `/case-study-autosoc.html` → `/signalfoundry`

## What was preserved

- AutoSOC references in page content where historically accurate (engine name, incident cards, system context)
- All case study content unchanged
- IA separation from PR #140 intact (nav: Home | SignalFoundry | Case Studies | ...)

## Validation

- `python scripts/drift_scan.py` → **PASS**
- `python scripts/validate_metrics.py` → **PASS**
- Pre-commit hooks (public-safety-scan, autosoc-publish-contract) → **PASS**
- Zero remaining `href="/case-study-autosoc"` in any HTML file
- 32/32 nav-bearing pages link to `/signalfoundry`
- Canonical and og:url both point to `https://hawkinsops.com/signalfoundry`

## What was intentionally deferred

- Broader AutoSOC label cleanup in page body content
- Updating 7 legacy pages without standard nav
- Any content rewrites beyond metadata/routing

## Test plan

- [ ] `/signalfoundry` resolves as a real page (not redirect)
- [ ] `/case-study-autosoc` 301s to `/signalfoundry`
- [ ] Nav links on Home, Case Studies, Proof, Detections, Resume all point to `/signalfoundry`
- [ ] Case Studies hub featured card links to `/signalfoundry`
- [ ] No broken internal links
- [ ] CI checks pass