### PR TITLE
Fix: remove scan-line overlay causing visible lines on resume page

### DIFF
--- a/site/assets/command-center.css
+++ b/site/assets/command-center.css
@@ -56,19 +56,13 @@ html body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* Scan-line texture overlay */
+/* Scan-line texture overlay — removed, caused visible
+   horizontal artifacts on most displays */
 html body::before {
-  background:
-    repeating-linear-gradient(
-      0deg,
-      transparent,
-      transparent 3px,
-      rgba(0, 212, 255, 0.02) 3px,
-      rgba(0, 212, 255, 0.02) 4px
-    ) !important;
+  background: none !important;
   background-size: auto !important;
   animation: none !important;
-  opacity: 1 !important;
+  opacity: 0 !important;
 }
 
 /* Keep starfield-deep layer but darken */


### PR DESCRIPTION
## Problem
The resume page (and any page loading command-center.css) displayed visible horizontal lines across the entire viewport. These came from a `repeating-linear-gradient` scan-line texture on `body::before` in command-center.css (lines 59-72).

The pattern — 3px transparent, 1px rgba(0,212,255,0.02) repeating — was intended as a subtle CRT/terminal effect but rendered as obvious artifacts on most displays, especially at non-100% zoom levels.

## Fix
Set `background: none` and `opacity: 0` on `html body::before` in command-center.css. The pseudo-element structure is preserved so downstream stylesheet layers (galaxy.css starfield) aren't disrupted.

## Files changed
- `site/assets/command-center.css` — scan-line overlay disabled

## Validation
- Resume page: lines eliminated
- Other pages loading command-center.css: same fix applies
- Starfield (galaxy.css) still renders on pages that load it
- No layout or z-index changes