### PR TITLE
Add detection content validation and fix Wazuh rule integrity issues

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,6 +31,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install detection validation deps
+        shell: bash
+        run: python3 -m pip install --quiet pyyaml==6.0.2
+
+      - name: Validate detection rule content
+        shell: bash
+        run: python3 ./scripts/verify/validate_detection_content.py
+
       - name: Generate site data artifacts
         shell: pwsh
         run: |

--- a/content/detection-rules/mappings/attack-navigator-layer.json
+++ b/content/detection-rules/mappings/attack-navigator-layer.json
@@ -213,7 +213,7 @@
     {
       "techniqueID": "T1053.005",
       "color": "#006d2c",
-      "comment": "Sigma: scheduled_task_execution + scheduled_task_creation, Wazuh: 100068 + 100068001 (XML import chain), Splunk: Scheduled Task Creation",
+      "comment": "Sigma: scheduled_task_execution + scheduled_task_creation, Wazuh: 100068 + 100168 (XML import chain), Splunk: Scheduled Task Creation",
       "enabled": true,
       "score": 3
     },
@@ -563,7 +563,7 @@
     {
       "techniqueID": "T1543.003",
       "color": "#006d2c",
-      "comment": "Sigma: new_service_creation, Wazuh: 100059 + 100059001 (service + suspicious path chain), Splunk: New Service Creation",
+      "comment": "Sigma: new_service_creation, Wazuh: 100059 + 100159 (service + suspicious path chain), Splunk: New Service Creation",
       "enabled": true,
       "score": 3
     },
@@ -591,7 +591,7 @@
     {
       "techniqueID": "T1547.001",
       "color": "#006d2c",
-      "comment": "Sigma: registry_run_keys + startup_folder_modification, Wazuh: 100070 + 100070001 (autorun + suspicious path chain), Splunk: Registry Run Key + Startup Folder",
+      "comment": "Sigma: registry_run_keys + startup_folder_modification, Wazuh: 100070 + 100170 (autorun + suspicious path chain), Splunk: Registry Run Key + Startup Folder",
       "enabled": true,
       "score": 3
     },
@@ -710,7 +710,7 @@
     {
       "techniqueID": "T1570",
       "color": "#006d2c",
-      "comment": "Sigma: remote_file_copy (EID 5145 executable files), Wazuh: 100069 + 100069001 (PsExec - NOTE: STRETCHED mapping but kept for completeness), Splunk: Remote File Copy via SMB",
+      "comment": "Sigma: remote_file_copy (EID 5145 executable files), Wazuh: 100069 + 100169 (PsExec - NOTE: STRETCHED mapping but kept for completeness), Splunk: Remote File Copy via SMB",
       "enabled": true,
       "score": 3
     },

--- a/content/detection-rules/wazuh/rules/wazuh-054-web-attack-sql-injection.xml
+++ b/content/detection-rules/wazuh/rules/wazuh-054-web-attack-sql-injection.xml
@@ -10,7 +10,7 @@
 <group name="web,attack,">
   <rule id="100054" level="11">
     <if_sid>31100</if_sid>
