### PR TITLE
Fix: prevent page auto-scroll on focus (detections page jump)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7,6 +7,17 @@
   const $ = (sel, root=document) => root.querySelector(sel);
   const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
   const html = document.documentElement;
+
+  // Focus without forcing the browser to scroll the element into view.
+  function safeFocus(el) {
+    if (!el || typeof el.focus !== 'function') return;
+    try {
+      el.focus({ preventScroll: true });
+    } catch (err) {
+      try { el.focus(); } catch (err2) { /* ignore */ }
+    }
+  }
+
   const VERIFIED_TIMEOUT_MS = 1500;
   const OPS_TIMEOUT_MS = 1500;
   const isLocalDebugHost = /^(localhost|127\.0\.0\.1)$/.test(window.location.hostname);
@@ -337,10 +348,10 @@
 
     if (e.shiftKey && document.activeElement === first) {
       e.preventDefault();
-      last.focus();
+      safeFocus(last);
     } else if (!e.shiftKey && document.activeElement === last) {
       e.preventDefault();
-      first.focus();
+      safeFocus(first);
     }
   }
 
@@ -350,7 +361,7 @@
     modalBg.setAttribute('aria-hidden', 'true');
     document.body.style.overflow = '';
     if (lastFocused && typeof lastFocused.focus === 'function') {
-      lastFocused.focus();
+      safeFocus(lastFocused);
     }
   }
 
@@ -364,7 +375,7 @@
     modalBg.setAttribute('aria-hidden', 'false');
     document.body.style.overflow = 'hidden';
     if (modalClose) {
-      modalClose.focus();
+      safeFocus(modalClose);
     }
   }
 


### PR DESCRIPTION
## Problem
The detections page jumps/scrolls unexpectedly because `app.js` calls `.focus()` on modal open/close. The browser's default behavior scrolls the focused element into view, which combined with `html { scroll-behavior: smooth }` and the sticky filter bar creates a jarring auto-scroll effect.

## Root cause
- `modalClose.focus()` in `openModal()` — scrolls to modal close button
- `lastFocused.focus()` in `closeModal()` — scrolls back to the element that opened the modal
- `first.focus()` / `last.focus()` in `trapFocus()` — Tab cycling inside modal

## Fix
Added `safeFocus()` helper that uses `focus({ preventScroll: true })` with a try/catch fallback for older browsers. Replaced all 4 direct `.focus()` calls with `safeFocus()`.

## Other .focus() instances in repo
Scanned all `.js` and `.html` files in `site/`. Only the 4 calls in `app.js` were found. No other focus calls exist.

## How to test
1. Open `/detections` in a browser
2. Scroll down so the sticky filter bar and detection cards are visible
3. If any modal triggers exist, open one — page should NOT jump
4. Close the modal — page should stay where you are
5. Tab through modal content — no scroll jump on wrap-around

## Files changed
- `site/assets/app.js` — added `safeFocus()`, replaced 4 `.focus()` calls