### PR TITLE
Bump coherence.css cache buster for dark-mode fix

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -24,7 +24,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -23,7 +23,7 @@
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/page-shells.css?v=03-16-2026-1">
 <style>
 /* ═══════════════════════════════════════════

--- a/site/autosoc-cutover.html
+++ b/site/autosoc-cutover.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/autosoc-hotfix-rca.html
+++ b/site/autosoc-hotfix-rca.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-studies.html
+++ b/site/case-studies.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/case-study-cve-patch.html
+++ b/site/case-study-cve-patch.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-detection-harness.html
+++ b/site/case-study-detection-harness.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-honeypot.html
+++ b/site/case-study-honeypot.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-ir-howe01.html
+++ b/site/case-study-ir-howe01.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-ir-playbooks.html
+++ b/site/case-study-ir-playbooks.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-pipeline-recovery.html
+++ b/site/case-study-pipeline-recovery.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/case-study-race-condition.html
+++ b/site/case-study-race-condition.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 :root{--bg:#060a10;--bg1:#0a0f18;--bg2:#0d1320;--bg3:#111827;--bgt:#080c14;--cy:#00e5ff;--cyd:#00e5ff88;--cyg:#00e5ff22;--gr:#28c840;--grd:#28c84066;--am:#febc2e;--amd:#febc2e55;--rd:#ff5f57;--rdd:#ff5f5755;--t1:#e2e8f0;--t2:#94a3b8;--t3:#64748b;--bd:#1e293b;--bdc:#00e5ff15}
 .pg{max-width:820px;margin:0 auto;padding:0 24px}

--- a/site/case-study-security-hardening.html
+++ b/site/case-study-security-hardening.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/case-study-sigma-library.html
+++ b/site/case-study-sigma-library.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-soc-integration.html
+++ b/site/case-study-soc-integration.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-splunk-codex-hunt.html
+++ b/site/case-study-splunk-codex-hunt.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/case-study-splunk-detection-audit.html
+++ b/site/case-study-splunk-detection-audit.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/case-study-threat-hunt-4688.html
+++ b/site/case-study-threat-hunt-4688.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/case-study-wazuh.html
+++ b/site/case-study-wazuh.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <style>
 body {
   background:

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/detections.html
+++ b/site/detections.html
@@ -27,7 +27,7 @@
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/design-system.css?v=03-16-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="/assets/page-shells.css?v=03-16-2026-1">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/enterprise-security.html
+++ b/site/enterprise-security.html
@@ -29,7 +29,7 @@
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/honeypot-proof.html
+++ b/site/honeypot-proof.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <style>
   .proof-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:16px; margin: 16px 0 22px; }

--- a/site/index.html
+++ b/site/index.html
@@ -88,7 +88,7 @@
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="/assets/system-map.css?v=03-25-2026-1">
 <link rel="stylesheet" href="/assets/page-shells.css?v=03-16-2026-1">

--- a/site/lab.html
+++ b/site/lab.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,follow">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>

--- a/site/march-2026-deep-dive.html
+++ b/site/march-2026-deep-dive.html
@@ -26,7 +26,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/projects.html
+++ b/site/projects.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/proof.html
+++ b/site/proof.html
@@ -30,7 +30,7 @@
 <link rel="stylesheet" href="/assets/design-tokens.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/base.css?v=03-24-2026-1">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="/assets/home.css?v=03-25-2026-1">
 <style>

--- a/site/resume.html
+++ b/site/resume.html
@@ -86,7 +86,7 @@
 </script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="/assets/page-shells.css?v=03-16-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />

--- a/site/security.html
+++ b/site/security.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,follow">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>

--- a/site/signalfoundry.html
+++ b/site/signalfoundry.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme','dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/site/triage.html
+++ b/site/triage.html
@@ -9,7 +9,7 @@
 <meta name="robots" content="noindex,follow">
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 </head>

--- a/site/wildcard.html
+++ b/site/wildcard.html
@@ -27,7 +27,7 @@
 <script>document.documentElement.setAttribute('data-theme', 'dark');</script>
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/modernize.css?v=03-24-2026-1">
-<link rel="stylesheet" href="/assets/coherence.css?v=03-24-2026-3">
+<link rel="stylesheet" href="/assets/coherence.css?v=04-10-2026-1">
 <link rel="stylesheet" href="/assets/galaxy.css?v=03-25-2026-1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Bumps `coherence.css?v=03-24-2026-3` to `?v=04-10-2026-1` across all 35 HTML pages
- Forces browsers to load the updated CSS with the `--neutral-900` dark-mode fix from PR #153
- Without this, browsers serve cached old coherence.css and terminal blocks remain white-on-white

## Test plan
- [ ] Hard-refresh case-study-wazuh page — terminal blocks should have dark backgrounds
- [ ] Spot-check other pages for correct styling