### PR TITLE
detect(wazuh): tune rule 92213 FP rate on dev workstations

### DIFF
--- a/wazuh/rules/local_rules_92213_tuning.xml
+++ b/wazuh/rules/local_rules_92213_tuning.xml
@@ -1,0 +1,30 @@
+<group name="windows,sysmon,local,fp_tune,">
+  <!--
+    Rule 100213 — FP tune for vendor rule 92213
+    ("Executable file dropped in folder commonly used by malware", Sysmon EID 11)
+
+    Scope
+      - agent.id gate: only fires on workstation agents 013 (win-hawkinsops) and 023 (HO-WE-02).
+      - image gate: only fires when the process doing the drop is a known-benign dev/browser/runtime binary.
+
+    Effect
+      - On allowlisted drops from the two workstations, demotes the alert from
+        level 15 (original 92213) to level 10 (noise but retained for audit).
+      - Any drop from a non-allowlisted image on 013/023 continues to match 92213 only → level 15.
+      - Drops on any other agent (servers, honeypot, Linux hosts) cannot match 100213 and
+        continue to fire 92213 at level 15 unchanged.
+
+    Allowlist intentionally excludes generic parents like `Update.exe` and `setup.exe`
+    because those names are too common in real malware staging.
+  -->
+  <rule id="100213" level="10">
+    <if_sid>92213</if_sid>
+    <field name="agent.id" type="pcre2">^(013|023)$</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)\\(msedgewebview2|msedge|MicrosoftEdgeUpdate|chrome|GoogleUpdate|firefox|Teams|Discord|Slack|OneDrive|Code|claude-code|node|npm|pnpm|git|python|python3|pip|cargo|rustc|go|dotnet|msiexec|TiWorker|TrustedInstaller)\.exe$</field>
+    <description>FP-tuned rule 92213: benign unpacker on dev workstation. Image: $(win.eventdata.image). Dropped: $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1036</id>
+    </mitre>
+    <group>tuned_fp,workstation_dev,</group>
+  </rule>
+</group>


### PR DESCRIPTION
## Summary
- Adds rule 100213 scoped to agents 013/023 (dev workstations) that demotes rule 92213 from level 15 → 10 when the dropping process is a known-benign binary (Edge/WebView2, Node, Python, git, VS Code, etc.)
- Non-allowlisted images on workstations remain at level 15 via original 92213 — detection preserved
- Server/non-workstation agents excluded by `agent.id` gate — zero impact on that scope

## Evidence
- 7-day baseline: 3 hits, 100% from `msedgewebview2.exe` unpacking `Microsoft.CognitiveServices.Speech.core.dll` into `%TEMP%`
- Negative test: `pwsh.exe` drop on agent 013 fired **92213 level 15** (not 100213) ✓
- Manager restart: clean, 11/11 agents retained, no ossec.log errors
- Full evidence pack: `R:\Vault\BuildLog\cases\2026-04-17_rule_92213\`

## Test plan
- [ ] Confirm 100213 fires at level 10 on next natural `msedgewebview2.exe` drop (next Edge/WebView2 update cycle)
- [ ] Verify no regression on server agents (004, 006, 011 etc.) under rule 92213
- [ ] Monitor 30-day FP rate post-merge for annualized estimate refinement