### PR TITLE
Fix: update all GitHub URLs to HawkinsOps org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation / Verification
-    url: https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/VERIFY_COMMANDS_POWERSHELL.md
+    url: https://github.com/HawkinsOps/HawkinsOperations/blob/main/docs/VERIFY_COMMANDS_POWERSHELL.md
     about: Run the verification commands to confirm counts and paths before filing issues.
   - name: Security policy
-    url: https://github.com/raylee-hawkins/HawkinsOperations/blob/main/SECURITY.md
+    url: https://github.com/HawkinsOps/HawkinsOperations/blob/main/SECURITY.md
     about: Please report security concerns according to SECURITY.md.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ proof/*  ───────────────→ generate-proof-lanes.j
 | CI/CD | GitHub Actions |
 | Hosting | Cloudflare Pages (publish dir: `site/`) |
 | Lab infra | Proxmox VMs, Wazuh Manager, Grafana |
-| Version control | Git / GitHub (`raylee-hawkins/HawkinsOperations`) |
+| Version control | Git / GitHub (`HawkinsOps/HawkinsOperations`) |
 
 **No `package.json`, no `requirements.txt`** — Node scripts and Python scripts are
 standalone with no external dependencies.

--- a/PROOF_PACK/site_link_inventory.md
+++ b/PROOF_PACK/site_link_inventory.md
@@ -18,7 +18,7 @@ Scope: links reviewed in Stage 4/5 edited pages
 Removed links: none
 
 ## Authoritative external links in active use
-- GitHub repository and artifact paths under `https://github.com/raylee-hawkins/HawkinsOperations/...`
+- GitHub repository and artifact paths under `https://github.com/HawkinsOps/HawkinsOperations/...`
 - National Vulnerability Database (NVD): `https://nvd.nist.gov/vuln/detail/CVE-2025-55130`
 - Node.js security advisories: `https://nodejs.org/en/blog/vulnerability`
 - LinkedIn profile: `https://linkedin.com/in/raylee-hawkins`

--- a/content/case-studies/autosoc-pipeline-recovery/README.md
+++ b/content/case-studies/autosoc-pipeline-recovery/README.md
@@ -123,7 +123,7 @@ gantt
 
 ```powershell
 # 1. Clone repository
-git clone https://github.com/raylee-hawkins/HawkinsOperations.git
+git clone https://github.com/HawkinsOps/HawkinsOperations.git
 cd HawkinsOperations
 
 # 2. Verify detection counts match VERIFIED_COUNTS.md

--- a/content/case-studies/autosoc-pipeline-recovery/reviewer_lanes.md
+++ b/content/case-studies/autosoc-pipeline-recovery/reviewer_lanes.md
@@ -36,7 +36,7 @@ case_study: autosoc-pipeline-recovery
 
 ```powershell
 # 1. Clone and enter
-git clone https://github.com/raylee-hawkins/HawkinsOperations.git && cd HawkinsOperations
+git clone https://github.com/HawkinsOps/HawkinsOperations.git && cd HawkinsOperations
 
 # 2. Verify detection counts (CI gate)
 pwsh -NoProfile -File ".\scripts\verify\verify-counts.ps1"
@@ -71,7 +71,7 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File ".\case-studies\autosoc-pipeline-r
 ### Sigma Rules
 - **Location:** `content/detection-rules/sigma/` — 103 rules across 10 tactic folders
 - **MITRE coverage:** 9 of 14 enterprise tactics, 36+ technique IDs
-- **Browse:** [GitHub](https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/sigma)
+- **Browse:** [GitHub](https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/sigma)
 
 **Tactic distribution:**
 | Tactic | Rules | Key Techniques |

--- a/content/case-studies/sigma-detection-library/README.md
+++ b/content/case-studies/sigma-detection-library/README.md
@@ -78,7 +78,7 @@ The count (103) is not hand-asserted. It is the output of `(Get-ChildItem -Recur
 
 ```powershell
 # 1. Clone and enter
-git clone https://github.com/raylee-hawkins/HawkinsOperations.git
+git clone https://github.com/HawkinsOps/HawkinsOperations.git
 cd HawkinsOperations
 
 # 2. Count Sigma rules (total)

--- a/content/case-studies/sigma-detection-library/reviewer_lanes.md
+++ b/content/case-studies/sigma-detection-library/reviewer_lanes.md
@@ -30,7 +30,7 @@ case_study: sigma-detection-library
 
 ```powershell
 # 1. Clone
-git clone https://github.com/raylee-hawkins/HawkinsOperations.git && cd HawkinsOperations
+git clone https://github.com/HawkinsOps/HawkinsOperations.git && cd HawkinsOperations
 
 # 2. Count Sigma rules
 (Get-ChildItem -Recurse .\content\detection-rules\sigma -Filter *.yml).Count
@@ -55,7 +55,7 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File ".\case-studies\sigma-detection-li
 ## Detection Engineer Lane (deep dive)
 
 ### Browse the rules
-- [GitHub: content/detection-rules/sigma/](https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/sigma)
+- [GitHub: content/detection-rules/sigma/](https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/sigma)
 
 ### Per-tactic inspection
 ```powershell

--- a/content/detection-rules/splunk/SPLUNK_TIGHTENING_DRAFT_POST_2026-03-29.md
+++ b/content/detection-rules/splunk/SPLUNK_TIGHTENING_DRAFT_POST_2026-03-29.md
@@ -117,4 +117,4 @@ Every exclusion added in this pass is:
 
 ---
 
-*Detection library: [github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/splunk](https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/splunk)*
+*Detection library: [github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/splunk](https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/splunk)*

--- a/content/detections.json
+++ b/content/detections.json
@@ -10,11 +10,11 @@
       "evidence": [
         {
           "label": "Sigma Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/sigma"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/sigma"
         },
         {
           "label": "Verification Source",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
         }
       ]
     },
@@ -28,11 +28,11 @@
       "evidence": [
         {
           "label": "Wazuh Rules Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
         },
         {
           "label": "Bundle Script",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/scripts/build-wazuh-bundle.ps1"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/scripts/build-wazuh-bundle.ps1"
         }
       ]
     },
@@ -46,11 +46,11 @@
       "evidence": [
         {
           "label": "Splunk Detections",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/splunk"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/splunk"
         },
         {
           "label": "Coverage Mapping",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/detection-rules/mappings/mitre_coverage_matrix.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/detection-rules/mappings/mitre_coverage_matrix.md"
         }
       ]
     },
@@ -64,11 +64,11 @@
       "evidence": [
         {
           "label": "Playbooks Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks"
         },
         {
           "label": "IR Quick Reference",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/checklists/IR-004-to-030-Quick-Reference.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/incident-response/checklists/IR-004-to-030-Quick-Reference.md"
         }
       ]
     }

--- a/content/projects.json
+++ b/content/projects.json
@@ -7,16 +7,16 @@
       "type": "detection",
       "status": "active",
       "tags": ["wazuh", "sigma", "splunk", "verification"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/detection-rules",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/detection-rules",
       "page_url": "/security.html",
       "evidence": [
         {
           "label": "Verified Counts",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
         },
         {
           "label": "Wazuh Rules",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
         }
       ]
     },
@@ -27,7 +27,7 @@
       "type": "soc",
       "status": "active",
       "tags": ["soc", "triage", "workflow"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/site/triage.html",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/site/triage.html",
       "page_url": "/triage.html",
       "evidence": [
         {
@@ -36,7 +36,7 @@
         },
         {
           "label": "Incident Example",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/incidents"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/incidents"
         }
       ]
     },
@@ -47,16 +47,16 @@
       "type": "ir",
       "status": "active",
       "tags": ["ir", "playbooks", "documentation"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks",
       "page_url": "/security.html",
       "evidence": [
         {
           "label": "Playbooks Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks"
         },
         {
           "label": "IR Index",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/INDEX.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/incident-response/INDEX.md"
         }
       ]
     },
@@ -67,16 +67,16 @@
       "type": "detection",
       "status": "active",
       "tags": ["wazuh", "python", "detection", "testing", "mitre"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness",
       "page_url": "/case-study-detection-harness",
       "evidence": [
         {
           "label": "Project README",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md"
         },
         {
           "label": "Sample Run Report",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/runs/run_02-19-2026_034113/report.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/runs/run_02-19-2026_034113/report.md"
         }
       ]
     },
@@ -87,16 +87,16 @@
       "type": "lab",
       "status": "active",
       "tags": ["honeypot", "cowrie", "grafana", "wazuh", "docker"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/honeypot-grafana-wazuh",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/honeypot-grafana-wazuh",
       "page_url": "/case-study-honeypot",
       "evidence": [
         {
           "label": "Project README",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/README.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/README.md"
         },
         {
           "label": "Docker Compose",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/docker-compose.yml"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/docker-compose.yml"
         }
       ]
     }

--- a/docs/ci/drift-scan-case-study.md
+++ b/docs/ci/drift-scan-case-study.md
@@ -2,7 +2,7 @@
 
 ## What happened
 
-On 2026-04-11, commit `b1fc28c` ("refactor: make /signalfoundry system-first instead of incident-first") refactored the SignalFoundry page to lead with system architecture rather than incident narrative. The `drift-scan` CI workflow failed on [run 24288009328](https://github.com/raylee-hawkins/HawkinsOperations/actions/runs/24288009328).
+On 2026-04-11, commit `b1fc28c` ("refactor: make /signalfoundry system-first instead of incident-first") refactored the SignalFoundry page to lead with system architecture rather than incident narrative. The `drift-scan` CI workflow failed on [run 24288009328](https://github.com/HawkinsOps/HawkinsOperations/actions/runs/24288009328).
 
 ## What drift_scan.py flagged
 
@@ -19,9 +19,9 @@ Commit `9028217` ("fix: reword escalation block to avoid drift-scan false positi
 
 ## Verification
 
-- **Failing run**: [24288009328](https://github.com/raylee-hawkins/HawkinsOperations/actions/runs/24288009328) on `b1fc28c` — `drift-scan` FAIL
-- **Passing run**: [24288056335](https://github.com/raylee-hawkins/HawkinsOperations/actions/runs/24288056335) on `9028217` — `drift-scan` PASS
-- **Merge run**: [24288088530](https://github.com/raylee-hawkins/HawkinsOperations/actions/runs/24288088530) on `ed06ef5` (PR #157 merge) — `drift-scan` PASS
+- **Failing run**: [24288009328](https://github.com/HawkinsOps/HawkinsOperations/actions/runs/24288009328) on `b1fc28c` — `drift-scan` FAIL
+- **Passing run**: [24288056335](https://github.com/HawkinsOps/HawkinsOperations/actions/runs/24288056335) on `9028217` — `drift-scan` PASS
+- **Merge run**: [24288088530](https://github.com/HawkinsOps/HawkinsOperations/actions/runs/24288088530) on `ed06ef5` (PR #157 merge) — `drift-scan` PASS
 
 ## Why this matters
 

--- a/docs/wazuh-honeypot-proof-pipeline.md
+++ b/docs/wazuh-honeypot-proof-pipeline.md
@@ -28,7 +28,7 @@ The honeypot proof pipeline runs on the private Wazuh manager and publishes only
 
 1. Check timestamp and count in `proof/wazuh/honeypot/latest.md`.
 2. Review commit history for updates:
-`https://github.com/raylee-hawkins/HawkinsOperations/commits/main/proof/wazuh/honeypot`
+`https://github.com/HawkinsOps/HawkinsOperations/commits/main/proof/wazuh/honeypot`
 3. Reproduce on the Wazuh manager:
 
 ```bash

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -2,13 +2,13 @@
 # setup-runner.sh — Install GitHub Actions self-hosted runner on HO-GPU-01 / HO-RUNNER-01
 # Run as: raylee@192.168.8.200
 # Usage: bash setup-runner.sh <GITHUB_RUNNER_TOKEN>
-# Get token from: https://github.com/raylee-hawkins/HawkinsOperations/settings/actions/runners/new
+# Get token from: https://github.com/HawkinsOps/HawkinsOperations/settings/actions/runners/new
 set -euo pipefail
 
 TOKEN="${1:-}"
 if [[ -z "$TOKEN" ]]; then
   echo "Usage: $0 <GITHUB_RUNNER_TOKEN>"
-  echo "Get token at: https://github.com/raylee-hawkins/HawkinsOperations/settings/actions/runners/new"
+  echo "Get token at: https://github.com/HawkinsOps/HawkinsOperations/settings/actions/runners/new"
   exit 1
 fi
 
@@ -53,7 +53,7 @@ tar xzf "${RUNNER_FILENAME}"
 
 echo "=== Step 5: Configure runner ==="
 ./config.sh \
-  --url "https://github.com/raylee-hawkins/HawkinsOperations" \
+  --url "https://github.com/HawkinsOps/HawkinsOperations" \
   --token "${TOKEN}" \
   --name "HO-RUNNER-01" \
   --labels "self-hosted,linux,x64,hawkinsops" \
@@ -66,7 +66,7 @@ sudo ./svc.sh status
 
 echo ""
 echo "=== Done! ==="
-echo "Runner status: https://github.com/raylee-hawkins/HawkinsOperations/settings/actions/runners"
+echo "Runner status: https://github.com/HawkinsOps/HawkinsOperations/settings/actions/runners"
 pwsh --version
 node --version
 python3 --version

--- a/site/README_DEPLOY.md
+++ b/site/README_DEPLOY.md
@@ -17,7 +17,7 @@ If you only upload `index.html`, the resume PDF and styling will 404 (because ho
 
 ## Update counts
 Counts are sourced from your repo releases / verification artifacts:
-- `raylee-hawkins/HawkinsOperations`
+- `HawkinsOps/HawkinsOperations`
 - Local verification script: `scripts/verify/verify-counts.ps1`
 
 When counts change, regenerate verified artifacts from source of truth:

--- a/site/assets/components/sections/listing-renderer.js
+++ b/site/assets/components/sections/listing-renderer.js
@@ -28,7 +28,7 @@ export function renderListing(container, items, kind = "projects") {
   container.innerHTML = items
     .map((item) => {
       const primaryLink = kind === "detections"
-        ? `https://github.com/raylee-hawkins/HawkinsOperations/tree/main/${esc(item.location || "")}`
+        ? `https://github.com/HawkinsOps/HawkinsOperations/tree/main/${esc(item.location || "")}`
         : esc(item.page_url || item.repo_url || "#");
       const title = esc(item.title || item.platform || "Untitled");
       const summary = esc(item.summary || `${item.count || ""} ${item.format || ""}`.trim());

--- a/site/assets/data/detections.json
+++ b/site/assets/data/detections.json
@@ -10,11 +10,11 @@
       "evidence": [
         {
           "label": "Sigma Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/sigma"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/sigma"
         },
         {
           "label": "Verification Source",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
         }
       ]
     },
@@ -28,11 +28,11 @@
       "evidence": [
         {
           "label": "Wazuh Rules Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
         },
         {
           "label": "Bundle Script",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/scripts/build-wazuh-bundle.ps1"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/scripts/build-wazuh-bundle.ps1"
         }
       ]
     },
@@ -46,11 +46,11 @@
       "evidence": [
         {
           "label": "Splunk Detections",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/splunk"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/splunk"
         },
         {
           "label": "Coverage Mapping",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/detection-rules/mappings/mitre_coverage_matrix.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/detection-rules/mappings/mitre_coverage_matrix.md"
         }
       ]
     },
@@ -64,11 +64,11 @@
       "evidence": [
         {
           "label": "Playbooks Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks"
         },
         {
           "label": "IR Quick Reference",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/checklists/IR-004-to-030-Quick-Reference.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/incident-response/checklists/IR-004-to-030-Quick-Reference.md"
         }
       ]
     }

--- a/site/assets/data/projects.json
+++ b/site/assets/data/projects.json
@@ -7,16 +7,16 @@
       "type": "detection",
       "status": "active",
       "tags": ["wazuh", "sigma", "splunk", "verification"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/detection-rules",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/detection-rules",
       "page_url": "/security.html",
       "evidence": [
         {
           "label": "Verified Counts",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md"
         },
         {
           "label": "Wazuh Rules",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules"
         }
       ]
     },
@@ -27,7 +27,7 @@
       "type": "soc",
       "status": "active",
       "tags": ["soc", "triage", "workflow"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/site/triage.html",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/site/triage.html",
       "page_url": "/triage.html",
       "evidence": [
         {
@@ -36,7 +36,7 @@
         },
         {
           "label": "Incident Example",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/incidents"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/incidents"
         }
       ]
     },
@@ -47,16 +47,16 @@
       "type": "ir",
       "status": "active",
       "tags": ["ir", "playbooks", "documentation"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks",
       "page_url": "/security.html",
       "evidence": [
         {
           "label": "Playbooks Folder",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks"
         },
         {
           "label": "IR Index",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/INDEX.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/incident-response/INDEX.md"
         }
       ]
     },
@@ -67,16 +67,16 @@
       "type": "detection",
       "status": "active",
       "tags": ["wazuh", "python", "detection", "testing", "mitre"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness",
       "page_url": "/case-study-detection-harness",
       "evidence": [
         {
           "label": "Project README",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md"
         },
         {
           "label": "Sample Run Report",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/runs/run_02-19-2026_034113/report.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/runs/run_02-19-2026_034113/report.md"
         }
       ]
     },
@@ -87,16 +87,16 @@
       "type": "lab",
       "status": "active",
       "tags": ["honeypot", "cowrie", "grafana", "wazuh", "docker"],
-      "repo_url": "https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/honeypot-grafana-wazuh",
+      "repo_url": "https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/honeypot-grafana-wazuh",
       "page_url": "/case-study-honeypot",
       "evidence": [
         {
           "label": "Project README",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/README.md"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/README.md"
         },
         {
           "label": "Docker Compose",
-          "url": "https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/docker-compose.yml"
+          "url": "https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/docker-compose.yml"
         }
       ]
     }

--- a/site/autosoc-cutover.html
+++ b/site/autosoc-cutover.html
@@ -270,7 +270,7 @@ freshness.status: PASS</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/autosoc-hotfix-rca.html
+++ b/site/autosoc-hotfix-rca.html
@@ -262,7 +262,7 @@ POINTS_RENDERED: 30</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/blog-python2-to-python3.html
+++ b/site/blog-python2-to-python3.html
@@ -122,7 +122,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-studies.html
+++ b/site/case-studies.html
@@ -635,7 +635,7 @@ body {
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-cve-patch.html
+++ b/site/case-study-cve-patch.html
@@ -184,8 +184,8 @@ winget list --name "Node.js"</pre>
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence/public_images" target="_blank" rel="noopener noreferrer">View evidence artifacts (GitHub)</a>
-      <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/PP_SOC_Integration/reports/IR_PATCH_REPORT_02-19-2026.md" target="_blank" rel="noopener noreferrer">Patch report (GitHub)</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence/public_images" target="_blank" rel="noopener noreferrer">View evidence artifacts (GitHub)</a>
+      <a class="btn btn-g" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/PP_SOC_Integration/reports/IR_PATCH_REPORT_02-19-2026.md" target="_blank" rel="noopener noreferrer">Patch report (GitHub)</a>
       <a class="btn btn-g" href="/signalfoundry">SignalFoundry case study</a>
     </div>
   </div>
@@ -206,7 +206,7 @@ winget list --name "Node.js"</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-detection-harness.html
+++ b/site/case-study-detection-harness.html
@@ -207,8 +207,8 @@ Result: 0/3 PASS
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness" target="_blank" rel="noopener noreferrer">View project (GitHub)</a>
-      <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md" target="_blank" rel="noopener noreferrer">Project run details</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/wazuh-detection-harness" target="_blank" rel="noopener noreferrer">View project (GitHub)</a>
+      <a class="btn btn-g" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/wazuh-detection-harness/README.md" target="_blank" rel="noopener noreferrer">Project run details</a>
       <a class="btn btn-g" href="/signalfoundry">SignalFoundry case study</a>
     </div>
   </div>
@@ -229,7 +229,7 @@ Result: 0/3 PASS
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-honeypot.html
+++ b/site/case-study-honeypot.html
@@ -202,8 +202,8 @@ docker compose up -d
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/honeypot-grafana-wazuh" target="_blank" rel="noopener noreferrer">View project (GitHub)</a>
-      <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/docker-compose.yml" target="_blank" rel="noopener noreferrer">Docker Compose file</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/honeypot-grafana-wazuh" target="_blank" rel="noopener noreferrer">View project (GitHub)</a>
+      <a class="btn btn-g" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/honeypot-grafana-wazuh/docker-compose.yml" target="_blank" rel="noopener noreferrer">Docker Compose file</a>
       <a class="btn btn-g" href="/enterprise-security">Enterprise Security</a>
     </div>
   </div>
@@ -224,7 +224,7 @@ docker compose up -d
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-ir-howe01.html
+++ b/site/case-study-ir-howe01.html
@@ -281,8 +281,8 @@ Get-Content "C:\Windows\System32\drivers\etc\hosts.ics"
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/incidents/2026/2026-01-25_howe01_r100052/evidence" target="_blank" rel="noopener noreferrer">View all 9 evidence artifacts</a>
-      <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/incidents/2026/2026-01-25_howe01_r100052/2026-01-25__howe01__rule100052__hosts-ics-modified__benign.md" target="_blank" rel="noopener noreferrer">Full IR report (GitHub)</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/incidents/2026/2026-01-25_howe01_r100052/evidence" target="_blank" rel="noopener noreferrer">View all 9 evidence artifacts</a>
+      <a class="btn btn-g" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/incident-response/incidents/2026/2026-01-25_howe01_r100052/2026-01-25__howe01__rule100052__hosts-ics-modified__benign.md" target="_blank" rel="noopener noreferrer">Full IR report (GitHub)</a>
       <a class="btn btn-g" href="/signalfoundry">SignalFoundry case study</a>
     </div>
   </div>
@@ -303,7 +303,7 @@ Get-Content "C:\Windows\System32\drivers\etc\hosts.ics"
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-ir-playbooks.html
+++ b/site/case-study-ir-playbooks.html
@@ -227,8 +227,8 @@ Get-ADUser -Filter * -Properties * |
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/incident-response/playbooks" target="_blank" rel="noopener noreferrer">View all <span data-verified="ir">10</span> playbooks (GitHub)</a>
-      <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/incident-response/INDEX.md" target="_blank" rel="noopener noreferrer">IR index</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/incident-response/playbooks" target="_blank" rel="noopener noreferrer">View all <span data-verified="ir">10</span> playbooks (GitHub)</a>
+      <a class="btn btn-g" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/incident-response/INDEX.md" target="_blank" rel="noopener noreferrer">IR index</a>
       <a class="btn btn-g" href="/case-study-ir-howe01">Live IR case study: Level 12 alert</a>
     </div>
   </div>
@@ -249,7 +249,7 @@ Get-ADUser -Filter * -Properties * |
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-pipeline-recovery.html
+++ b/site/case-study-pipeline-recovery.html
@@ -301,7 +301,7 @@ coverage.missing_hosts: 0</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-race-condition.html
+++ b/site/case-study-race-condition.html
@@ -385,7 +385,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-security-hardening.html
+++ b/site/case-study-security-hardening.html
@@ -281,7 +281,7 @@ AFTER:  1 GB (1,073,741,824 bytes)</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-sigma-library.html
+++ b/site/case-study-sigma-library.html
@@ -230,8 +230,8 @@ level: high</pre>
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/sigma" target="_blank" rel="noopener noreferrer">Browse Sigma rules (GitHub)</a>
-      <a class="btn btn-g" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">Verified counts</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/sigma" target="_blank" rel="noopener noreferrer">Browse Sigma rules (GitHub)</a>
+      <a class="btn btn-g" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">Verified counts</a>
       <a class="btn btn-g" href="/detections">Security page</a>
     </div>
   </div>
@@ -252,7 +252,7 @@ level: high</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-soc-integration.html
+++ b/site/case-study-soc-integration.html
@@ -136,10 +136,10 @@
       <div class="card-sub">
         <p>All artifacts from this project are collected in the repository evidence directory. Screenshots containing internal identifiers are redacted per repo sanitization policy.</p>
         <ul style="padding-left:18px;margin-top:10px">
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence" target="_blank" rel="noopener noreferrer">PP_SOC_Integration evidence directory (GitHub)</a> - Wazuh alert screenshots, agent status, CVE remediation artifacts.</li>
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/lab/proxmox/vms/104/splunk/exports" target="_blank" rel="noopener noreferrer">Splunk VM 104 exports (GitHub)</a> - sanitized live-ingest validation summary and validated Event ID 4688 SPL pivots.</li>
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration" target="_blank" rel="noopener noreferrer">Full project package (GitHub)</a> - README, docs, and structured proof artifacts.</li>
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/PP_SOC_Integration/docs/UPCOMING_PROJECT_DIRECTION.md" target="_blank" rel="noopener noreferrer">Upcoming project direction doc</a> - next phase priorities and expansion plan.</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence" target="_blank" rel="noopener noreferrer">PP_SOC_Integration evidence directory (GitHub)</a> - Wazuh alert screenshots, agent status, CVE remediation artifacts.</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/lab/proxmox/vms/104/splunk/exports" target="_blank" rel="noopener noreferrer">Splunk VM 104 exports (GitHub)</a> - sanitized live-ingest validation summary and validated Event ID 4688 SPL pivots.</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration" target="_blank" rel="noopener noreferrer">Full project package (GitHub)</a> - README, docs, and structured proof artifacts.</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/PP_SOC_Integration/docs/UPCOMING_PROJECT_DIRECTION.md" target="_blank" rel="noopener noreferrer">Upcoming project direction doc</a> - next phase priorities and expansion plan.</li>
         </ul>
         <div style="margin-top:12px">
           <img src="/assets/pp_soc_integration/t5-proxmox-redacted.png" alt="SOC infrastructure map showing collect detect triage investigate respond improve workflow across Proxmox and endpoint systems" style="display:block;width:100%;height:auto;border-radius:10px;border:1px solid var(--stroke)">
@@ -174,7 +174,7 @@
 
     <div style="height:20px"></div>
     <div class="hctas">
-      <a class="btn btn-p" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence" target="_blank" rel="noopener noreferrer">View evidence artifacts</a>
+      <a class="btn btn-p" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/PP_SOC_Integration/evidence" target="_blank" rel="noopener noreferrer">View evidence artifacts</a>
       <a class="btn btn-g" href="/proof">See the proof pack</a>
       <a class="btn btn-g" href="/case-study">Wazuh rule-build case study</a>
     </div>
@@ -196,7 +196,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-splunk-codex-hunt.html
+++ b/site/case-study-splunk-codex-hunt.html
@@ -272,7 +272,7 @@ codex.exe -> git.exe                           (427 events)</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-splunk-detection-audit.html
+++ b/site/case-study-splunk-detection-audit.html
@@ -250,7 +250,7 @@ Wazuh agent forwarding Security Event Log as <span class="m-inline-code">XmlWinE
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-threat-hunt-4688.html
+++ b/site/case-study-threat-hunt-4688.html
@@ -260,7 +260,7 @@ body {
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study-wazuh.html
+++ b/site/case-study-wazuh.html
@@ -303,7 +303,7 @@ Primary endpoint visibility:    Blind         Full (4688 + Sysmon EID 1)</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/case-study.html
+++ b/site/case-study.html
@@ -115,10 +115,10 @@ pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</pre>
       <div class="card-sub">
         <p>The rule source files, bundle script, and verification outputs are all in the public repo:</p>
         <ul style="padding-left:18px;margin:8px 0 0">
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules" target="_blank" rel="noopener noreferrer">Wazuh rules directory</a> - <span data-verified="wazuh_xml_files">24</span> XML files</li>
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/scripts/build-wazuh-bundle.ps1" target="_blank" rel="noopener noreferrer">Bundle build script</a></li>
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">VERIFIED_COUNTS.md</a> - locked counts</li>
-          <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/scripts/verify/verify-counts.ps1" target="_blank" rel="noopener noreferrer">verify-counts.ps1</a> - run to reproduce</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/detection-rules/wazuh/rules" target="_blank" rel="noopener noreferrer">Wazuh rules directory</a> - <span data-verified="wazuh_xml_files">24</span> XML files</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/scripts/build-wazuh-bundle.ps1" target="_blank" rel="noopener noreferrer">Bundle build script</a></li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">VERIFIED_COUNTS.md</a> - locked counts</li>
+          <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/scripts/verify/verify-counts.ps1" target="_blank" rel="noopener noreferrer">verify-counts.ps1</a> - run to reproduce</li>
         </ul>
         <p style="margin-top:10px;font-size:.82rem;color:var(--faint)">Lab screenshots of alert firing are available on request. Dashboard images are withheld to avoid exposing internal Wazuh indexer configuration.</p>
       </div>
@@ -169,7 +169,7 @@ pwsh -NoProfile -File .\scripts\verify\verify-counts.ps1</pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/detections.html
+++ b/site/detections.html
@@ -328,7 +328,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/enterprise-security.html
+++ b/site/enterprise-security.html
@@ -75,7 +75,7 @@
       <p class="m-outcome" style="font-size:0.85rem;">Testbed: 72-core Proxmox with dedicated Wazuh, Splunk, and Grafana VMs. Host coverage: 8/8 (Windows Server 2022).</p>
       <div class="m-actions">
         <a class="m-cta m-cta-dominant" href="/assets/evidence/enterprise-hardening-evidence.zip" download>Download Evidence Pack</a>
-        <a class="m-cta m-cta-accent" href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening" target="_blank" rel="noopener noreferrer">Source Artifacts</a>
+        <a class="m-cta m-cta-accent" href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening" target="_blank" rel="noopener noreferrer">Source Artifacts</a>
         <a class="m-cta m-cta-secondary" href="/proof">Proof Receipts</a>
       </div>
       <div class="m-hero-signals">
@@ -333,7 +333,7 @@
           </div>
           <div style="padding:10px 14px;background:rgba(122,184,255,0.04);border:1px solid rgba(122,184,255,0.12);border-radius:8px;margin-top:4px;">
             <div style="font-size:0.78rem;font-weight:600;color:#7ab8ff;">Raw evidence artifacts</div>
-            <div style="font-size:0.72rem;color:var(--muted,#8ea4c7);">4688 before/after JSON exports, 4719 policy change events, and KPI comparison available in the <a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening/evidence-pack" target="_blank" rel="noopener noreferrer" style="color:#7ab8ff;">evidence pack</a>.</div>
+            <div style="font-size:0.72rem;color:var(--muted,#8ea4c7);">4688 before/after JSON exports, 4719 policy change events, and KPI comparison available in the <a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening/evidence-pack" target="_blank" rel="noopener noreferrer" style="color:#7ab8ff;">evidence pack</a>.</div>
           </div>
         </div>
       </div>
@@ -411,7 +411,7 @@
           </tbody>
         </table>
       </div>
-      <p style="font-size:0.72rem;color:var(--muted,#8ea4c7);margin-top:12px;">S+F = Success and Failure. Full 60-subcategory comparison available in <a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/projects/lab/enterprise-hardening/baseline-comparison.md" target="_blank" rel="noopener noreferrer" style="color:#7ab8ff;">baseline-comparison.md</a>.</p>
+      <p style="font-size:0.72rem;color:var(--muted,#8ea4c7);margin-top:12px;">S+F = Success and Failure. Full 60-subcategory comparison available in <a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/projects/lab/enterprise-hardening/baseline-comparison.md" target="_blank" rel="noopener noreferrer" style="color:#7ab8ff;">baseline-comparison.md</a>.</p>
     </div>
 
     <!-- Additional verified settings -->
@@ -721,7 +721,7 @@ sourcetype="WinEventLog:Security" EventCode=4688
       <div class="m-card-kicker" data-aos="fade-up">Proof links</div>
       <h2>Validate the hardening</h2>
       <div class="m-grid-2">
-        <a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening" target="_blank" rel="noopener noreferrer" class="m-link-item">
+        <a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening" target="_blank" rel="noopener noreferrer" class="m-link-item">
           <strong>Source artifacts</strong>
           <span>Full markdown documentation, CSV exports, and PowerShell scripts in the repository.</span>
         </a>
@@ -737,7 +737,7 @@ sourcetype="WinEventLog:Security" EventCode=4688
           <strong>Detections</strong>
           <span>Browse the detection rules that benefit from the expanded audit coverage.</span>
         </a>
-        <a href="https://github.com/raylee-hawkins/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening/evidence-pack" target="_blank" rel="noopener noreferrer" class="m-link-item">
+        <a href="https://github.com/HawkinsOps/HawkinsOperations/tree/main/content/projects/lab/enterprise-hardening/evidence-pack" target="_blank" rel="noopener noreferrer" class="m-link-item">
           <strong>Evidence Pack</strong>
           <span>Before/after Splunk exports, GPO export, KPI comparison, and collection metadata with full redaction documentation.</span>
         </a>
@@ -764,7 +764,7 @@ sourcetype="WinEventLog:Security" EventCode=4688
           <strong>Browse Detections</strong>
           <span>See the detection rules that now receive signal from the hardened audit policy.</span>
         </a>
-        <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="m-link-item">
+        <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="m-link-item">
           <strong>Inspect the repository</strong>
           <span>Trace the public code, docs, and commit history behind the hardening work.</span>
         </a>
@@ -779,7 +779,7 @@ sourcetype="WinEventLog:Security" EventCode=4688
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/honeypot-proof.html
+++ b/site/honeypot-proof.html
@@ -106,8 +106,8 @@
       </div>
       <div class="card">
         <div class="card-ttl">GitHub artifact path</div>
-        <div class="card-sub"><a id="githubJson" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/proof/wazuh/honeypot/latest.json" target="_blank" rel="noopener noreferrer">proof/wazuh/honeypot/latest.json</a></div>
-        <div class="card-sub"><a id="githubSummary" href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/proof/wazuh/honeypot/latest.summary.json" target="_blank" rel="noopener noreferrer">proof/wazuh/honeypot/latest.summary.json</a></div>
+        <div class="card-sub"><a id="githubJson" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/proof/wazuh/honeypot/latest.json" target="_blank" rel="noopener noreferrer">proof/wazuh/honeypot/latest.json</a></div>
+        <div class="card-sub"><a id="githubSummary" href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/proof/wazuh/honeypot/latest.summary.json" target="_blank" rel="noopener noreferrer">proof/wazuh/honeypot/latest.summary.json</a></div>
       </div>
     </div>
 
@@ -142,7 +142,7 @@
       <div class="details-body">
         <ol style="padding-left:18px">
           <li style="margin:8px 0">Check the timestamp in the artifact.</li>
-          <li style="margin:8px 0">View the commit history for proof updates: <a href="https://github.com/raylee-hawkins/HawkinsOperations/commits/main/proof/wazuh/honeypot" target="_blank" rel="noopener noreferrer">proof/wazuh/honeypot commits</a>.</li>
+          <li style="margin:8px 0">View the commit history for proof updates: <a href="https://github.com/HawkinsOps/HawkinsOperations/commits/main/proof/wazuh/honeypot" target="_blank" rel="noopener noreferrer">proof/wazuh/honeypot commits</a>.</li>
           <li style="margin:8px 0">Reproduce: exporter reads Wazuh <code>alerts.json</code> and publishes sanitized artifacts.</li>
         </ol>
       </div>
@@ -156,7 +156,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -70,7 +70,7 @@
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux",
       "author": { "@id": "https://hawkinsops.com/#person" },
-      "url": "https://github.com/raylee-hawkins/HawkinsOperations",
+      "url": "https://github.com/HawkinsOps/HawkinsOperations",
       "isPartOf": { "@id": "https://hawkinsops.com" }
     }
   ]
@@ -575,7 +575,7 @@ node scripts/generate-site-data.js</code></pre>
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/march-2026-deep-dive.html
+++ b/site/march-2026-deep-dive.html
@@ -279,7 +279,7 @@
     <a class="sf-button sf-button-primary sf-focus-ring" href="/signalfoundry">SignalFoundry Overview</a>
     <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Proof &amp; Metrics</a>
     <a class="sf-button sf-button-secondary sf-focus-ring" href="/">Home</a>
-    <a class="sf-button sf-button-secondary sf-focus-ring" href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer">GitHub Repo</a>
+    <a class="sf-button sf-button-secondary sf-focus-ring" href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer">GitHub Repo</a>
   </div>
 
 </main>
@@ -289,7 +289,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/march-2026-release.html
+++ b/site/march-2026-release.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="refresh" content="0;url=https://github.com/raylee-hawkins/HawkinsOperations/releases">
+<meta http-equiv="refresh" content="0;url=https://github.com/HawkinsOps/HawkinsOperations/releases">
 <title>Moved</title>
 </head>
 <body>
-<a href="https://github.com/raylee-hawkins/HawkinsOperations/releases">This page has moved to GitHub Releases</a>
+<a href="https://github.com/HawkinsOps/HawkinsOperations/releases">This page has moved to GitHub Releases</a>
 </body>
 </html>

--- a/site/operations-bridge.html
+++ b/site/operations-bridge.html
@@ -233,7 +233,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/projects.html
+++ b/site/projects.html
@@ -169,7 +169,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/proof.html
+++ b/site/proof.html
@@ -391,7 +391,7 @@ body.proof-page {
 
       <div class="proof-hero-actions">
         <a href="/signalfoundry" class="btn btn-p">SignalFoundry &rarr;</a>
-        <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="btn btn-s">GitHub Repo</a>
+        <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="btn btn-s">GitHub Repo</a>
       </div>
     </div>
   </section>
@@ -579,8 +579,8 @@ body.proof-page {
           <h3>Recovery Run Evidence</h3>
           <p class="m-copy">Pipeline recovery case study from 03-13-2026. Final run: <code>run_id=autosoc-20260313T215029Z-31020</code>, <code>status=SUCCESS</code>, <code>cases_processed=173</code>, <code>reconciliation.mismatch_count=0</code>. Proves concrete execution output and validated recovery path.</p>
           <ul class="m-list-tight" style="margin-top:10px;">
-            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md" target="_blank" rel="noopener noreferrer">Pipeline recovery public snippets (GitHub)</a></li>
-            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">VERIFIED_COUNTS.md (GitHub)</a></li>
+            <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md" target="_blank" rel="noopener noreferrer">Pipeline recovery public snippets (GitHub)</a></li>
+            <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">VERIFIED_COUNTS.md (GitHub)</a></li>
           </ul>
           <p class="m-copy" style="margin-top:10px;font-size:0.85rem;color:var(--muted,#8ea4c7);">Historical reference only &mdash; not current-facing authority</p>
         </article>
@@ -611,7 +611,7 @@ body.proof-page {
           <h3>Splunk Ingest Proof</h3>
           <p class="m-copy">Pipeline proof artifact confirms Splunk ingest was operational for the locked reviewer snapshot. The export remains in the repository under the Splunk evidence path.</p>
           <ul class="m-list-tight" style="margin-top:10px;">
-            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/detection-rules/mappings/technique_map.csv" target="_blank" rel="noopener noreferrer">technique_map.csv &mdash; detection coverage map (GitHub)</a></li>
+            <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/detection-rules/mappings/technique_map.csv" target="_blank" rel="noopener noreferrer">technique_map.csv &mdash; detection coverage map (GitHub)</a></li>
           </ul>
           <p class="m-copy" style="margin-top:10px;font-size:0.85rem;color:var(--muted,#8ea4c7);">Splunk role: home lab only &mdash; verified per <code>current-authority.json</code> claim ceiling</p>
         </article>
@@ -660,9 +660,9 @@ body.proof-page {
           <div class="m-card-kicker" data-aos="fade-up">Proof links</div>
           <h3>Primary artifacts</h3>
           <ul class="m-list-tight">
-            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">VERIFIED_COUNTS.md &mdash; detection inventory source (GitHub)</a></li>
-            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/content/detection-rules/mappings/technique_map.csv" target="_blank" rel="noopener noreferrer">technique_map.csv &mdash; MITRE coverage map (GitHub)</a></li>
-            <li><a href="https://github.com/raylee-hawkins/HawkinsOperations/blob/main/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md" target="_blank" rel="noopener noreferrer">AutoSOC pipeline recovery snippets (GitHub)</a></li>
+            <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/PROOF_PACK/VERIFIED_COUNTS.md" target="_blank" rel="noopener noreferrer">VERIFIED_COUNTS.md &mdash; detection inventory source (GitHub)</a></li>
+            <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/content/detection-rules/mappings/technique_map.csv" target="_blank" rel="noopener noreferrer">technique_map.csv &mdash; MITRE coverage map (GitHub)</a></li>
+            <li><a href="https://github.com/HawkinsOps/HawkinsOperations/blob/main/docs/execution/AUTOSOC_PIPELINE_RECOVERY_PUBLIC_SNIPPETS_03-13-2026.md" target="_blank" rel="noopener noreferrer">AutoSOC pipeline recovery snippets (GitHub)</a></li>
           </ul>
         </article>
 
@@ -701,7 +701,7 @@ body.proof-page {
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/resume.html
+++ b/site/resume.html
@@ -36,7 +36,7 @@
     "addressCountry": "US"
   },
   "sameAs": [
-    "https://github.com/raylee-hawkins/HawkinsOperations",
+    "https://github.com/HawkinsOps/HawkinsOperations",
     "https://linkedin.com/in/raylee-hawkins"
   ],
   "worksFor": [
@@ -140,7 +140,7 @@
         <a href="mailto:Raylee@hawkinsops.com">Raylee@hawkinsops.com</a>
         <!-- Phone: print/PDF only — never shown on screen -->
         <span class="print-only" style="font-family:var(--mono);font-size:10px;">📞 (256) 328-3711</span>
-        <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener">GitHub</a>
         <a href="https://hawkinsops.com">hawkinsops.com</a>
         <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener">LinkedIn</a>
       </div>
@@ -486,7 +486,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/signalfoundry.html
+++ b/site/signalfoundry.html
@@ -176,7 +176,7 @@
     <div class="cs-ctas">
       <a href="/proof" class="cs-cta primary">View Proof &amp; Evidence</a>
       <a href="/case-studies" class="cs-cta">Case Studies</a>
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="cs-cta">Inspect Repository</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="cs-cta">Inspect Repository</a>
     </div>
   </div>
 
@@ -351,7 +351,7 @@
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>

--- a/site/wildcard.html
+++ b/site/wildcard.html
@@ -346,7 +346,7 @@ document.addEventListener('DOMContentLoaded', () => {
   <div class="ctr">
     <p><b>HawkinsOps</b> | Huntsville-adjacent (North Alabama)</p>
     <div class="fl">
-      <a href="https://github.com/raylee-hawkins/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
+      <a href="https://github.com/HawkinsOps/HawkinsOperations" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository (opens in a new tab)">GitHub</a>
       <a href="https://linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile (opens in a new tab)">LinkedIn</a>
       <a href="mailto:raylee@hawkinsops.com" aria-label="Email Raylee Hawkins">raylee@hawkinsops.com</a>
     </div>


### PR DESCRIPTION
## Summary
- Updated all 48 files that still referenced `raylee-hawkins/HawkinsOperations` to `HawkinsOps/HawkinsOperations`
- Covers site HTML, JSON data files, content, docs, scripts, PROOF_PACK, issue templates

## Test plan
- [ ] Site GitHub links point to `github.com/HawkinsOps/HawkinsOperations`
- [ ] Detection/project JSON data URLs resolve correctly
- [ ] No remaining references to `raylee-hawkins/HawkinsOperations` in tracked files