### PR TITLE
fix(site): eliminate detections scroll jank from sticky filter blur

### DIFF
--- a/site/detections.html
+++ b/site/detections.html
@@ -52,7 +52,7 @@
 .mitre-bar .cnt{font-family:'JetBrains Mono',monospace;font-size:0.82rem;font-weight:700;text-align:right;}
 
 /* Filter bar */
-.filter-section{padding:40px 0 20px;position:sticky;top:59px;z-index:10;background:rgba(8,12,16,0.95);backdrop-filter:blur(12px);border-bottom:1px solid rgba(122,184,255,0.06);}
+.filter-section{padding:20px 0 14px;position:sticky;top:59px;z-index:10;background:#080c10;border-bottom:1px solid rgba(122,184,255,0.06);}
 .filter-row{display:flex;gap:8px;flex-wrap:wrap;align-items:center;}
 .filter-row input[type=search]{flex:1;min-width:200px;padding:8px 14px;background:rgba(17,24,39,0.6);border:1px solid rgba(122,184,255,0.12);border-radius:3px;color:#d4e0ec;font-family:'JetBrains Mono',monospace;font-size:0.78rem;}
 .filter-row input::placeholder{color:#4a5568;}


### PR DESCRIPTION
## Summary

One-line CSS fix for the upward-scroll jank on the Detections page.

## Root cause

`.filter-section` used `backdrop-filter:blur(12px)` with a semi-transparent `rgba(8,12,16,0.95)` background while `position:sticky`. This forces per-frame compositing during scroll — the browser must re-blur all content passing behind the sticky bar. Upward scroll is worst because previously offscreen content slides back into the blur zone.

## Fix

```css
/* Before */
padding:40px 0 20px; background:rgba(8,12,16,0.95); backdrop-filter:blur(12px);

/* After */
padding:20px 0 14px; background:#080c10;
```

- **Removed** `backdrop-filter:blur(12px)` — eliminates the compositing cost
- **Opaque background** `#080c10` — visually identical (0.95 alpha on #03060b page ≈ opaque), no transparency compositing
- **Trimmed padding** — smaller sticky bar = smaller repaint area

Filter bar remains sticky and fully functional.

## Validation
- `drift_scan.py` → **PASS**
- Pre-commit hooks → **PASS**

## Test plan
- [ ] Scroll up/down on Detections page — no jank
- [ ] Filter bar sticks correctly
- [ ] Search + filter buttons work
- [ ] CI checks pass