### PR TITLE
pipeline: path hardening + subprocess guardrails + redact nested-output fix

### DIFF
--- a/scripts/auto-soc/assemble-pack.py
+++ b/scripts/auto-soc/assemble-pack.py
@@ -63,7 +63,7 @@ def assert_no_absolute_paths(pack_dir: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Assemble report pack from redacted case data.")
     parser.add_argument("--case-dir", type=Path, required=True)
-    parser.add_argument("--redacted-dir", type=Path, help="Default: <case-dir>/redacted")
+    parser.add_argument("--redacted-dir", type=Path, help="Default: resolved from case_dir/redaction_report.json[output_dir]; falls back to legacy <case-dir>/redacted for pre-fix cases.")
     parser.add_argument("--pack-dir", type=Path, help="Default: <case-dir>/pack")
     args = parser.parse_args()
 
@@ -77,7 +77,10 @@ def main() -> None:
             if out:
                 redacted = Path(out)
     if redacted is None:
-        # Prefer the newest timestamped redaction output when available.
+        # LEGACY FALLBACK (pre-2026-04-18): older cases may still have redacted
+        # output co-located at <case_dir>/redacted* from the previous output-
+        # inside-input scheme. Current redact.py writes to an external tree and
+        # records its path in redaction_report.json (preferred resolution above).
         redacted_dirs = sorted(
             [p for p in case_dir.glob("redacted*") if p.is_dir()],
             key=lambda p: p.stat().st_mtime,

--- a/scripts/auto-soc/capture-passfile-acl.ps1
+++ b/scripts/auto-soc/capture-passfile-acl.ps1
@@ -1,6 +1,6 @@
 param(
-    [string]$PassFile = "C:\RH\OPS\30_Projects\Active\AutoSOC\Build\Config\secrets\wazuh_indexer_pass.txt",
-    [string]$OutJson = "C:\RH\OPS\30_Projects\Active\AutoSOC\Output\passfile_acl_latest.json"
+    [string]$PassFile = $(if ($env:WAZUH_INDEXER_PASS_FILE) { $env:WAZUH_INDEXER_PASS_FILE } else { "C:\RH\OPS\30_Projects\Active\AutoSOC\Build\Config\secrets\wazuh_indexer_pass.txt" }),
+    [string]$OutJson = $(if ($env:AUTOSOC_OUTPUT) { Join-Path $env:AUTOSOC_OUTPUT 'passfile_acl_latest.json' } else { 'R:\DailyOps\Data\autosoc\runtime_data\Output\passfile_acl_latest.json' })
 )
 
 $acl = Get-Acl -LiteralPath $PassFile

--- a/scripts/auto-soc/common.py
+++ b/scripts/auto-soc/common.py
@@ -32,7 +32,7 @@ else:
     CASES_ROOT = _DATA_ROOT / "Cases"
     OUTPUT_ROOT = Path(os.getenv("AUTOSOC_OUTPUT", str(_DATA_ROOT / "Output")))
     LOGS_ROOT = Path(os.getenv("AUTOSOC_LOGS", str(AUTOSOC_ROOT / "logs" / "Runtime")))
-    REPO_ROOT_DEFAULT = Path(os.getenv("AUTOSOC_REPO", r"Z:\GitHub\HawkinsOperations"))
+    REPO_ROOT_DEFAULT = Path(os.getenv("AUTOSOC_REPO", r"R:\GitHub\HawkinsOperations"))
 
 PROCESSED_ROOT = QUEUE_ROOT / "Processed"
 LEDGER_PATH = OUTPUT_ROOT / "ledger.json"

--- a/scripts/auto-soc/common.py
+++ b/scripts/auto-soc/common.py
@@ -7,23 +7,49 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-OPS_ROOT = Path(os.getenv("OPS_ROOT") or r"C:\RH\OPS")
-AUTOSOC_ROOT = Path(os.getenv("AUTOSOC_ROOT") or str(OPS_ROOT / "30_Projects" / "Active" / "AutoSOC"))
-BUILD_ROOT = AUTOSOC_ROOT / "Build"
-CONFIG_ROOT = BUILD_ROOT / "Config"
-QUEUE_ROOT = BUILD_ROOT / "Queue"
+# Path resolution: Z:-native layout by default, with legacy OPS_ROOT override
+# for rollback. If OPS_ROOT is set, the old C:\RH\OPS hierarchy is reconstructed;
+# otherwise everything resolves under Z:\AutoSOC\ with the current on-disk layout.
+_LEGACY_OPS_ROOT = os.getenv("OPS_ROOT")
+if _LEGACY_OPS_ROOT:
+    OPS_ROOT = Path(_LEGACY_OPS_ROOT)
+    AUTOSOC_ROOT = Path(os.getenv("AUTOSOC_ROOT", str(OPS_ROOT / "30_Projects" / "Active" / "AutoSOC")))
+    BUILD_ROOT = AUTOSOC_ROOT / "Build"
+    CONFIG_ROOT = Path(os.getenv("AUTOSOC_CONFIG", str(BUILD_ROOT / "Config")))
+    _DATA_ROOT = Path(os.getenv("AUTOSOC_DATA", str(BUILD_ROOT)))
+    QUEUE_ROOT = _DATA_ROOT / "Queue"
+    CASES_ROOT = _DATA_ROOT / "Cases"
+    OUTPUT_ROOT = Path(os.getenv("AUTOSOC_OUTPUT", str(AUTOSOC_ROOT / "Output")))
+    LOGS_ROOT = Path(os.getenv("AUTOSOC_LOGS", str(OPS_ROOT / "50_System" / "Runs" / "Logs")))
+    REPO_ROOT_DEFAULT = Path(os.getenv("AUTOSOC_REPO", str(OPS_ROOT / "10_Portfolio" / "HawkinsOperations")))
+else:
+    AUTOSOC_ROOT = Path(os.getenv("AUTOSOC_ROOT", r"Z:\AutoSOC"))
+    OPS_ROOT = AUTOSOC_ROOT  # legacy alias; scripts referencing OPS_ROOT still resolve
+    BUILD_ROOT = AUTOSOC_ROOT  # legacy alias; BUILD_ROOT is flattened in Z: layout
+    CONFIG_ROOT = Path(os.getenv("AUTOSOC_CONFIG", str(AUTOSOC_ROOT / "config")))
+    _DATA_ROOT = Path(os.getenv("AUTOSOC_DATA", str(AUTOSOC_ROOT / "data")))
+    QUEUE_ROOT = _DATA_ROOT / "Queue"
+    CASES_ROOT = _DATA_ROOT / "Cases"
+    OUTPUT_ROOT = Path(os.getenv("AUTOSOC_OUTPUT", str(_DATA_ROOT / "Output")))
+    LOGS_ROOT = Path(os.getenv("AUTOSOC_LOGS", str(AUTOSOC_ROOT / "logs" / "Runtime")))
+    REPO_ROOT_DEFAULT = Path(os.getenv("AUTOSOC_REPO", r"Z:\GitHub\HawkinsOperations"))
+
 PROCESSED_ROOT = QUEUE_ROOT / "Processed"
-CASES_ROOT = BUILD_ROOT / "Cases"
-OUTPUT_ROOT = AUTOSOC_ROOT / "Output"
 LEDGER_PATH = OUTPUT_ROOT / "ledger.json"
-LOGS_ROOT = OPS_ROOT / "50_System" / "Runs" / "Logs"
-REPO_ROOT_DEFAULT = OPS_ROOT / "10_Portfolio" / "HawkinsOperations"
 
 POLICY_PATH = CONFIG_ROOT / "policy.yaml"
 KNOWN_FPS_PATH = CONFIG_ROOT / "known_fps.yaml"
 ENV_PATH = CONFIG_ROOT / ".env"
 CURSOR_PATH = QUEUE_ROOT / ".cursor.json"
 AGENT_INVENTORY_PATH = CONFIG_ROOT / "agent_inventory.json"
+
+# Secrets live under the config tree. The DPAPI blob is produced by
+# Z:\AutoSOC\scripts\set-wazuh-credential.ps1 and consumed by
+# Z:\AutoSOC\scripts\get-wazuh-credential.ps1 (invoked via subprocess from
+# poll-alerts.py). The plaintext passfile is retained as a legacy fallback.
+SECRETS_DIR = Path(os.getenv("AUTOSOC_SECRETS", str(CONFIG_ROOT / "secrets")))
+PASS_DPAPI_PATH = Path(os.getenv("WAZUH_INDEXER_PASS_DPAPI", str(SECRETS_DIR / "wazuh_indexer_pass.dpapi")))
+GET_CREDENTIAL_SCRIPT = Path(os.getenv("AUTOSOC_GET_CRED_SCRIPT", str(AUTOSOC_ROOT / "scripts" / "get-wazuh-credential.ps1")))
 
 
 def utc_now() -> str:

--- a/scripts/auto-soc/daily-ops.ps1
+++ b/scripts/auto-soc/daily-ops.ps1
@@ -13,9 +13,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$opsRoot = "C:\RH\OPS"
-$scriptRoot = Join-Path $opsRoot "50_System\Scripts\Automation\auto-soc"
-$outputRoot = Join-Path $opsRoot "30_Projects\Active\AutoSOC\Output"
+# Path resolution: env-var overrides with canonical R:\ defaults. $PSScriptRoot
+# is the natural default for the pipeline dir since daily-ops.ps1 lives
+# alongside run-pipeline.py in the canonical repo tree.
+$scriptRoot = if ($env:AUTOSOC_PIPELINE) { $env:AUTOSOC_PIPELINE } else { $PSScriptRoot }
+$outputRoot = if ($env:AUTOSOC_OUTPUT)   { $env:AUTOSOC_OUTPUT }   else { 'R:\DailyOps\Data\autosoc\runtime_data\Output' }
 
 $heartbeatPath = Join-Path $outputRoot "heartbeat.json"
 $coveragePath = Join-Path $outputRoot "coverage_latest.json"

--- a/scripts/auto-soc/redact.py
+++ b/scripts/auto-soc/redact.py
@@ -1,15 +1,26 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import re
 import shutil
 from pathlib import Path
 from typing import Dict
 
-from common import utc_now
+from common import CASES_ROOT, utc_now
 
 
 TEXT_EXTS = {".md", ".txt", ".json", ".csv", ".log", ".yaml", ".yml", ".xml", ".ps1", ".sh"}
+
+# Redacted output lives outside the case directory so repeat runs never see
+# prior output as new input. Per-case path: REDACTED_ROOT/<case_name>/redacted.
+# Override with AUTOSOC_REDACTED (consistent with other AUTOSOC_* env vars in
+# common.py). Default parallels CASES_ROOT as a sibling tree.
+REDACTED_ROOT = Path(os.getenv("AUTOSOC_REDACTED", str(CASES_ROOT.parent / "Cases_Redacted")))
+
+
+def default_out_dir(case_dir: Path) -> Path:
+    return REDACTED_ROOT / case_dir.name / "redacted"
 
 REPLACEMENTS = {
     re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"): "[REDACTED_IP]",
@@ -54,9 +65,14 @@ def redact_json_file(raw: str) -> str:
 
 def copy_and_redact(case_dir: Path, out_dir: Path) -> tuple[Dict[str, int], Path]:
     stats = {"files_total": 0, "files_text": 0, "files_binary": 0}
+    # Output path is now deterministic per case. If an output dir from a prior
+    # run exists, delete it and rewrite: redaction content is idempotent, and
+    # overwrite cleanly handles partial-failure state from aborted prior runs.
+    # This replaces the previous timestamp-suffix collision scheme, which
+    # caused redacted_<ts>/ siblings to accumulate inside case_dir and be
+    # re-ingested by subsequent rglob walks (incident 2026-04-18).
     if out_dir.exists():
-        suffix = utc_now().replace(":", "").replace("-", "").replace("T", "_").replace("Z", "")
-        out_dir = out_dir.parent / f"{out_dir.name}_{suffix}"
+        shutil.rmtree(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     for src in case_dir.rglob("*"):
@@ -102,11 +118,11 @@ def fails_post_redaction(out_dir: Path) -> bool:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Redact case data before assembly/publish.")
     parser.add_argument("--case-dir", type=Path, required=True)
-    parser.add_argument("--output-dir", type=Path, help="Default: <case-dir>/redacted")
+    parser.add_argument("--output-dir", type=Path, help="Default: <Cases_Redacted>/<case-name>/redacted (AUTOSOC_REDACTED overrides root)")
     args = parser.parse_args()
 
     case_dir = args.case_dir
-    out_dir = args.output_dir or (case_dir / "redacted")
+    out_dir = args.output_dir or default_out_dir(case_dir)
     stats, final_out_dir = copy_and_redact(case_dir, out_dir)
     failed = fails_post_redaction(final_out_dir)
 

--- a/scripts/auto-soc/run-autosoc-live-task.cmd
+++ b/scripts/auto-soc/run-autosoc-live-task.cmd
@@ -1,3 +1,2 @@
 @echo off
-"C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "C:\RH\OPS\50_System\Scripts\Automation\auto-soc\run-autosoc-live-task.ps1"
-
+"C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "R:\GitHub\HawkinsOperations\scripts\auto-soc\run-autosoc-live-task.ps1"

--- a/scripts/auto-soc/run-autosoc-live-task.ps1
+++ b/scripts/auto-soc/run-autosoc-live-task.ps1
@@ -7,6 +7,7 @@ $env:AUTOSOC_PIPELINE        = 'R:\GitHub\HawkinsOperations\scripts\auto-soc'
 $env:AUTOSOC_LOGS            = 'R:\DailyOps\Lab\autosoc\runtime\logs'
 $env:AUTOSOC_CONFIG          = 'R:\DailyOps\Lab\autosoc\runtime\config'
 $env:AUTOSOC_SECRETS         = 'R:\AgentOps\env\credentials_store\wazuh'
+$env:AUTOSOC_REPO            = 'R:\GitHub\HawkinsOperations'
 $env:WAZUH_INDEXER_PASS_FILE = 'R:\AgentOps\env\credentials_store\wazuh\all.txt'
 
 $logDir = 'R:\DailyOps\Lab\autosoc\runtime\logs'

--- a/scripts/auto-soc/run-autosoc-live-task.ps1
+++ b/scripts/auto-soc/run-autosoc-live-task.ps1
@@ -1,7 +1,19 @@
-﻿$ErrorActionPreference = 'Continue'
-$log = 'C:\RH\OPS\50_System\Runs\Logs\autosoc-live-task.log'
-$prev = 'C:\RH\OPS\50_System\Runs\Logs\autosoc-live-task.log.1'
-$max = 262144
+$ErrorActionPreference = 'Continue'
+
+# Env var routing — all pipeline paths resolve to R:\ via common.py / daily-ops.ps1.
+$env:AUTOSOC_OUTPUT          = 'R:\DailyOps\Data\autosoc\runtime_data\Output'
+$env:AUTOSOC_DATA            = 'R:\DailyOps\Data\autosoc\runtime_data'
+$env:AUTOSOC_PIPELINE        = 'R:\GitHub\HawkinsOperations\scripts\auto-soc'
+$env:AUTOSOC_LOGS            = 'R:\DailyOps\Lab\autosoc\runtime\logs'
+$env:AUTOSOC_CONFIG          = 'R:\DailyOps\Lab\autosoc\runtime\config'
+$env:AUTOSOC_SECRETS         = 'R:\AgentOps\env\credentials_store\wazuh'
+$env:WAZUH_INDEXER_PASS_FILE = 'R:\AgentOps\env\credentials_store\wazuh\all.txt'
+
+$logDir = 'R:\DailyOps\Lab\autosoc\runtime\logs'
+if (-not (Test-Path -LiteralPath $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+$log  = Join-Path $logDir 'autosoc-live-task.log'
+$prev = Join-Path $logDir 'autosoc-live-task.log.1'
+$max  = 262144
 if (Test-Path -LiteralPath $log) {
     try {
         if ((Get-Item -LiteralPath $log).Length -gt $max) {
@@ -10,4 +22,4 @@ if (Test-Path -LiteralPath $log) {
         }
     } catch {}
 }
-& 'C:\Program Files\PowerShell\7\pwsh.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\RH\OPS\50_System\Scripts\Automation\auto-soc\daily-ops.ps1' -Refresh -SkipTests -FreshnessP95MaxSeconds 3600 -FreshnessOldestMaxSeconds 7200 *>> 'C:\RH\OPS\50_System\Runs\Logs\autosoc-live-task.log'
+& 'C:\Program Files\PowerShell\7\pwsh.exe' -NoProfile -ExecutionPolicy Bypass -File 'R:\GitHub\HawkinsOperations\scripts\auto-soc\daily-ops.ps1' -Refresh -SkipTests -FreshnessP95MaxSeconds 3600 -FreshnessOldestMaxSeconds 7200 *>> $log

--- a/scripts/auto-soc/run-pipeline.py
+++ b/scripts/auto-soc/run-pipeline.py
@@ -356,7 +356,7 @@ def main() -> None:
             finalize("FAILED", "tests", 10)
 
     if args.reconcile_only:
-        case_dirs_scanned = len([p for p in CASES_ROOT.iterdir() if p.is_dir()]) if CASES_ROOT.exists() else 0
+        case_dirs_scanned = len([p for p in CASES_ROOT.iterdir() if p.is_dir() and not p.name.startswith((".", "_"))]) if CASES_ROOT.exists() else 0
         reconcile_cmd = [sys.executable, str(SCRIPT_DIR / "reconcile-state.py")]
         if args.reconcile_strict:
             reconcile_cmd.append("--strict")
@@ -420,7 +420,10 @@ def main() -> None:
         )
         step_seconds["triage_quality_chart"] = round(time.time() - t0, 3)
 
-        case_dirs = sorted([p for p in CASES_ROOT.iterdir() if p.is_dir()], key=lambda p: p.stat().st_mtime)
+        # Skip dot- or underscore-prefixed case dirs (quarantine/forensic-hold
+        # convention). Added after 2026-04-18 incident where .FORENSIC_HOLD_*
+        # entries were still enumerated on Windows (no hidden-attribute semantics).
+        case_dirs = sorted([p for p in CASES_ROOT.iterdir() if p.is_dir() and not p.name.startswith((".", "_"))], key=lambda p: p.stat().st_mtime)
         case_dirs_scanned = len(case_dirs)
 
         t_case = time.time()

--- a/scripts/auto-soc/run-pipeline.py
+++ b/scripts/auto-soc/run-pipeline.py
@@ -21,6 +21,15 @@ HEARTBEAT_HISTORY_PATH = OUTPUT_ROOT / "heartbeat_history.jsonl"
 RECONCILE_JSON_PATH = OUTPUT_ROOT / "reconciliation_latest.json"
 COVERAGE_JSON_PATH = OUTPUT_ROOT / "coverage_latest.json"
 
+# Per-step subprocess guardrails. The timeout is the hard last-resort kill;
+# the warn threshold is an early-detection signal (structured log only, no kill).
+# Sized after the 2026-04-18 redact-hang incident: 600s = 2 scheduler intervals,
+# generous enough for legitimate batch cases (seen: <1s on a 30-50 file case,
+# ~60-90s projected worst-case at 5k files), tight enough that a hang gets
+# surfaced within a single missed run rather than cascading for hours.
+STEP_TIMEOUT_SECONDS = 600
+STEP_WARN_SECONDS = 30
+
 
 def hide_console_window() -> None:
     if os.name != "nt":
@@ -35,13 +44,32 @@ def hide_console_window() -> None:
 
 
 def run_step(cmd: list[str], log_path: Path) -> tuple[int, str]:
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    combined = (proc.stdout or "") + (proc.stderr or "")
+    start = time.monotonic()
+    rc: int
+    combined: str
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=STEP_TIMEOUT_SECONDS)
+        combined = (proc.stdout or "") + (proc.stderr or "")
+        rc = proc.returncode
+    except subprocess.TimeoutExpired as e:
+        stdout = e.stdout if isinstance(e.stdout, str) else (e.stdout.decode("utf-8", errors="ignore") if e.stdout else "")
+        stderr = e.stderr if isinstance(e.stderr, str) else (e.stderr.decode("utf-8", errors="ignore") if e.stderr else "")
+        # subprocess.run already killed the child process at timeout; we just
+        # record the elapsed time and surface a non-zero rc so the caller's
+        # finalize("FAILED", <stage>, rc) path fires.
+        combined = (
+            f"STEP_TIMEOUT seconds={STEP_TIMEOUT_SECONDS} cmd={' '.join(cmd)}\n"
+            f"{stdout}{stderr}"
+        )
+        rc = 124  # conventional timeout exit code
+    elapsed = time.monotonic() - start
     with log_path.open("a", encoding="utf-8") as log:
         log.write(f"\n$ {' '.join(cmd)}\n")
+        if elapsed >= STEP_WARN_SECONDS:
+            log.write(f"STEP_SLOW elapsed_seconds={elapsed:.1f} threshold={STEP_WARN_SECONDS}\n")
         if combined:
             log.write(combined)
-    return proc.returncode, combined
+    return rc, combined
 
 
 def parse_kv(output: str) -> dict[str, str]:

--- a/scripts/auto-soc/tests/test_redact.py
+++ b/scripts/auto-soc/tests/test_redact.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import os
 import shutil
 import sys
 import unittest
@@ -14,6 +15,30 @@ spec = importlib.util.spec_from_file_location("redact_module", SCRIPT_DIR / "red
 redact = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(redact)
+
+
+class _AutosocRedactedEnv:
+    """Context helper: isolate AUTOSOC_REDACTED to a tmp path per test."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._prev: str | None = None
+
+    def __enter__(self) -> Path:
+        self._prev = os.environ.get("AUTOSOC_REDACTED")
+        os.environ["AUTOSOC_REDACTED"] = str(self.path)
+        # Re-read the module-level REDACTED_ROOT so default_out_dir sees the new root.
+        redact.REDACTED_ROOT = Path(os.environ["AUTOSOC_REDACTED"])
+        return self.path
+
+    def __exit__(self, *_exc) -> None:
+        if self._prev is None:
+            os.environ.pop("AUTOSOC_REDACTED", None)
+        else:
+            os.environ["AUTOSOC_REDACTED"] = self._prev
+        redact.REDACTED_ROOT = Path(
+            os.environ.get("AUTOSOC_REDACTED", str(redact.CASES_ROOT.parent / "Cases_Redacted"))
+        )
 
 
 class RedactionTests(unittest.TestCase):
@@ -58,6 +83,53 @@ class RedactionTests(unittest.TestCase):
         self.assertIn("[REDACTED_PATH]", text)
         self.assertIn("[REDACTED_IP]", text)
         self.assertFalse(redact.fails_post_redaction(final_out))
+        shutil.rmtree(td, ignore_errors=True)
+
+    def test_default_out_dir_is_outside_case_dir(self) -> None:
+        """New default: <AUTOSOC_REDACTED>/<case_name>/redacted — not a child of case_dir."""
+        td = self._tmpdir()
+        case_dir = td / "case_abc"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        with _AutosocRedactedEnv(td / "Cases_Redacted"):
+            out = redact.default_out_dir(case_dir)
+        self.assertEqual(out, td / "Cases_Redacted" / "case_abc" / "redacted")
+        # Must NOT be a descendant of case_dir.
+        self.assertFalse(case_dir in out.parents)
+        shutil.rmtree(td, ignore_errors=True)
+
+    def test_repeat_run_overwrites_not_timestamp_suffixes(self) -> None:
+        """Second run on same case must reuse the same out_dir (overwrite),
+        not create redacted_<ts>/ siblings. Direct regression test for
+        incident 2026-04-18."""
+        td = self._tmpdir()
+        case_dir = td / "case"
+        out_dir = td / "out" / "redacted"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        (case_dir / "alert.raw.json").write_text(
+            '{"source":"HO-GRAFANA-01","ip":"10.0.0.5"}',
+            encoding="utf-8",
+        )
+        _stats1, final1 = redact.copy_and_redact(case_dir, out_dir)
+        _stats2, final2 = redact.copy_and_redact(case_dir, out_dir)
+        self.assertEqual(final1, out_dir)
+        self.assertEqual(final2, out_dir)
+        # No timestamped sibling should exist next to out_dir.
+        siblings = [p for p in out_dir.parent.glob("redacted*") if p.is_dir()]
+        self.assertEqual(siblings, [out_dir])
+        shutil.rmtree(td, ignore_errors=True)
+
+    def test_output_dir_not_nested_inside_case_dir_on_main_invocation(self) -> None:
+        """End-to-end: running the default redact path on a case dir must not
+        create any redacted*/ directory inside the case dir."""
+        td = self._tmpdir()
+        case_dir = td / "case_e2e"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        (case_dir / "alert.raw.json").write_text('{"ip":"10.0.0.1"}', encoding="utf-8")
+        with _AutosocRedactedEnv(td / "Cases_Redacted"):
+            out = redact.default_out_dir(case_dir)
+            redact.copy_and_redact(case_dir, out)
+        nested = [p for p in case_dir.glob("redacted*") if p.is_dir()]
+        self.assertEqual(nested, [], f"redact leaked into case_dir: {nested}")
         shutil.rmtree(td, ignore_errors=True)
 
 


### PR DESCRIPTION
Merges `fix/pipeline-restart-2026-04-17` to `main`. 11 commits, scope-checked, 
all changes in `scripts/auto-soc/`. No workflow, governance, or rule churn.

## Context

On 2026-04-18 the pipeline hung on a pathological redact case. Root cause 
was redact.py defaulting output inside the case directory, which turned 
reruns into input growth, which eventually wedged on a case that hit 
regex backtracking. The incident validation itself was blocked by a 
quarantine method (`.FORENSIC_HOLD_*`) that does not work on Windows — 
Python's `iterdir()` has no hidden-attribute semantics there, so 
quarantined dirs kept being picked up.

## What this PR closes

- **Redact output nesting bug.** Output now writes to an external tree, 
  not inside the case dir. Repro case preserved at 
  `R:\DailyOps\Lab\diagnostics\pipeline_lock_deadlock_2026-04-18\`.
- **Subprocess hang class.** Adds `STEP_TIMEOUT=600s` with `rc=124` on 
  timeout and `STEP_WARN=30s` slow-step log marker. Caught a second 
  slow stage (`triage-quality.py`) during validation — tracked as 
  follow-up, not fixed here.
- **Enumeration quarantine respect.** Case-dir enumeration skips `.` 
  and `_` prefixed directories to honor quarantine/work-in-progress 
  conventions at the Python level, since Windows filesystem semantics 
  don't enforce it.

## What this PR does NOT close

Tracked separately, landing in gate-truth-sprint PRs after this merge:

- Reconcile strict override at `run-pipeline.py:177` — PR #1
- VERIFIED_COUNTS.md freshness gate in `verify.yml` — PR #3  
- Coverage-check rc discard — PR #4
- Stuck-case skip predicate at `run-pipeline.py:425` — PR #2 (requires 
  silent-loss backlog audit first)
- Agent 013 signal quality / rule 100203-100204 severity — Phase 3

## Validation

- Clean offline repro of redact nesting bug: passed
- Pytest: 6/6 unchanged
- Incident case report: `PROOF_PACK/incidents/2026-04-18-redact-nesting.md` 
  (to be written post-merge)

## Scope confirmation

Pre-merge scope check confirmed all 11 commits touch `scripts/auto-soc/` 
only. No `.github/workflows/` changes. No `CLAUDE.md`, `AGENTS.md`, or 
`policy/` changes. No `content/detection-rules/` or `PROOF_PACK/` 
changes. No destructive operations.

## Strategic framing

This merge makes the system less fragile. The next sprint makes it 
less dishonest. This PR belongs to the first half.