### PR TITLE
site: replace 'Live Pipeline' with snapshot wording on resume

### DIFF
--- a/site/resume.html
+++ b/site/resume.html
@@ -275,7 +275,7 @@
       <div class="wc-top">
         <div>
           <div class="wc-role">Detection Engineer · Security Automation</div>
-          <div class="wc-company">HawkinsOperations — Independent SOC Lab (Live Pipeline)</div>
+          <div class="wc-company">HawkinsOperations — Independent SOC Lab · April 2026 verified snapshot</div>
         </div>
       </div>
       <ul class="wc-bullets">


### PR DESCRIPTION
## Summary
Replaces the `resume.html` work-card subtitle from `HawkinsOperations — Independent SOC Lab (Live Pipeline)` to `HawkinsOperations — Independent SOC Lab · April 2026 verified snapshot`.

Drops the present-tense *"Live Pipeline"* assertion in favor of a time-bounded snapshot label. The underlying pipeline has not produced fresh output since 2026-03-25; the `(Live Pipeline)` subtitle was the single highest-exposure present-tense overclaim on the recruiter-facing resume surface.

## Source of authority
Audit: `R:/AgentOps/audits/public_claims_integrity_2026-04-15.md` — section **R.8** (flagged `RED — highest priority` in §1, row 18). Option A wording ("verified snapshot") was preferred over Option B ("no parenthetical") because it keeps the freshness anchor and signals discipline rather than erasing context.

## Scope
- Single file: `site/resume.html`
- Single line change (was line 277 on `fix/pr163-followups`, line 278 on `main` — same content, one-line offset from unrelated dirty edits)
- No formatting changes outside the edited line
- No CSS/JS touched
- No PDF regeneration (audit §5.4 flag: if `Raylee_Hawkins_Resume.pdf` embeds the `(Live Pipeline)` string, a follow-up regeneration is required — not in scope for this PR)

## Not in scope / separate authorizations required
Other RED rows from the same audit (index.html meta, hero body, signalfoundry.html header, autosoc-cutover.html stale banner, detections.html Wazuh grid, case-study-splunk-detection-audit.html 8→9 fix) are **not** touched in this PR. Each requires its own publish-gate authorization.

## Test plan
- [ ] Visual diff on `site/resume.html` shows exactly one changed line
- [ ] Rendered resume page at `/resume` shows `April 2026 verified snapshot` subtitle
- [ ] No layout shift in the work-card (string length comparable; same font/weight)
- [ ] `grep -n "Live Pipeline" site/resume.html` returns zero hits
- [ ] Operator review before merge (no auto-merge)