### PR TITLE
fix(site): remove stale sitemap entries

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -127,7 +127,7 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://hawkinsops.com/proof/honeypot</loc>
+    <loc>https://hawkinsops.com/honeypot-proof</loc>
     <lastmod>2026-04-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -167,23 +167,5 @@
     <lastmod>2026-03-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://hawkinsops.com/modernize/</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://hawkinsops.com/modernize/autosoc</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://hawkinsops.com/modernize/demo</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
   </url>
 </urlset>


### PR DESCRIPTION
Found during pre-call stress test. Removed 3 dead /modernize/ entries, fixed /proof/honeypot → /honeypot-proof. 31→28 entries. drift_scan PASS.