### PR TITLE
site: remove 'live' present-tense claims from index.html

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <title>Raylee Hawkins | SOC Analyst &amp; Detection Engineer | HawkinsOps</title>
-<meta name="description" content="Raylee Hawkins — SOC Analyst and Detection Engineer in Huntsville, AL. Built SignalFoundry: a live Python triage pipeline processing 324,074 Wazuh alerts with CI-verified detections across Sigma, Wazuh, and Splunk.">
+<meta name="description" content="Raylee Hawkins — SOC Analyst and Detection Engineer in Huntsville, AL. Built SignalFoundry: a Python triage pipeline that has processed 324,074 Wazuh alerts with CI-verified detections across Sigma, Wazuh, and Splunk.">
 <meta name="author" content="Raylee Hawkins">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,7 +10,7 @@
 <link rel="canonical" href="https://hawkinsops.com/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Raylee Hawkins | SOC Analyst &amp; Detection Engineer | HawkinsOps">
-<meta property="og:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer in Huntsville, AL. Built SignalFoundry: a live Python triage pipeline processing 324,074 Wazuh alerts with CI-verified detections across Sigma, Wazuh, and Splunk.">
+<meta property="og:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer in Huntsville, AL. Built SignalFoundry: a Python triage pipeline that has processed 324,074 Wazuh alerts with CI-verified detections across Sigma, Wazuh, and Splunk.">
 <meta property="og:url" content="https://hawkinsops.com/">
 <meta property="og:image" content="https://hawkinsops.com/assets/og-card.png">
 <meta property="og:image:width" content="1200">
@@ -18,7 +18,7 @@
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Raylee Hawkins | SOC Analyst &amp; Detection Engineer | HawkinsOps">
-<meta name="twitter:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer in Huntsville, AL. Built SignalFoundry: a live Python triage pipeline processing 324,074 Wazuh alerts with CI-verified detections across Sigma, Wazuh, and Splunk.">
+<meta name="twitter:description" content="Raylee Hawkins — SOC Analyst and Detection Engineer in Huntsville, AL. Built SignalFoundry: a Python triage pipeline that has processed 324,074 Wazuh alerts with CI-verified detections across Sigma, Wazuh, and Splunk.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og-card.png">
 <script type="application/ld+json">
 {
@@ -139,7 +139,7 @@
         </div>
         <p class="sf-body" style="line-height:1.7;margin-bottom:6px;font-weight:600;color:#71c7b8;">This is a working security operations system, not a static portfolio.</p>
         <p class="sf-body" style="line-height:1.7;margin-bottom:14px;">I built and operate <a href="/signalfoundry" class="sf-inline-link">SignalFoundry</a> — a 35-script Python pipeline that ingests Wazuh alerts, performs policy-driven triage, and publishes redacted escalation packs. <span data-verified="detections">210</span> detection rules across Sigma, Wazuh, and Splunk, plus 10 IR playbooks. Every metric is CI-verified. Every claim is <a href="/proof" class="sf-inline-link">reproducible</a>.</p>
-        <p class="sf-body" style="line-height:1.7;color:var(--muted);margin-bottom:20px;">Sept 2025: zero computer experience. Mar 2026: 324,074 verified cases processed, live pipeline processing on cadence. Previous career: production supervisor — 30+ operators, IATF audit compliance, mandatory 12-hour shifts. The domain changed. The discipline didn't.</p>
+        <p class="sf-body" style="line-height:1.7;color:var(--muted);margin-bottom:20px;">Sept 2025: zero computer experience. Mar 2026: 324,074 verified cases processed through an automated triage pipeline. Previous career: production supervisor — 30+ operators, IATF audit compliance, mandatory 12-hour shifts. The domain changed. The discipline didn't.</p>
         <div class="sf-actions">
           <a class="sf-button sf-button-primary sf-focus-ring" href="/signalfoundry">SignalFoundry &rarr;</a>
           <a class="sf-button sf-button-secondary sf-focus-ring" href="/proof">Proof</a>
@@ -189,7 +189,7 @@
     <!-- PIPELINE — THE ANCHOR -->
     <section id="pipeline" class="sf-section" data-aos="fade-up" style="padding:80px 0 60px;background:linear-gradient(180deg,rgba(17,24,39,0.4) 0%,transparent 100%);border-top:1px solid rgba(122,184,255,0.08);border-bottom:1px solid rgba(122,184,255,0.08);">
       <div style="text-align:center;margin-bottom:24px;">
-        <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.12em;color:#7ab8ff;margin-bottom:8px;">SignalFoundry Pipeline (Live)</div>
+        <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.12em;color:#7ab8ff;margin-bottom:8px;">SignalFoundry Pipeline</div>
         <h2 style="font-size:clamp(1.4rem,2.5vw,2rem);margin:0;">Every alert passes through this system.</h2>
       </div>
       <div style="max-width:1000px;margin:0 auto;border-radius:8px;overflow:hidden;border:1px solid rgba(122,184,255,0.15);box-shadow:0 0 40px rgba(59,143,217,0.06);">


### PR DESCRIPTION
## Summary
- Replace "a live Python triage pipeline" with "a Python triage pipeline that has processed" in meta description, og:description, and twitter:description
- Replace "live pipeline processing on cadence" with "processed through an automated triage pipeline" in hero body
- Drop "(Live)" from the SignalFoundry Pipeline section label

Addresses RED rows AR.1, AR.2, AR.4 from `R:\AgentOps\audits\public_claims_integrity_2026-04-15.md`. Same pattern as PR #180 (resume.html snapshot wording).

## Test plan
- [ ] Verify site renders correctly at `/` after merge
- [ ] Grep `site/index.html` for `live` — zero remaining present-tense pipeline claims
- [ ] OG/Twitter card preview shows updated description