### PR TITLE
fix(security): restore fork-PR runner isolation on verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,15 +7,11 @@ on:
 
 jobs:
   verify:
-    runs-on: self-hosted
+    # Security: PRs from forks must not run on self-hosted runners (public repo).
+    # PR triggers run on GitHub-hosted ubuntu-latest; push/dispatch stay on self-hosted.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       contents: read
-
-    env:
-      WAZUH_HOST: ${{ secrets.WAZUH_HOST }}
-      WAZUH_SSH_USER: ${{ secrets.WAZUH_SSH_USER }}
-      WAZUH_SSH_PORT: ${{ secrets.WAZUH_SSH_PORT }}
-      WAZUH_SSH_KEY: ${{ secrets.WAZUH_SSH_KEY }}
 
     steps:
       - name: Checkout repository
@@ -46,11 +42,20 @@ jobs:
         run: python3 ./scripts/verify/validate_detection_content.py
 
       - name: Run detection unit tests (Layer 1)
+        # Requires SSH to the Wazuh manager via WAZUH_* secrets. Secrets are not
+        # available to fork pull_request runs, and this harness validates the
+        # currently-deployed ruleset (not the in-PR bundle), so skip on PRs.
+        if: github.event_name != 'pull_request'
         shell: bash
+        env:
+          WAZUH_HOST: ${{ secrets.WAZUH_HOST }}
+          WAZUH_SSH_USER: ${{ secrets.WAZUH_SSH_USER }}
+          WAZUH_SSH_PORT: ${{ secrets.WAZUH_SSH_PORT }}
+          WAZUH_SSH_KEY: ${{ secrets.WAZUH_SSH_KEY }}
         run: python3 ./scripts/verify/run_detection_unit_tests.py
 
       - name: Upload detection unit test summary
-        if: always()
+        if: github.event_name != 'pull_request' && always()
         uses: actions/upload-artifact@v4
         with:
           name: detection-unit-tests-summary


### PR DESCRIPTION
## Summary

Reverts a **CRITICAL public-repo RCE regression** introduced by PR #169 on `verify.yml`. Restores the conditional `runs-on` expression originally landed by PR #167 (`45f5c40`, the H1 hardening), and scopes the `WAZUH_*` env block to the one step that needs it.

## Risk this closes

Pre-fix, on `origin/main`, `verify.yml` matched this anti-pattern:

- trigger: `pull_request` (any fork)
- `runs-on: self-hosted` (unconditional)
- required status check on `main`

Any unauthenticated GitHub user could open a PR from a fork and cause `actions/checkout@v4`, `actions/setup-node@v4`, `actions/setup-python@v5`, and 7 pwsh/python steps to execute on the self-hosted runner host, with the attacker's PR head tree as the working copy. Blast radius: self-hosted runner -> LAN 192.168.8.0/24 -> Wazuh manager via on-disk SSH keys.

## Diff

- `runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}` — PR triggers run on GitHub-hosted `ubuntu-latest`; `push` / `workflow_dispatch` stay on `self-hosted`. Matches `autosoc-publish-contract.yml`, `drift-scan.yml`, `public-safety-gate.yml`.
- Drops the job-scoped `env:` block exposing `WAZUH_HOST` / `WAZUH_SSH_USER` / `WAZUH_SSH_PORT` / `WAZUH_SSH_KEY`. The only step that consumes these is `Run detection unit tests (Layer 1)`, so env is moved to that step.
- That step (and its artifact upload) is gated with `if: github.event_name != 'pull_request'`. The harness validates the currently-deployed ruleset, not the in-PR bundle, so skipping on PR events is semantically correct (see comment in `scripts/verify/run_detection_unit_tests.py` header).

## Validation

- [x] YAML parses cleanly (`python -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Diff limited to `.github/workflows/verify.yml` (1 file, +13 -8)
- [x] `scripts/build-wazuh-bundle.ps1` confirmed portable pwsh (audit Lane G §2.3); runs on `ubuntu-latest` with `shell: pwsh`
- [ ] Expect verify to pass on `push` to this branch after review
- [ ] Expect verify on this PR itself to run on `ubuntu-latest` with the detection-unit-tests step skipped

## References

- full_system_audit_2026-04-15 Lane G §0 (CRITICAL headline), §2.1, drift register G-1
- Regression commit: `da67918` (PR #169)
- Original H1 fix: `45f5c40` (PR #167)

## Follow-ups (not in this PR)

- Add a CI lint asserting `verify.yml` contains the conditional `runs-on` ternary, so this cannot silently regress again (audit recommendation §11 / G-11)
- SHA-pin the 24 floating first-party `actions/*` references across all 8 workflows (G-2)