### PR TITLE
ci(update-site-data): use AUTOMATION_PAT to trigger required checks on auto PR

### DIFF
--- a/.github/workflows/update-site-data.yml
+++ b/.github/workflows/update-site-data.yml
@@ -50,7 +50,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMATION_PAT }}
           commit-message: "chore(site): auto-regenerate site data from source artifacts"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Summary

Fixes the GITHUB_TOKEN recursion bug that leaves PR #170 (`auto/site-data-regen`) permanently stuck on `drift-scan`, `verify`, and `contract-scan` as `Expected — Waiting for status to be reported`.

## Root cause

GitHub deliberately prevents workflow recursion: any push or `pull_request` event authored by `GITHUB_TOKEN` does **not** trigger downstream workflows ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)).

`peter-evans/create-pull-request@v7` uses the `token:` input for **both** the REST API call that opens/updates the PR **and** the underlying `git push` that force-pushes `auto/site-data-regen`. Currently that token is `secrets.GITHUB_TOKEN`, so every force-push suppresses the Required checks.

**Evidence collected 2026-04-15:**

```
gh run list --branch auto/site-data-regen --limit 20
(empty)
```

```
PR #170 timeline
2026-04-14T04:24Z labeled (initial open)            → no checks
2026-04-14T08:03Z head_ref_force_pushed → 88a4bc0f → no checks
2026-04-14T14:12Z head_ref_force_pushed → 8bd31960 → no checks
2026-04-14T19:41Z head_ref_force_pushed → e0e50d44 → no checks
```

Three force-pushes over 16 hours, zero workflow runs on the branch. Only CodeQL runs because it's installed via GitHub Default Setup (not a YAML workflow in the repo, uses a different token mechanism, exempt from the recursion rule).

## Change

One line in `.github/workflows/update-site-data.yml`:

```diff
- token: ${{ secrets.GITHUB_TOKEN }}
+ token: ${{ secrets.AUTOMATION_PAT }}
```

## Required operator setup before this helps

This PR is inert until the `AUTOMATION_PAT` secret exists. Steps:

1. Create a fine-grained Personal Access Token at github.com/settings/tokens?type=beta
   - Resource owner: HawkinsOps
   - Repository: `HawkinsOperations` only (not all repos)
   - Permissions:
     - Contents: **Read and write**
     - Pull requests: **Read and write**
   - Expiration: as long as your policy allows (the action silently fails the day it expires — plan for rotation)
2. Add as repo secret at `Settings → Secrets and variables → Actions → New repository secret`, name: `AUTOMATION_PAT`
3. Merge this PR
4. Either close+reopen PR #170, or manually `gh workflow run update-site-data.yml -R HawkinsOps/HawkinsOperations`, or wait for the next cron tick (every 6h at :17 past)

After that, the next force-push to `auto/site-data-regen` will be PAT-authored → `pull_request: synchronize` fires → `drift-scan` + `verify` + `contract-scan` run → PR can actually merge.

## Considered alternatives

- **GitHub App token** (`actions/create-github-app-token`): more secure (auto-rotating, install-scoped, no human owner), but requires creating an App and installing it on the repo. Overkill for a one-developer org.
- **Close + reopen PR #170 repeatedly**: works once, then the next cron tick force-pushes with GITHUB_TOKEN and undoes it. Not sustainable.
- **Revert PR #168 and go back to direct-push-to-main**: would require bypassing branch protection on every auto-regen, loses review surface area.

## Test plan

- [ ] After `AUTOMATION_PAT` secret is created and this PR merges, run `gh workflow run update-site-data.yml -R HawkinsOps/HawkinsOperations`
- [ ] Confirm the workflow succeeds (it has been succeeding since 2026-04-14 04:24Z already, so this should be unchanged)
- [ ] Confirm `gh run list --branch auto/site-data-regen --limit 5` now shows **actual** runs (currently empty)
- [ ] Confirm PR #170 shows `drift-scan`, `verify`, `contract-scan` as real SUCCESS/FAIL checks instead of `Expected`
- [ ] If those pass, merge PR #170 and the cron loop is healthy again

## Scope

Single line. No other workflows touched. No secret management in this PR (PAT creation is manual in the GitHub web UI — I can't generate PATs from here).