### PR TITLE
ci(update-site-data): wire auto-merge + pin action SHAs

### DIFF
--- a/.github/workflows/update-site-data.yml
+++ b/.github/workflows/update-site-data.yml
@@ -47,8 +47,9 @@ jobs:
           git diff --quiet data/metrics.json data/metrics.json.sha256 proof/validation/ proof/quality/ site/proof/validation/ site/proof/quality/ site/data/ site/assets/data/ site/assets/verified-counts.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Open or update PR with regenerated site data
+        id: cpr
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7 (2025-12-05)
         with:
           token: ${{ secrets.AUTOMATION_PAT }}
           commit-message: "chore(site): auto-regenerate site data from source artifacts"
@@ -82,3 +83,11 @@ jobs:
             site/data
             site/assets/data
             site/assets/verified-counts.json
+
+      - name: Enable auto-merge on PR
+        if: steps.diff.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3 (2023-03-23)
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
Wires auto-merge into the `update-site-data` workflow so the cron-produced drift PRs land without manual merge, and pins the two `peter-evans` actions to commit SHAs instead of floating tags.

## Changes
- `.github/workflows/update-site-data.yml`:
  - **Pinned** `peter-evans/create-pull-request@v7` → `@22a9089034f40e5a961c8808d113e2c98fb63676` (v7 head as of 2025-12-05)
  - Added `id: cpr` to the create-pull-request step so its `pull-request-number` output is referenceable
  - **Added** new step `Enable auto-merge on PR` using `peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d` (v3 head as of 2023-03-23), guarded by `steps.cpr.outputs.pull-request-number != ''`
  - Auto-merge step uses `AUTOMATION_PAT` and `merge-method: squash` — matches repo's only allowed merge style

## Why
Post-AUTOMATION_PAT-fix, drift PRs (#170, #175) have been opening with all checks green but requiring manual `gh pr merge` to land. Wiring auto-merge closes the loop: cron tick → PR open → checks fire (PAT-authored) → GitHub auto-merges on green → branch deleted.

Pinning the action SHAs partially closes hardening item D9 for this workflow file (`sha_pinning_required: false` at repo level is still the policy, but this workflow is now compliant).

## Test plan
- [ ] Required checks pass: `verify`, `drift-scan`, `contract-scan`
- [ ] Merge this PR (auto or manual)
- [ ] Watch the next cron tick (`17 */6 * * *` → next fire ~14:17 UTC or earlier if a push triggers the path filter). Expected behavior: drift PR opens, checks pass, PR auto-merges, `auto/site-data-regen` branch auto-deletes.
- [ ] Confirm no `workflow_dispatch` manual trigger is needed to land the next drift PR.

## Rollback
Revert this commit and push a new PR. The AUTOMATION_PAT token swap (PR #173, commit `fde1bbc`) is independent of this change and does not need to be rolled back.