### PR TITLE
Fix: PR #163 follow-ups — Get-RemoteRuleIds ssh guard + dead duplicate rules

### DIFF
--- a/content/wazuh/pack/rules/local_rules.xml
+++ b/content/wazuh/pack/rules/local_rules.xml
@@ -499,25 +499,6 @@
     <group>noise_tuning,audit_noise,</group>
   </rule>
 
-  <!-- Suppress 100052 CryptoNetURLCache and scheduled task churn on HO-WE-02 -->
-  <rule id="100255" level="0">
-    <if_sid>100052</if_sid>
-    <hostname>HO-WE-02</hostname>
-    <field name="syscheck.path" type="pcre2">(?i)\\cryptneturlcache\\</field>
-    <description>Suppressed: CryptoNetURLCache metadata changes on HO-WE-02</description>
-    <options>no_full_log</options>
-    <group>noise_tuning,fim_noise,</group>
-  </rule>
-
-  <rule id="100256" level="0">
-    <if_sid>100052</if_sid>
-    <hostname>HO-WE-02</hostname>
-    <field name="syscheck.path" type="pcre2">(?i)\\softwareprotectionplatform\\</field>
-    <description>Suppressed: Software Protection scheduled task changes on HO-WE-02</description>
-    <options>no_full_log</options>
-    <group>noise_tuning,fim_noise,</group>
-  </rule>
-
   <!-- Suppress 92058 App Compat Database on win-hawkinsops (benign sdbinst.exe) -->
   <rule id="100257" level="0">
     <if_sid>92058</if_sid>

--- a/scripts/deploy_wazuh_pack.ps1
+++ b/scripts/deploy_wazuh_pack.ps1
@@ -33,13 +33,18 @@ function Get-RemoteRuleIds {
     [int]$Port,
     [string]$KeyPath
   )
-  $check = "sudo -n test -f '$RemotePath' && sudo -n grep -oE 'id=`"[0-9]+`"' '$RemotePath' || true"
+  # Sentinel proves the ssh channel delivered. Without it, an unreachable
+  # host / auth failure would return an empty HashSet and Assert-SafeOverwrite
+  # would silently pass (count == 0 short-circuit), defeating the guard.
+  $sentinel = "__WAZUH_DEPLOY_SSH_OK__"
+  $check = "echo $sentinel; if sudo -n test -f '$RemotePath'; then sudo -n grep -oE 'id=`"[0-9]+`"' '$RemotePath' || true; fi"
   $raw = Invoke-Ssh -RemoteHost $RemoteHost -User $User -Port $Port -KeyPath $KeyPath -Command $check
+  if (-not ($raw -match [regex]::Escape($sentinel))) {
+    throw "SSH reachability check failed for ${User}@${RemoteHost}:${Port} — cannot verify remote rule IDs at '$RemotePath'. Raw output: $raw"
+  }
   $ids = [System.Collections.Generic.HashSet[string]]::new()
-  if ($raw) {
-    foreach ($line in ($raw -split "`n")) {
-      if ($line -match 'id="(\d+)"') { [void]$ids.Add($matches[1]) }
-    }
+  foreach ($line in ($raw -split "`n")) {
+    if ($line -match 'id="(\d+)"') { [void]$ids.Add($matches[1]) }
   }
   return ,$ids
 }


### PR DESCRIPTION
## Summary

Cleans up two of the three follow-ups flagged at the bottom of #163. The third (leftover merge-conflict markers in `.github/workflows/verify.yml`) was already resolved on `main` and is not touched here.

## Commits

### 1. `a5144d7` — `Get-RemoteRuleIds` must fail on unreachable ssh, not silently pass

Without this guard, an unreachable Wazuh manager or auth failure returns an empty `HashSet` from `Get-RemoteRuleIds`. `Assert-SafeOverwrite` then short-circuits on `$remoteIds.Count -eq 0` and the **destructive-overwrite guard silently passes**, defeating the whole point of the check.

The remote command now prefixes its output with a sentinel string (`__WAZUH_DEPLOY_SSH_OK__`). If the sentinel is missing from the ssh response, the function throws with the raw output included for diagnosis. The legitimate "file missing" and "file exists with zero rule IDs" cases still return an empty `HashSet` — the existing short-circuit is still correct for those.

### 2. `7da9ad7` — Remove dead duplicate rules `100255` / `100256` from `local_rules.xml`

These two rule blocks in `content/wazuh/pack/rules/local_rules.xml` chained off parent rule `100052`, whose `<match>` regex only fires on:

```
/etc/passwd|/etc/shadow|/etc/sudoers|/boot/|C:\Windows\System32\
```

The suppression targets (`\cryptneturlcache\` and `\softwareprotectionplatform\`) cannot match that parent's regex, so these rules **never fired**. They were dead code that only served to trip analysisd's duplicate-id warning against the correct, working versions in `fim_suppression_ho_we02.xml`, which chain off base FIM rule `550` where they belong.

## Validation

- `pwsh -NoProfile -File scripts/validate_wazuh_pack.ps1` → **PASS** (5 rules XML, 6 total)
- Fleet-wide duplicate rule ID scan across `content/wazuh/pack/rules/*.xml` → **0 collisions**
- `[ScriptBlock]::Create` parse check on `deploy_wazuh_pack.ps1` → **PARSE OK**

## Test plan

- [ ] CI `deploy-wazuh-pack` workflow parses `deploy_wazuh_pack.ps1` cleanly
- [ ] Next real `workflow_dispatch` against HO-SR-WM-01 — sentinel present in ssh output, function does not throw
- [ ] Manual negative test: point the script at an unreachable host, confirm it throws instead of silently passing
- [ ] Post-deploy: `analysisd` no longer logs duplicate-id warnings for `100255` / `100256`