### PR TITLE
fix(ci): update-site-data opens PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/update-site-data.yml
+++ b/.github/workflows/update-site-data.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: self-hosted
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -45,12 +46,39 @@ jobs:
         run: |
           git diff --quiet data/metrics.json data/metrics.json.sha256 proof/validation/ proof/quality/ site/proof/validation/ site/proof/quality/ site/data/ site/assets/data/ site/assets/verified-counts.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
-      - name: Commit and push updated site data
+      - name: Open or update PR with regenerated site data
         if: steps.diff.outputs.changed == 'true'
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/metrics.json data/metrics.json.sha256 proof/validation/ proof/quality/ site/proof/validation/ site/proof/quality/ site/data/ site/assets/data/ site/assets/verified-counts.json
-          git commit -m "chore(site): auto-regenerate site data from source artifacts"
-          git push
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(site): auto-regenerate site data from source artifacts"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          branch: auto/site-data-regen
+          base: main
+          delete-branch: true
+          title: "chore(site): auto-regenerate site data"
+          body: |
+            Automated PR opened by the `update-site-data` workflow on its scheduled run.
+
+            Regenerated artifacts:
+            - `data/metrics.json` + `data/metrics.json.sha256`
+            - `proof/validation/**`, `proof/quality/**`
+            - `site/proof/validation/**`, `site/proof/quality/**`
+            - `site/data/**`, `site/assets/data/**`
+            - `site/assets/verified-counts.json`
+
+            Merge after required status checks pass. Branch is re-used across runs and deleted after merge.
+          labels: |
+            automated
+            site-data
+          add-paths: |
+            data/metrics.json
+            data/metrics.json.sha256
+            proof/validation
+            proof/quality
+            site/proof/validation
+            site/proof/quality
+            site/data
+            site/assets/data
+            site/assets/verified-counts.json


### PR DESCRIPTION
## Summary

The `update-site-data` scheduled workflow has been failing on every run that produces a diff. Root cause: the final step attempts `git push` directly to `main`, but `main` is a protected branch that requires changes to go through a PR with required status checks.

### Example failure (run 24347852837, 2026-04-13 14:07 UTC)

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 3 of 3 required status checks are expected.
 ! [remote rejected] main -> main (protected branch hook declined)
```

3 failures today alone (03:52, 08:22, 14:07 UTC). This is structural, not flaky.

## Fix

Replace the direct-push step with `peter-evans/create-pull-request@v7`, which opens (or updates) a PR against `main` on a deterministic branch `auto/site-data-regen`.

### Why a PR instead of a push

- Respects the branch protection rule that was already the right call
- Regenerated site data still goes through the same required status checks as any other change
- Branch is reused across runs (`delete-branch: true` cleans it on merge), so we don't spam PR history
- Matches the detection-as-code principle: nothing reaches `main` without review

## Changes

- `.github/workflows/update-site-data.yml`
  - Added `pull-requests: write` to job permissions
  - Replaced the `Commit and push` step with `peter-evans/create-pull-request@v7`
  - Kept the existing `Check for changes` gate unchanged

## Test plan

- [x] Workflow YAML is valid (syntax unchanged from pattern used elsewhere in repo)
- [ ] CI (CodeQL + contract-scan + drift-scan + public-safety-gate + verify) passes on this PR
- [ ] After merge, next scheduled run of `update-site-data` opens `auto/site-data-regen` PR instead of failing at the push step
- [ ] Existing `schedule` + `workflow_dispatch` triggers unaffected