### PR TITLE
Fix: PR #163 follow-ups — deploy workflow stdout + self-hosted runner hardening

### DIFF
--- a/.github/workflows/autosoc-publish-contract.yml
+++ b/.github/workflows/autosoc-publish-contract.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   contract-scan:
-    runs-on: self-hosted
+    # Security: PRs from forks must not run on self-hosted runners (public repo).
+    # PR triggers run on GitHub-hosted ubuntu-latest; push/dispatch stay on self-hosted.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       contents: read
 

--- a/.github/workflows/deploy-wazuh-pack.yml
+++ b/.github/workflows/deploy-wazuh-pack.yml
@@ -69,8 +69,12 @@ jobs:
         id: deploy
         shell: pwsh
         run: |
-          $output = pwsh -NoProfile -File "./scripts/deploy_wazuh_pack.ps1" 2>&1 | Tee-Object -Variable deployLog
-          $deployLog | Out-File -LiteralPath "./deploy_output.log" -Encoding UTF8
+          # Stream the script's stdout/stderr to the Actions log live AND tee
+          # it to deploy_output.log for the job summary step. Previously this
+          # captured into a variable and swallowed output, so failures surfaced
+          # only as "exited with code 1" with no reason.
+          pwsh -NoProfile -File "./scripts/deploy_wazuh_pack.ps1" 2>&1 |
+            Tee-Object -FilePath "./deploy_output.log"
           if ($LASTEXITCODE -ne 0) {
             throw "deploy_wazuh_pack.ps1 exited with code $LASTEXITCODE"
           }

--- a/.github/workflows/drift-scan.yml
+++ b/.github/workflows/drift-scan.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   drift-scan:
-    runs-on: self-hosted
+    # Security: PRs from forks must not run on self-hosted runners (public repo).
+    # PR triggers run on GitHub-hosted ubuntu-latest; push stays on self-hosted.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       contents: read
 

--- a/.github/workflows/public-safety-gate.yml
+++ b/.github/workflows/public-safety-gate.yml
@@ -25,7 +25,9 @@ on:
 
 jobs:
   scan:
-    runs-on: self-hosted
+    # Security: PRs from forks must not run on self-hosted runners (public repo).
+    # PR triggers run on GitHub-hosted ubuntu-latest; push/dispatch stay on self-hosted.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   verify:
-    runs-on: self-hosted
+    # Security: PRs from forks must not run on self-hosted runners (public repo).
+    # PR triggers run on GitHub-hosted ubuntu-latest; push/dispatch stay on self-hosted.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       contents: read
 

--- a/content/wazuh/pack/rules/local_rules.xml
+++ b/content/wazuh/pack/rules/local_rules.xml
@@ -499,25 +499,6 @@
     <group>noise_tuning,audit_noise,</group>
   </rule>
 
-  <!-- Suppress 100052 CryptoNetURLCache and scheduled task churn on HO-WE-02 -->
-  <rule id="100255" level="0">
-    <if_sid>100052</if_sid>
-    <hostname>HO-WE-02</hostname>
-    <field name="syscheck.path" type="pcre2">(?i)\\cryptneturlcache\\</field>
-    <description>Suppressed: CryptoNetURLCache metadata changes on HO-WE-02</description>
-    <options>no_full_log</options>
-    <group>noise_tuning,fim_noise,</group>
-  </rule>
-
-  <rule id="100256" level="0">
-    <if_sid>100052</if_sid>
-    <hostname>HO-WE-02</hostname>
-    <field name="syscheck.path" type="pcre2">(?i)\\softwareprotectionplatform\\</field>
-    <description>Suppressed: Software Protection scheduled task changes on HO-WE-02</description>
-    <options>no_full_log</options>
-    <group>noise_tuning,fim_noise,</group>
-  </rule>
-
   <!-- Suppress 92058 App Compat Database on win-hawkinsops (benign sdbinst.exe) -->
   <rule id="100257" level="0">
     <if_sid>92058</if_sid>

--- a/scripts/deploy_wazuh_pack.ps1
+++ b/scripts/deploy_wazuh_pack.ps1
@@ -33,13 +33,18 @@ function Get-RemoteRuleIds {
     [int]$Port,
     [string]$KeyPath
   )
-  $check = "sudo -n test -f '$RemotePath' && sudo -n grep -oE 'id=`"[0-9]+`"' '$RemotePath' || true"
+  # Sentinel proves the ssh channel delivered. Without it, an unreachable
+  # host / auth failure would return an empty HashSet and Assert-SafeOverwrite
+  # would silently pass (count == 0 short-circuit), defeating the guard.
+  $sentinel = "__WAZUH_DEPLOY_SSH_OK__"
+  $check = "echo $sentinel; if sudo -n test -f '$RemotePath'; then sudo -n grep -oE 'id=`"[0-9]+`"' '$RemotePath' || true; fi"
   $raw = Invoke-Ssh -RemoteHost $RemoteHost -User $User -Port $Port -KeyPath $KeyPath -Command $check
+  if (-not ($raw -match [regex]::Escape($sentinel))) {
+    throw "SSH reachability check failed for ${User}@${RemoteHost}:${Port} — cannot verify remote rule IDs at '$RemotePath'. Raw output: $raw"
+  }
   $ids = [System.Collections.Generic.HashSet[string]]::new()
-  if ($raw) {
-    foreach ($line in ($raw -split "`n")) {
-      if ($line -match 'id="(\d+)"') { [void]$ids.Add($matches[1]) }
-    }
+  foreach ($line in ($raw -split "`n")) {
+    if ($line -match 'id="(\d+)"') { [void]$ids.Add($matches[1]) }
   }
   return ,$ids
 }


### PR DESCRIPTION
## Summary

- **`.github/workflows/deploy-wazuh-pack.yml`** — Deploy Wazuh pack step was capturing pwsh output into a variable via `Tee-Object -Variable deployLog`, which swallowed stdout/stderr so failures only surfaced as the generic `exited with code 1` in the Actions log. Now tees to `./deploy_output.log` while streaming to the Actions log live, so failure reasons appear in the UI immediately instead of requiring runner-local evidence archaeology.
- **`.github/workflows/*.yml`** — Security hardening from prior commit 45f5c40 (move PR-triggered workflows off self-hosted runners, H1 fix).

## Context

Run [24319047110](https://github.com/HawkinsOps/HawkinsOperations/actions/runs/24319047110) failed with the opaque "exited with code 1" message. Real cause — `Assert-SafeOverwrite` correctly refused to drop dead IDs 100255/100256 from live — was only reachable via `evidence/wazuh/run_*/deploy_report.md` on the self-hosted runner's disk. That stops now.

Live `/var/ossec/etc/rules/local_rules.xml` on HO-SR-WM-01 has already been manually cleaned to remove the dead blocks (backed up to `local_rules.xml.bak_20260412_dead_id_cleanup`, validated with `wazuh-analysisd -t` → EXIT=0). The working 100255/100256 remain in `fim_suppression_ho_we02.xml` chained off FIM base rule 550 where they can actually fire.

## Test plan

- [x] `scripts/validate_wazuh_pack.ps1` → PASS (5 rules XML, 6 total)
- [x] Live `wazuh-analysisd -t` post-cleanup → EXIT=0
- [ ] `workflow_dispatch` of deploy-wazuh-pack.yml reaches the Deploy step and succeeds (diff guard should pass now that live no longer has 100255/100256)
- [ ] Confirm streamed stdout is visible in a future intentional failure