-    <match>union.*select|' or '1'='1|'; DROP TABLE|exec\(|<script>|javascript:</match>
+    <match><![CDATA[union.*select|' or '1'='1|'; DROP TABLE|exec\(|<script>|javascript:]]></match>
     <description>Possible SQL injection or XSS attack detected</description>
     <mitre>
       <id>T1190</id>
@@ -48,8 +48,8 @@ Log Sources:
 
 Test Examples:
   - /search.php?q=' OR '1'='1
-  - /admin.php?id=1' UNION SELECT * FROM users--
-  - /page.asp?id=1; DROP TABLE users;--
+  - /admin.php?id=1' UNION SELECT * FROM users- -
+  - /page.asp?id=1; DROP TABLE users;- -
   - /?q=<script>alert('XSS')</script>
 
 Tuning Notes:

--- a/content/detection-rules/wazuh/rules/wazuh-059-new-service-creation.xml
+++ b/content/detection-rules/wazuh/rules/wazuh-059-new-service-creation.xml
@@ -18,7 +18,7 @@
     <group>service_creation,persistence,</group>
   </rule>
 
-  <rule id="100059001" level="10">
+  <rule id="100159" level="10">
     <if_sid>100059</if_sid>
     <field name="win.eventdata.imagePath">\\Temp\\|\\AppData\\|\\Users\\Public\\|cmd.exe|powershell.exe</field>
     <description>Suspicious Windows service created - Unusual executable path</description>

--- a/content/detection-rules/wazuh/rules/wazuh-068-suspicious-scheduled-task-xml.xml
+++ b/content/detection-rules/wazuh/rules/wazuh-068-suspicious-scheduled-task-xml.xml
@@ -18,7 +18,7 @@
     <group>scheduled_task,persistence,</group>
   </rule>
 
-  <rule id="100068001" level="11">
+  <rule id="100168" level="11">
     <if_sid>100068</if_sid>
     <field name="win.eventdata.commandLine">\\Temp\\|\\AppData\\|\\Public\\</field>
     <description>Suspicious scheduled task created via XML from unusual location</description>

--- a/content/detection-rules/wazuh/rules/wazuh-069-lateral-movement-psexec.xml
+++ b/content/detection-rules/wazuh/rules/wazuh-069-lateral-movement-psexec.xml
@@ -19,7 +19,7 @@
     <group>psexec,lateral_movement,</group>
   </rule>
 
-  <rule id="100069001" level="12" frequency="3" timeframe="600">
+  <rule id="100169" level="12" frequency="3" timeframe="600">
     <if_matched_sid>100069</if_matched_sid>
     <description>Multiple PsExec service installations across hosts - Active lateral movement</description>
     <mitre>

--- a/content/detection-rules/wazuh/rules/wazuh-070-registry-autorun-modification.xml
+++ b/content/detection-rules/wazuh/rules/wazuh-070-registry-autorun-modification.xml
@@ -19,7 +19,7 @@
     <group>registry_persistence,autorun,</group>
   </rule>
 
-  <rule id="100070001" level="11">
+  <rule id="100170" level="11">
     <if_sid>100070</if_sid>
     <field name="win.eventdata.details">\\Temp\\|\\AppData\\|\\Users\\Public\\|cmd.exe|powershell.exe</field>
     <description>Suspicious registry autorun key - Points to unusual location or script</description>

--- a/content/detection-rules/wazuh/rules/wazuh-074-container-escape-attempt.xml
+++ b/content/detection-rules/wazuh/rules/wazuh-074-container-escape-attempt.xml
@@ -47,9 +47,9 @@ Log Sources:
   - System call monitoring
 
 Test Examples:
-  - docker run --privileged -it ubuntu /bin/bash
+  - docker run - -privileged -it ubuntu /bin/bash
   - docker run -v /var/run/docker.sock:/var/run/docker.sock
-  - nsenter --target 1 --mount --uts --ipc --net /bin/bash
+  - nsenter - -target 1 - -mount - -uts - -ipc - -net /bin/bash
   - Mounting host filesystem in container
 
 Tuning Notes:

--- a/docs/IMPLEMENTATION_PROOF.md
+++ b/docs/IMPLEMENTATION_PROOF.md
@@ -181,7 +181,7 @@ Mar  4 15:23:45 docker-host bash[12345]: docker run --privileged -v /:/mnt alpin
 | 100062 (Ransomware) | Frequency-based: 50+ events in 120s | Batch rename files with encrypted extensions |
 | 100064 (Impossible Travel) | Requires geoip.distance field | Mock geoIP enrichment in test log |
 | 100067 (DNS Tunneling) | Frequency-based: 30+ events in 300s | Generate long DNS queries via nslookup/dig |
-| 100069001 (Mass PsExec) | Frequency-based: 3+ events in 600s | Install PSEXESVC on multiple hosts |
+| 100169 (Mass PsExec) | Frequency-based: 3+ events in 600s | Install PSEXESVC on multiple hosts |
 | 100072 (Kerberoasting) | Frequency-based: 10+ events in 60s | Rubeus kerberoast against multiple SPNs |
 | 100073 (Share Access) | Frequency-based: 5+ events in 300s | Access admin shares on multiple hosts |
 
@@ -206,7 +206,7 @@ Mar  4 15:23:45 docker-host bash[12345]: docker run --privileged -v /:/mnt alpin
 | 100065 | SID 80200 | AWS CloudTrail event | Built-in (AWS rules) |
 | 100067 | SID 5200 | DNS query event | Built-in (DNS rules) |
 
-**Assessment:** All parent SID dependencies reference standard Wazuh built-in rules. No custom decoder dependencies beyond what ships with Wazuh. Rule chain dependencies (100059→100059001, 100068→100068001, 100069→100069001, 100070→100070001) are self-contained within the custom rule set.
+**Assessment:** All parent SID dependencies reference standard Wazuh built-in rules. No custom decoder dependencies beyond what ships with Wazuh. Rule chain dependencies (100059→100159, 100068→100168, 100069→100169, 100070→100170) are self-contained within the custom rule set.
 
 **Deployment requirement:** The full custom rule set (all 24 XML files) must be deployed together. Partial deployment is safe — chained rules will silently not fire if their parent isn't present, but no errors will occur.
 

--- a/docs/analysis/COVERAGE_ANALYSIS.md
+++ b/docs/analysis/COVERAGE_ANALYSIS.md
@@ -194,7 +194,7 @@ If asked "walk me through a detection," lead with these — they show the most s
 
 3. **LSASS Memory Dump via Comsvcs.dll** (Sigma + Wazuh + Splunk) — Detects a specific credential dumping technique using a living-off-the-land binary. Shows knowledge of alternative dumping methods beyond just Mimikatz.
 
-4. **Registry Autorun Persistence with Suspicious Path Chaining** (Wazuh 100070 + 100070001) — Demonstrates rule chaining: base rule detects any autorun modification, child rule elevates severity when the target is a suspicious path. This is how Wazuh rules should be written.
+4. **Registry Autorun Persistence with Suspicious Path Chaining** (Wazuh 100070 + 100170) — Demonstrates rule chaining: base rule detects any autorun modification, child rule elevates severity when the target is a suspicious path. This is how Wazuh rules should be written.
 
 5. **Impossible Travel Detection** (Wazuh 100064) — Shows awareness of identity-based detection beyond simple log monitoring. Requires geoIP enrichment — demonstrates understanding of data pipeline requirements for advanced detections.
 

--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -8,6 +8,11 @@
 - `autosoc-publish-contract-scan.ps1` blocks commits that stage runtime AutoSOC output, incident firehose paths, too many files, or oversized files.
 - `repo-state-grade.ps1` prints a simple 0-100 repo hygiene score from current working tree state (modified/untracked/deleted counts).
 - `install-precommit-public-safety.ps1` installs an optional local pre-commit hook that runs both `public-safety-scan.ps1` and `autosoc-publish-contract-scan.ps1`.
+- `validate_detection_content.py` enforces structural correctness of Sigma and Wazuh rule content (complements `verify-counts.ps1`, which only counts files). Wired into `.github/workflows/verify.yml` and required for merge.
+  - Sigma: parses each `.yml`/`.yaml` with PyYAML; requires `title`, `id`, `logsource`, `detection.condition`; validates `id` is UUID-shaped; checks `logsource` has at least one of `product`/`service`/`category`; checks `level` is a valid Sigma severity; enforces cross-tree UUID uniqueness.
+  - Wazuh: **strict**. Parses each `.xml` with stdlib `xml.etree.ElementTree`; requires `<group>` root, at least one `<rule id="...">`, integer IDs inside `[100000, 199999]`, non-empty `<description>`, and cross-tree rule-ID uniqueness. No allowlist — all Wazuh rules must pass.
+  - Sigma duplicate-ID quarantine: `validation_exceptions.yml` lists 33 placeholder-UUID collisions (69 files) discovered on first validator run. Listed collisions are downgraded to warnings **only** when the live collision set matches the allowlist exactly; any drift (new file reusing a listed ID, or a listed file renamed) fails hard. Remediation is tracked in `Z:\AgentOps\plans\sigma_id_remediation_2026-04.md`. New Sigma rules must use fresh UUIDv4s (`python -c "import uuid; print(uuid.uuid4())"`) and cannot be added to the allowlist.
+- `validation_exceptions.yml` is the quarantine file for `validate_detection_content.py`. Do not add new entries to unblock new bugs — it exists only to carry pre-existing Sigma placeholder-ID collisions while remediation proceeds.
 
 Count rules:
 
@@ -25,5 +30,7 @@ pwsh -NoProfile -File ".\scripts\verify\autosoc-publish-contract-scan.ps1"
 pwsh -NoProfile -File ".\scripts\verify\repo-state-grade.ps1" -WarnBelow 80
 pwsh -NoProfile -File ".\scripts\verify\install-precommit-public-safety.ps1"
 node .\scripts\generate-media-manifest.js
+python3 -m pip install --quiet pyyaml==6.0.2
+python3 .\scripts\verify\validate_detection_content.py
 ```
 

--- a/scripts/verify/validate_detection_content.py
+++ b/scripts/verify/validate_detection_content.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Validate detection rule content (Sigma + Wazuh).
+
+Fails if any rule file is structurally broken. Complements verify-counts.ps1,
+which only counts files — this script checks that each file is actually a
+well-formed rule the relevant engine would accept.
+
+Sigma (PyYAML):
+  - parses as YAML
+  - top-level is a mapping
+  - required keys: title, id, logsource, detection
+  - id is a UUID
+  - detection is a mapping containing a 'condition' key
+  - logsource is a mapping with at least one of product/service/category
+  - level (if present) is in the standard sigma severity set
+  - rule ids are unique across the tree
+
+Wazuh (stdlib xml.etree.ElementTree):
+  - file parses as XML
+  - root element is <group>
+  - contains at least one <rule id="...">
+  - every rule/@id is an integer in [100000, 199999]
+  - every rule has a non-empty <description>
+  - rule ids are unique across the tree
+
+Splunk is intentionally out of scope for this validator — see
+scripts/verify/README.md for the justification.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import List
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIGMA_DIR = REPO_ROOT / "content" / "detection-rules" / "sigma"
+WAZUH_RULES_DIR = REPO_ROOT / "content" / "detection-rules" / "wazuh" / "rules"
+EXCEPTIONS_PATH = REPO_ROOT / "scripts" / "verify" / "validation_exceptions.yml"
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+SIGMA_LEVELS = {"informational", "low", "medium", "high", "critical"}
+WAZUH_ID_MIN = 100000
+WAZUH_ID_MAX = 199999
+
+
+def load_sigma_duplicate_allowlist() -> dict[str, frozenset[str]]:
+    """Return {uuid: frozenset(repo-relative forward-slash paths)} from the
+    exceptions file. Missing file returns an empty dict — strict mode."""
+    if not EXCEPTIONS_PATH.exists():
+        return {}
+    raw = yaml.safe_load(EXCEPTIONS_PATH.read_text(encoding="utf-8")) or {}
+    entries = raw.get("sigma_duplicate_ids") or []
+    out: dict[str, frozenset[str]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        uid = entry.get("id")
+        files = entry.get("files") or []
+        if isinstance(uid, str) and isinstance(files, list):
+            out[uid] = frozenset(str(f).replace("\\", "/") for f in files)
+    return out
+
+
+def validate_sigma(
+    sigma_root: Path,
+    dup_allowlist: dict[str, frozenset[str]],
+) -> tuple[List[str], List[str]]:
+    errors: List[str] = []
+    warnings: List[str] = []
+    if not sigma_root.is_dir():
+        return [f"sigma: directory not found: {sigma_root}"], []
+
+    files = sorted(
+        list(sigma_root.rglob("*.yml")) + list(sigma_root.rglob("*.yaml"))
+    )
+    if not files:
+        return [f"sigma: no rule files under {sigma_root}"], []
+
+    id_to_paths: dict[str, List[Path]] = {}
+
+    for path in files:
+        rel = path.relative_to(REPO_ROOT)
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            errors.append(f"sigma {rel}: YAML parse error: {exc}")
+            continue
+
+        if not isinstance(doc, dict):
+            errors.append(f"sigma {rel}: top-level must be a mapping")
+            continue
+
+        for key in ("title", "id", "logsource", "detection"):
+            if key not in doc:
+                errors.append(f"sigma {rel}: missing required key '{key}'")
+
+        rid = doc.get("id")
+        if isinstance(rid, str):
+            if not UUID_RE.match(rid):
+                errors.append(f"sigma {rel}: id '{rid}' is not a UUID")
+            else:
+                id_to_paths.setdefault(rid, []).append(path)
+        elif rid is not None:
+            errors.append(f"sigma {rel}: id must be a string UUID")
+
+        logsource = doc.get("logsource")
+        if logsource is not None:
+            if not isinstance(logsource, dict):
+                errors.append(f"sigma {rel}: logsource must be a mapping")
+            elif not any(
+                k in logsource for k in ("product", "service", "category")
+            ):
+                errors.append(
+                    f"sigma {rel}: logsource must define at least one of "
+                    f"product/service/category"
+                )
+
+        detection = doc.get("detection")
+        if detection is not None:
+            if not isinstance(detection, dict):
+                errors.append(f"sigma {rel}: detection must be a mapping")
+            elif "condition" not in detection:
+                errors.append(f"sigma {rel}: detection is missing 'condition'")
+
+        level = doc.get("level")
+        if level is not None and level not in SIGMA_LEVELS:
+            errors.append(
+                f"sigma {rel}: level '{level}' is not one of "
+                f"{sorted(SIGMA_LEVELS)}"
+            )
+
+    # Resolve duplicate-id collisions against the allowlist.
+    for rid, paths in sorted(id_to_paths.items()):
+        if len(paths) < 2:
+            continue
+        rels_posix = sorted(
+            str(p.relative_to(REPO_ROOT)).replace("\\", "/") for p in paths
+        )
+        allowed_set = dup_allowlist.get(rid)
+        involved_set = frozenset(rels_posix)
+        if allowed_set is not None and involved_set == allowed_set:
+            warnings.append(
+                f"sigma: duplicate id '{rid}' is in the known-exceptions "
+                f"allowlist ({len(rels_posix)} files): "
+                f"{', '.join(rels_posix)}"
+            )
+        else:
+            if allowed_set is not None:
+                extra = sorted(involved_set - allowed_set)
+                missing = sorted(allowed_set - involved_set)
+                detail = []
+                if extra:
+                    detail.append(f"unlisted files: {', '.join(extra)}")
+                if missing:
+                    detail.append(f"listed but not seen: {', '.join(missing)}")
+                errors.append(
+                    f"sigma: duplicate id '{rid}' collision set does not "
+                    f"match allowlist — {'; '.join(detail)}"
+                )
+            else:
+                errors.append(
+                    f"sigma: duplicate id '{rid}' across {len(rels_posix)} "
+                    f"files: {', '.join(rels_posix)}"
+                )
+
+    return errors, warnings
+
+
+def validate_wazuh(wazuh_root: Path) -> tuple[List[str], List[str]]:
+    errors: List[str] = []
+    warnings: List[str] = []
+    if not wazuh_root.is_dir():
+        return [f"wazuh: directory not found: {wazuh_root}"], []
+
+    files = sorted(wazuh_root.glob("*.xml"))
+    if not files:
+        return [f"wazuh: no rule files under {wazuh_root}"], []
+
+    ids_seen: dict[str, Path] = {}
+
+    for path in files:
+        rel = path.relative_to(REPO_ROOT)
+        try:
+            root = ET.fromstring(path.read_text(encoding="utf-8"))
+        except ET.ParseError as exc:
+            errors.append(f"wazuh {rel}: XML parse error: {exc}")
+            continue
+
+        if root.tag != "group":
+            errors.append(
+                f"wazuh {rel}: root tag is <{root.tag}>, expected <group>"
+            )
+            continue
+
+        rules = root.findall(".//rule[@id]")
+        if not rules:
+            errors.append(f"wazuh {rel}: no <rule id=\"...\"> elements found")
+            continue
+
+        for rule in rules:
+            rid = rule.get("id", "")
+            try:
+                rid_int = int(rid)
+            except ValueError:
+                errors.append(
+                    f"wazuh {rel}: rule id '{rid}' is not an integer"
+                )
+                continue
+
+            if not (WAZUH_ID_MIN <= rid_int <= WAZUH_ID_MAX):
+                errors.append(
+                    f"wazuh {rel}: rule id {rid_int} outside allowed local "
+                    f"range [{WAZUH_ID_MIN}, {WAZUH_ID_MAX}]"
+                )
+
+            if rid in ids_seen:
+                errors.append(
+                    f"wazuh {rel}: duplicate rule id {rid} "
+                    f"(also in {ids_seen[rid].relative_to(REPO_ROOT)})"
+                )
+            else:
+                ids_seen[rid] = path
+
+            desc = rule.find("description")
+            if desc is None or not (desc.text or "").strip():
+                errors.append(
+                    f"wazuh {rel}: rule id {rid} missing or empty "
+                    f"<description>"
+                )
+
+    return errors, warnings
+
+
+def main() -> int:
+    dup_allowlist = load_sigma_duplicate_allowlist()
+
+    sigma_errors, sigma_warnings = validate_sigma(SIGMA_DIR, dup_allowlist)
+    wazuh_errors, wazuh_warnings = validate_wazuh(WAZUH_RULES_DIR)
+
+    errors = sigma_errors + wazuh_errors
+    warnings = sigma_warnings + wazuh_warnings
+
+    if warnings:
+        print(f"detection content validation warnings ({len(warnings)}):")
+        for w in warnings:
+            print(f"- {w}")
+        print()
+
+    if errors:
+        print(
+            f"detection content validation FAILED ({len(errors)} errors):",
+            file=sys.stderr,
+        )
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("detection content validation passed")
+    print(f"  sigma dir            : {SIGMA_DIR.relative_to(REPO_ROOT)}")
+    print(f"  wazuh dir            : {WAZUH_RULES_DIR.relative_to(REPO_ROOT)}")
+    print(f"  allowlisted dup ids  : {len(dup_allowlist)}")
+    print(f"  warnings emitted     : {len(warnings)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/validation_exceptions.yml
+++ b/scripts/verify/validation_exceptions.yml
@@ -1,0 +1,195 @@
+# Detection content validator — known exceptions
+#
+# This file quarantines detection-rule validation failures that are
+# recognized debt, not regressions. Items listed here are downgraded
+# from ERROR to WARNING by scripts/verify/validate_detection_content.py
+# so CI can enforce everything else while remediation proceeds.
+#
+# Do NOT add new entries to unblock new bugs. New duplicates must be
+# fixed at the source. This file only exists to carry pre-existing
+# placeholder-ID collisions discovered on first validator run.
+#
+# Remediation plan: plans/sigma_id_remediation_2026-04.md
+#
+# Schema:
+#   sigma_duplicate_ids:
+#     - id: <uuid string that collides>
+#       files:
+#         - <repo-relative path using forward slashes>
+#         - ...
+#       reason: <short free-text, why it is allowed>
+#
+# Matching rule: a Sigma duplicate-id error is downgraded to warning ONLY
+# when the offending UUID appears here AND every file involved in the
+# collision is listed under that UUID's files: block. If a new file
+# starts using an allowlisted UUID, validation fails hard as intended.
+
+sigma_duplicate_ids:
+- id: 0b1c2d3e-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+  files:
+  - content/detection-rules/sigma/execution/linux_bash_suspicious.yml
+  - content/detection-rules/sigma/privilege-escalation/kernel_module_load.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a
+  files:
+  - content/detection-rules/sigma/lateral-movement/dcom_lateral_movement.yml
+  - content/detection-rules/sigma/persistence/linux_bashrc_modification.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 0f1a2b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+  files:
+  - content/detection-rules/sigma/defense-evasion/dll_sideloading.yml
+  - content/detection-rules/sigma/discovery/network_share_discovery.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+  files:
+  - content/detection-rules/sigma/credential-access/powershell_credential_prompt.yml
+  - content/detection-rules/sigma/defense-evasion/amsi_bypass.yml
+  - content/detection-rules/sigma/discovery/linux_network_discovery.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+  files:
+  - content/detection-rules/sigma/execution/macro_execution.yml
+  - content/detection-rules/sigma/privilege-escalation/printspooler_privilege_escalation.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b
+  files:
+  - content/detection-rules/sigma/lateral-movement/ssh_lateral_movement.yml
+  - content/detection-rules/sigma/persistence/bits_job_persistence.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
+  files:
+  - content/detection-rules/sigma/credential-access/credential_access_ssh_keys.yml
+  - content/detection-rules/sigma/defense-evasion/disable_firewall.yml
+  - content/detection-rules/sigma/discovery/ad_enumeration.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 2d3e4f5a-6b7c-8d9e-0f1a-2b3c4d5e6f7a
+  files:
+  - content/detection-rules/sigma/execution/scheduled_task_execution.yml
+  - content/detection-rules/sigma/privilege-escalation/runas_execution.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 2f3a4b5c-6d7e-8f9a-0b1c-2d3e4f5a6b7c
+  files:
+  - content/detection-rules/sigma/lateral-movement/winrm_lateral_movement.yml
+  - content/detection-rules/sigma/persistence/office_addins.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
+  files:
+  - content/detection-rules/sigma/lateral-movement/remote_file_copy.yml
+  - content/detection-rules/sigma/persistence/screensaver_persistence.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+  files:
+  - content/detection-rules/sigma/defense-evasion/rootkit_behavior.yml
+  - content/detection-rules/sigma/discovery/cloud_service_enumeration.yml
+  - content/detection-rules/sigma/persistence/scheduled_task_creation.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 3e4f5a6b-7c8d-9e0f-1a2b-3c4d5e6f7a8b
+  files:
+  - content/detection-rules/sigma/execution/at_command.yml
+  - content/detection-rules/sigma/privilege-escalation/eventvwr_uac_bypass.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
+  files:
+  - content/detection-rules/sigma/execution/powershell_suspicious_commands.yml
+  - content/detection-rules/sigma/privilege-escalation/uac_bypass_fodhelper.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
+  files:
+  - content/detection-rules/sigma/lateral-movement/psexec_execution.yml
+  - content/detection-rules/sigma/persistence/registry_run_keys.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 4e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b
+  files:
+  - content/detection-rules/sigma/collection/clipboard_capture.yml
+  - content/detection-rules/sigma/impact/linux_data_destruction.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 4f5a6b7c-8d9e-0f1a-2b3c-4d5e6f7a8b9c
+  files:
+  - content/detection-rules/sigma/defense-evasion/clear_windows_event_logs.yml
+  - content/detection-rules/sigma/discovery/network_reconnaissance.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 5a6b7c8d-9e0f-1a2b-3c4d-5e6f7a8b9c0d
+  files:
+  - content/detection-rules/sigma/defense-evasion/disable_windows_defender.yml
+  - content/detection-rules/sigma/discovery/whoami_execution.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
+  files:
+  - content/detection-rules/sigma/lateral-movement/remote_desktop_logon.yml
+  - content/detection-rules/sigma/persistence/wmi_event_subscription.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 5f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c
+  files:
+  - content/detection-rules/sigma/collection/screen_capture.yml
+  - content/detection-rules/sigma/impact/firmware_corruption.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
+  files:
+  - content/detection-rules/sigma/collection/audio_capture.yml
+  - content/detection-rules/sigma/impact/database_destruction.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 6b7c8d9e-0f1a-2b3c-4d5e-6f7a8b9c0d1e
+  files:
+  - content/detection-rules/sigma/defense-evasion/timestomping.yml
+  - content/detection-rules/sigma/discovery/process_enumeration.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 6d7e8f9a-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+  files:
+  - content/detection-rules/sigma/execution/wscript_cscript_suspicious.yml
+  - content/detection-rules/sigma/privilege-escalation/sudo_abuse.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
+  files:
+  - content/detection-rules/sigma/lateral-movement/wmi_lateral_movement.yml
+  - content/detection-rules/sigma/persistence/new_service_creation.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
+  files:
+  - content/detection-rules/sigma/lateral-movement/windows_admin_shares.yml
+  - content/detection-rules/sigma/persistence/startup_folder_modification.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
+  files:
+  - content/detection-rules/sigma/defense-evasion/indicator_removal_linux.yml
+  - content/detection-rules/sigma/discovery/system_information_discovery.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 7e8f9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+  files:
+  - content/detection-rules/sigma/execution/mshta_suspicious_execution.yml
+  - content/detection-rules/sigma/privilege-escalation/suid_binary_execution.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
+  files:
+  - content/detection-rules/sigma/lateral-movement/remote_service_creation.yml
+  - content/detection-rules/sigma/persistence/linux_cron_persistence.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 8d9e0f1a-2b3c-4d5e-6f7a-8b9c0d1e2f3a
+  files:
+  - content/detection-rules/sigma/defense-evasion/process_injection.yml
+  - content/detection-rules/sigma/discovery/domain_trust_discovery.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 8f9a0b1c-2d3e-4f5a-6b7c-8d9e0f1a2b3c
+  files:
+  - content/detection-rules/sigma/execution/cmd_suspicious_commands.yml
+  - content/detection-rules/sigma/privilege-escalation/named_pipe_impersonation.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+  files:
+  - content/detection-rules/sigma/execution/regsvr32_suspicious.yml
+  - content/detection-rules/sigma/privilege-escalation/always_install_elevated.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f
+  files:
+  - content/detection-rules/sigma/lateral-movement/pass_the_hash.yml
+  - content/detection-rules/sigma/persistence/linux_systemd_service.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b
+  files:
+  - content/detection-rules/sigma/defense-evasion/masquerading.yml
+  - content/detection-rules/sigma/discovery/file_directory_discovery.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md
+- id: 9f0a1b2c-3d4e-5f6a-7b8c-9d0e1f2a3b4c
+  files:
+  - content/detection-rules/sigma/credential-access/browser_credential_theft.yml
+  - content/detection-rules/sigma/impact/disk_wipe.yml
+  reason: placeholder-pattern UUID from batch-authored sigma library; tracked in plans/sigma_id_remediation_2026-04.md


### PR DESCRIPTION
## Summary

Adds real Sigma + Wazuh detection-rule content validation to the verify gate, fixes pre-existing XML and rule-ID bugs that were hiding behind the regex-only file counter, and quarantines a cohort of placeholder-UUID Sigma duplicates with a tracked remediation plan.

## What changes

### Validator (new)
- `scripts/verify/validate_detection_content.py` — PyYAML for Sigma, stdlib `xml.etree` for Wazuh.
  - **Sigma:** parse, required keys (`title`, `id`, `logsource`, `detection.condition`), UUID-shaped `id`, valid `logsource`, valid `level`, cross-tree UUID uniqueness.
  - **Wazuh: strict.** Parse, root `<group>`, `<rule id>` integer in `[100000, 199999]`, non-empty `<description>`, cross-tree rule-ID uniqueness. No allowlist.
- `scripts/verify/validation_exceptions.yml` — quarantine file. 33 entries covering 69 Sigma files with placeholder-pattern UUIDs (e.g. `1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d`) discovered on first validator run. Generated programmatically from the live tree.
  - Allowlist semantics: a duplicate-id error is downgraded to **warning** only when the UUID is listed AND the live collision set matches the allowlist file list **exactly**. Any drift (new file reusing a listed ID, or a listed file renamed) fails hard.

### Wired into verify.yml
Two new steps inserted between `Setup Python` and `Generate site data artifacts`:
- `Install detection validation deps` — `python3 -m pip install --quiet pyyaml==6.0.2`
- `Validate detection rule content` — runs the new script

A broken rule will now redline the gate **before** downstream site-data generation runs.

### Wazuh content fixes (caught by the new validator)
Two files were already invalid XML and were silently passing the regex counter:
- `wazuh-054-web-attack-sql-injection.xml`: literal `<script>` inside `<match>` was unescaped markup. Wrapped in `<![CDATA[ ... ]]>`. Also fixed two `--` sequences inside the documentation comment block (XML spec forbids `--` inside comments).
- `wazuh-074-container-escape-attempt.xml`: six `--` CLI flag sequences inside the documentation comment block. Replaced with `- -`. The `<match>` element on line 13 already uses `--` in element text (legal, untouched).

Four sub-rules had 9-digit IDs outside Wazuh's documented local range `[100000, 120000]` and would almost certainly be rejected by the manager on reload:
- `wazuh-059`: `100059001` → `100159`
- `wazuh-068`: `100068001` → `100168`
- `wazuh-069`: `100069001` → `100169`
- `wazuh-070`: `100070001` → `100170`

Cross-references in `attack-navigator-layer.json`, `COVERAGE_ANALYSIS.md`, and `IMPLEMENTATION_PROOF.md` were updated in the same commit so nothing points at the old IDs. Rule logic, parent `<if_sid>` chains, levels, and MITRE mappings are unchanged.

### Documentation
- `scripts/verify/README.md` — paragraph documenting the validator (what it enforces, Sigma schema checks, Wazuh strict mode, allowlist semantics) plus updated run-from-root command block.

## Local validation results

```
$ python3 scripts/verify/validate_detection_content.py
exit code        : 0
errors           : 0
warnings         : 33 (all sigma duplicate ids, all matched against allowlist)

$ pwsh scripts/verify/verify-counts.ps1
Sigma (.yml/.yaml files): 103
Splunk (.spl files):      9
Splunk (searches):        79
Wazuh XML files:          24
Wazuh <rule id=> blocks:  28   (PS regex agrees with the XML parser)
IR Playbooks (IR-*.md):   10
```

## What this PR does NOT do
- Does not remediate the 33 placeholder-UUID Sigma collisions. Those are quarantined and tracked separately.
- Does not redeploy Wazuh. The manager at HO-SR-WM-01 still has the old 9-digit IDs loaded; `deploy-wazuh-pack.yml` will pick up the renumber automatically on `workflow_run` success after merge.
- Does not touch `verify-counts.ps1` (the regex counter), `drift-scan.yml`, or any other workflow.

## Test plan
- [ ] verify.yml passes on the self-hosted runner — **the first real test of `pip install pyyaml==6.0.2` on the actual runner**. If this step fails, fallback is to vendor the wheel under `tools/python3/` and switch the install step to `pip install --no-index`.
- [ ] Validator step output shows `exit 0`, 0 errors, 33 warnings.
- [ ] No regression in downstream verify steps (site data, hosting contract, runtime contract, site diagnosis, Wazuh bundle build).
- [ ] Do not merge until the runner is green.
- [ ] Post-merge: confirm `deploy-wazuh-pack.yml` succeeds and the Wazuh manager loads the renumbered rules cleanly. Do not call this done until that's verified.

## Remediation tracker
The 33 quarantined Sigma placeholder UUIDs are remediation debt tracked in `Z:\AgentOps\plans\sigma_id_remediation_2026-04.md` (operator workspace, not in repo). Plan splits the cleanup into 4 PRs by tactic cohort over the next few days.