### PR TITLE
Feat: Sigma CI lane — validator, pipeline, tests, workflow

### DIFF
--- a/.github/workflows/sigma-ci.yml
+++ b/.github/workflows/sigma-ci.yml
@@ -1,0 +1,62 @@
+name: sigma-ci
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content/detection-rules/sigma/**"
+      - "content/detection-rules/ci/**"
+      - "content/detection-rules/tests/**"
+      - ".github/workflows/sigma-ci.yml"
+  pull_request:
+    paths:
+      - "content/detection-rules/sigma/**"
+      - "content/detection-rules/ci/**"
+      - "content/detection-rules/tests/**"
+      - ".github/workflows/sigma-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sigma:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: content/detection-rules
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: content/detection-rules/ci/requirements.txt
+
+      - name: Install sigma toolchain
+        run: pip install -r ci/requirements.txt
+
+      - name: Lint Sigma rules (schema + syntax)
+        run: sigma check sigma/
+
+      - name: Convert Sigma rules to Splunk SPL
+        run: |
+          mkdir -p build
+          sigma convert \
+            --target splunk \
+            --pipeline ci/splunk-pipeline.yml \
+            --output build/rules.spl \
+            sigma/
+          test -s build/rules.spl
+
+      - name: Run pytest (parse + convert + fixture match)
+        run: pytest tests/ -q
+
+      - name: Upload generated SPL
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sigma-splunk-output
+          path: content/detection-rules/build/rules.spl
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ __pycache__/
 # Runtime artifacts (never commit)
 tokens/
 scripts/runs/
+content/detection-rules/build/
 
 # Secrets and credentials
 .env

--- a/content/detection-rules/ci/README.md
+++ b/content/detection-rules/ci/README.md
@@ -1,0 +1,33 @@
+# Detection-rules CI
+
+CI lane for Sigma rules under `content/detection-rules/sigma/`.
+
+## What the gate enforces
+
+1. **Schema + syntax** — every rule in `sigma/` passes `sigma check`.
+2. **Convertibility** — every rule compiles to Splunk SPL via `sigma convert` with the pipeline in `ci/splunk-pipeline.yml`.
+3. **Behavioral tests** — `pytest` runs the suites in `../tests/`, including positive-fixture matching for selected rules.
+
+Workflow: `.github/workflows/sigma-ci.yml`.
+
+## Run locally
+
+```bash
+cd content/detection-rules
+python -m venv .venv && . .venv/bin/activate
+pip install -r ci/requirements.txt
+
+sigma check sigma/
+sigma convert -t splunk -p ci/splunk-pipeline.yml -o build/rules.spl sigma/
+pytest tests/ -q
+```
+
+## Pipeline scope
+
+`ci/splunk-pipeline.yml` maps Sigma logsources to HawkinsOps Splunk conventions:
+
+- `windows/security` → `index=wineventlog sourcetype=WinEventLog:Security`
+- `linux/auth` → `sourcetype=linux_secure`
+- `EventID` → `EventCode` (Splunk field name)
+
+Extend the pipeline when a new logsource appears in `sigma/`; do not hand-edit generated SPL.

--- a/content/detection-rules/ci/requirements.txt
+++ b/content/detection-rules/ci/requirements.txt
@@ -1,0 +1,5 @@
+pysigma>=0.11.18,<0.12
+pysigma-backend-splunk==1.1.*
+sigma-cli>=1.0,<2
+pyyaml>=6.0
+pytest>=8.0

--- a/content/detection-rules/ci/splunk-pipeline.yml
+++ b/content/detection-rules/ci/splunk-pipeline.yml
@@ -1,0 +1,38 @@
+name: HawkinsOps Splunk pipeline
+priority: 20
+
+transformations:
+  - id: windows_security_index
+    type: set_state
+    key: index
+    val: wineventlog
+    rule_conditions:
+      - type: logsource
+        product: windows
+        service: security
+
+  - id: windows_security_sourcetype
+    type: add_condition
+    conditions:
+      sourcetype: "WinEventLog:Security"
+    rule_conditions:
+      - type: logsource
+        product: windows
+        service: security
+
+  - id: linux_auth_sourcetype
+    type: add_condition
+    conditions:
+      sourcetype: "linux_secure"
+    rule_conditions:
+      - type: logsource
+        product: linux
+        service: auth
+
+  - id: field_event_id_to_eventcode
+    type: field_name_mapping
+    mapping:
+      EventID: EventCode
+    rule_conditions:
+      - type: logsource
+        product: windows

--- a/content/detection-rules/sigma/README.md
+++ b/content/detection-rules/sigma/README.md
@@ -1,6 +1,18 @@
-# Sigma Rules (planned)
+# Sigma Rules
 
-This folder is scaffolded for Sigma detections (YAML). Add rules here when ready.
+Sigma detections (YAML) organized by MITRE ATT&CK tactic:
+`credential-access/`, `execution/`, `persistence/`, `privilege-escalation/`,
+`defense-evasion/`, `discovery/`, `lateral-movement/`, `collection/`,
+`exfiltration/`, `impact/`.
 
-Verification:
-- Sigma rule count is computed by `docs/VERIFY_COMMANDS_POWERSHELL.md`.
+## CI gate
+
+Every change under this folder is validated by `.github/workflows/sigma-ci.yml`:
+
+1. `sigma check` — schema + syntax lint
+2. `sigma convert` — compiles all rules to Splunk SPL via `../ci/splunk-pipeline.yml`
+3. `pytest` — parse, convert, and positive-fixture tests in `../tests/`
+
+See `../ci/README.md` for local-run instructions.
+
+Rule count and verification are also computed by `docs/VERIFY_COMMANDS_POWERSHELL.md`.

--- a/content/detection-rules/tests/fixtures/kerberoasting_4769_rc4.json
+++ b/content/detection-rules/tests/fixtures/kerberoasting_4769_rc4.json
@@ -1,0 +1,12 @@
+{
+  "EventID": 4769,
+  "Channel": "Security",
+  "Computer": "DC01.corp.hawkinsops.local",
+  "TargetUserName": "alice@corp.hawkinsops.local",
+  "ServiceName": "svc_sql$",
+  "TicketEncryptionType": "0x17",
+  "TicketOptions": "0x40810000",
+  "IpAddress": "10.20.30.41",
+  "IpPort": "51822",
+  "Status": "0x0"
+}

--- a/content/detection-rules/tests/test_sigma_rules.py
+++ b/content/detection-rules/tests/test_sigma_rules.py
@@ -1,0 +1,100 @@
+"""Sigma rule validation tests.
+
+Runs three checks across every rule under ../sigma/:
+
+1. parse  — YAML loads and SigmaRule.from_dict accepts it
+2. convert — rule compiles to Splunk SPL via the HawkinsOps pipeline
+3. fixture — selected rules match a hand-authored positive event
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from sigma.collection import SigmaCollection
+from sigma.processing.resolver import ProcessingPipelineResolver
+from sigma.processing.pipeline import ProcessingPipeline
+from sigma.backends.splunk import SplunkBackend
+
+ROOT = Path(__file__).resolve().parents[1]
+SIGMA_DIR = ROOT / "sigma"
+PIPELINE_PATH = ROOT / "ci" / "splunk-pipeline.yml"
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+RULE_FILES = sorted(p for p in SIGMA_DIR.rglob("*.yml") if p.is_file())
+
+
+def _load_pipeline() -> ProcessingPipeline:
+    return ProcessingPipelineResolver({
+        "splunk": ProcessingPipeline.from_yaml(PIPELINE_PATH.read_text(encoding="utf-8"))
+    }).resolve(["splunk"])
+
+
+@pytest.fixture(scope="session")
+def backend() -> SplunkBackend:
+    return SplunkBackend(processing_pipeline=_load_pipeline())
+
+
+def test_rule_corpus_is_not_empty():
+    assert RULE_FILES, f"no Sigma rules found under {SIGMA_DIR}"
+
+
+@pytest.mark.parametrize("rule_path", RULE_FILES, ids=lambda p: p.relative_to(SIGMA_DIR).as_posix())
+def test_rule_parses(rule_path: Path):
+    data = yaml.safe_load(rule_path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{rule_path} did not parse as a mapping"
+    SigmaCollection.from_dicts([data])
+
+
+@pytest.mark.parametrize("rule_path", RULE_FILES, ids=lambda p: p.relative_to(SIGMA_DIR).as_posix())
+def test_rule_converts_to_splunk(rule_path: Path, backend: SplunkBackend):
+    collection = SigmaCollection.from_yaml(rule_path.read_text(encoding="utf-8"))
+    queries = backend.convert(collection)
+    assert queries and all(q.strip() for q in queries), f"{rule_path} produced empty SPL"
+
+
+def _event_matches_selection(event: dict, selection: dict) -> bool:
+    """Minimal Sigma-selection matcher sufficient for fixture smoke tests.
+
+    Supports bare equality and the |endswith / |startswith modifiers used by
+    the kerberoasting fixture. Not a general Sigma evaluator.
+    """
+    for raw_key, expected in selection.items():
+        if "|" in raw_key:
+            field, modifier = raw_key.split("|", 1)
+        else:
+            field, modifier = raw_key, "eq"
+
+        actual = event.get(field)
+        if actual is None:
+            return False
+
+        expected_values = expected if isinstance(expected, list) else [expected]
+        matched = False
+        for value in expected_values:
+            if modifier == "eq" and str(actual) == str(value):
+                matched = True
+            elif modifier == "endswith" and str(actual).endswith(str(value)):
+                matched = True
+            elif modifier == "startswith" and str(actual).startswith(str(value)):
+                matched = True
+            if matched:
+                break
+        if not matched:
+            return False
+    return True
+
+
+def test_kerberoasting_fixture_matches_selection():
+    rule = yaml.safe_load(
+        (SIGMA_DIR / "credential-access" / "kerberoasting.yml").read_text(encoding="utf-8")
+    )
+    event = json.loads((FIXTURES_DIR / "kerberoasting_4769_rc4.json").read_text(encoding="utf-8"))
+
+    selection = rule["detection"]["selection"]
+    assert _event_matches_selection(event, selection), (
+        "kerberoasting positive fixture did not match rule 'selection' block"
+    )


### PR DESCRIPTION
## Summary

Bootstraps a reproducible Sigma detection content pipeline. Every push / PR against detection rules will now be parsed, converted to Splunk SPL through the repo's own pipeline mapping, and validated against a fixture-based behavioral test. First time this lane has had an actual gate.

## What ships

- **`.github/workflows/sigma-ci.yml`** — `sigma check` + `pytest` + `sigma convert` (build artifact) on push and PR; fails on any parse/convert/test error
- **`content/detection-rules/ci/requirements.txt`** — `sigma-cli>=1.0,<2` + `pysigma>=0.11.18,<0.12`. This pair was resolved from a `sigma-cli 2.x → pysigma 1.2.0` conflict against `pysigma-backend-splunk 1.1.3` that surfaced during local validation
- **`content/detection-rules/ci/splunk-pipeline.yml`** — field/index mapping used by the convert step. Verified `EventCode=4104` appears in generated SPL
- **`content/detection-rules/tests/test_sigma_rules.py`** — pytest suite: parse-all, convert-all, targeted kerberoasting 4769-rc4 fixture match
- **`content/detection-rules/tests/fixtures/kerberoasting_4769_rc4.json`** — behavioral fixture for the targeted test
- **`content/detection-rules/sigma/README.md`** — replaced stale "planned / scaffolded" wording with live description of the CI gate
- **`.gitignore`** — added `content/detection-rules/build/` so convert artifacts never land in history

## Local validation (before push)

| Step | Result |
|---|---|
| `sigma check sigma/` | 0 errors, 0 condition errors |
| `pytest tests/ -q` | **208 passed**, 0 failed |
| `sigma convert --target splunk --pipeline ci/splunk-pipeline.yml` | 207-line `build/rules.spl`, pipeline field mapping confirmed |

## Known out-of-scope warnings (tracked, not fixed here)

Pre-existing rule-quality issues in the corpus that `sigma check` flags as non-fatal. These do not fail the gate and belong in a separate detection-quality pass:

- 56× `InvalidATTACKTagIssue` (MEDIUM) — outdated / renamed ATT&CK tactic tags
- 6× `DanglingDetectionIssue` (HIGH) — defined filter block not referenced in condition (e.g. `persistence/linux_bashrc_modification.yml`, `privilege-escalation/token_manipulation.yml`)
- 6× `SpecificInsteadOfGenericLogsourceIssue` (HIGH) — e.g. `privilege-escalation/named_pipe_impersonation.yml` uses `service: sysmon + EventID 17` instead of `category: pipe_created`

## Test plan

- [ ] CI run on this PR — `sigma check` passes
- [ ] CI run on this PR — `pytest` passes (208 / 208)
- [ ] CI run on this PR — `sigma convert` emits `build/rules.spl`
- [ ] Verify `build/` is not tracked after the CI artifact step
- [ ] Confirm gate fails correctly when a deliberately-broken rule is pushed (follow-up exercise)