### PR TITLE
fix: restore CI by propagating authority dates and correcting drift-scan false positives

### DIFF
--- a/scripts/drift_scan.py
+++ b/scripts/drift_scan.py
@@ -1,5 +1,31 @@
 #!/usr/bin/env python3
-"""Fail on drift between VERIFIED_COUNTS.md and website claim surfaces."""
+"""Fail on drift between VERIFIED_COUNTS.md and website claim surfaces.
+
+Scanner features:
+  - Compares VERIFIED_COUNTS.md truth values against generated JSON artifacts.
+  - Scans .html/.md/.txt under site/ for hard-coded numbers that match
+    authority values near claim-context words (detection, sigma, wazuh, etc.).
+  - Verifies data-verified fallback spans match authoritative truth.
+
+Escape hatches for false positives:
+
+  1. Natural-language date masking. The scanner masks these formats so
+     embedded day-of-month digits do not false-positive against authority
+     values:
+       - ISO hyphenated dates:  YYYY-MM-DD and MM-DD-YYYY
+       - Natural-language date: "Month DD, YYYY" (with optional ordinal
+         suffix, e.g. "March 25th, 2026")
+       - Natural-language range: "Month DD-DD" and "Month DD-DD, YYYY"
+       - Numeric ratios:        N/M
+
+  2. Inline ignore directive: <!-- drift-scan-ignore -->
+     Place on the same line as the flagged content, or as a standalone
+     comment on the immediately preceding line. An optional reason after
+     a colon is allowed (and encouraged) for future reviewers:
+       <!-- drift-scan-ignore: short reason -->
+     Use sparingly and document why the literal number is legitimately
+     unrelated to the authority claim it collides with.
+"""
 
 from __future__ import annotations
 
@@ -79,6 +105,55 @@ def compare_counts(expected: Dict[str, int], actual: Dict[str, int], label: str)
     return errors
 
 
+_MONTH_NAMES = (
+    r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|"
+    r"Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|"
+    r"Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)"
+)
+
+# Hyphenated ISO-style dates: 04-07-2026 or 2026-04-07.
+ISO_DATE_RE = re.compile(r"\d{2}-\d{2}-\d{4}|\d{4}-\d{2}-\d{2}")
+
+# Natural-language dates and date ranges:
+#   "March 25, 2026"           -> match
+#   "March 25th, 2026"         -> match (ordinal suffix)
+#   "March 11-25"              -> match (day range)
+#   "March 11-25, 2026"        -> match (day range with year)
+#   "Mar 25"                   -> match (bare month+day)
+# Day tokens accept optional ordinal suffix (st/nd/rd/th).
+NATURAL_DATE_RE = re.compile(
+    _MONTH_NAMES
+    + r"\s+\d{1,2}(?:st|nd|rd|th)?"
+    + r"(?:\s*[-–—]\s*\d{1,2}(?:st|nd|rd|th)?)?"
+    + r"(?:,\s*\d{4})?",
+    re.IGNORECASE,
+)
+
+RATIO_RE = re.compile(r"\b\d+/\d+\b")
+
+# <!-- drift-scan-ignore -->   or   <!-- drift-scan-ignore: reason -->
+IGNORE_DIRECTIVE_RE = re.compile(
+    r"<!--\s*drift-scan-ignore(?:\s*:[^>]*?)?\s*-->",
+    re.IGNORECASE,
+)
+
+
+def _mask_dates_and_ratios(line: str) -> str:
+    masked = ISO_DATE_RE.sub("__DATE__", line)
+    masked = NATURAL_DATE_RE.sub("__DATE__", masked)
+    masked = RATIO_RE.sub("__RATIO__", masked)
+    return masked
+
+
+def _has_ignore_directive(line: str) -> bool:
+    return bool(IGNORE_DIRECTIVE_RE.search(line))
+
+
+def _is_standalone_comment_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("<!--") and stripped.endswith("-->")
+
+
 def scan_hardcoded_claim_numbers(site_root: Path, truth: Dict[str, int]) -> List[Tuple[Path, int, str]]:
     claim_files = sorted(
         [
@@ -95,16 +170,13 @@ def scan_hardcoded_claim_numbers(site_root: Path, truth: Dict[str, int]) -> List
     )
     issues: List[Tuple[Path, int, str]] = []
 
-    # Patterns that embed claim numbers inside dates or ratios (false positives).
-    date_re = re.compile(r"\d{2}-\d{2}-\d{4}|\d{4}-\d{2}-\d{2}")
-    ratio_re = re.compile(r"\b\d+/\d+\b")
-
     for path in claim_files:
         if not path.exists():
             continue
+        lines = path.read_text(encoding="utf-8").splitlines()
         in_comment = False
         in_template = False
-        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        for lineno, line in enumerate(lines, start=1):
             stripped = line.strip()
             # Track multi-line HTML comments.
             if "<!--" in stripped:
@@ -139,9 +211,17 @@ def scan_hardcoded_claim_numbers(site_root: Path, truth: Dict[str, int]) -> List
             # data-ops spans are runtime-bound (same as data-verified).
             if "data-ops" in line:
                 continue
+            # Honor <!-- drift-scan-ignore --> on the same line.
+            if _has_ignore_directive(line):
+                continue
+            # Honor <!-- drift-scan-ignore --> on the preceding line when it
+            # is a standalone comment (avoids matching markers buried mid-line).
+            if lineno > 1:
+                prev = lines[lineno - 2]
+                if _has_ignore_directive(prev) and _is_standalone_comment_line(prev):
+                    continue
             # Mask dates and ratios so embedded digits don't false-positive.
-            masked = date_re.sub("__DATE__", line)
-            masked = ratio_re.sub("__RATIO__", masked)
+            masked = _mask_dates_and_ratios(line)
             if token_re.search(masked) and claim_context_re.search(masked):
                 issues.append((path, lineno, line.strip()))
     return issues

--- a/scripts/generate-site-data.js
+++ b/scripts/generate-site-data.js
@@ -14,6 +14,7 @@ const siteOpsJsonOutPath = path.join(root, "site", "assets", "data", "ops-metric
 const siteOpsJsOutPath = path.join(root, "site", "data", "ops-metrics.js");
 const detectionsDataPath = path.join(root, "site", "assets", "data", "detections.json");
 const siteIndexHtmlPath = path.join(root, "site", "index.html");
+const siteProofHtmlPath = path.join(root, "site", "proof.html");
 const withProofPack = process.argv.includes("--with-proof-pack");
 const regenerateMetricsFlag = process.argv.includes("--regenerate-metrics");
 
@@ -284,25 +285,30 @@ function writeSiteOpsMetrics(payload) {
 }
 
 function patchIndexHtmlFallbacks(payload) {
-  if (!fs.existsSync(siteIndexHtmlPath)) return;
+  // Patches hand-maintained <span data-ops="..."> fallbacks on every page
+  // that site-runtime-contract.js validates. Currently: index.html and proof.html.
+  const targets = [siteIndexHtmlPath, siteProofHtmlPath];
   const keys = ["stable_locked_date", "lifetime_last_updated"];
-  let html = fs.readFileSync(siteIndexHtmlPath, "utf8");
-  let changed = false;
-  for (const key of keys) {
-    const value = payload && payload.metrics ? payload.metrics[key] : undefined;
-    if (typeof value !== "string" || !value) {
-      throw new Error(`generate-site-data: metrics.${key} missing or non-string; cannot patch site/index.html fallback`);
+  for (const targetPath of targets) {
+    if (!fs.existsSync(targetPath)) continue;
+    let html = fs.readFileSync(targetPath, "utf8");
+    let changed = false;
+    for (const key of keys) {
+      const value = payload && payload.metrics ? payload.metrics[key] : undefined;
+      if (typeof value !== "string" || !value) {
+        throw new Error(`generate-site-data: metrics.${key} missing or non-string; cannot patch ${path.relative(root, targetPath)} fallback`);
+      }
+      const re = new RegExp(`(<span data-ops="${key}">)[^<]*(</span>)`, "g");
+      const next = html.replace(re, `$1${value}$2`);
+      if (next !== html) {
+        html = next;
+        changed = true;
+      }
     }
-    const re = new RegExp(`(<span data-ops="${key}">)[^<]*(</span>)`, "g");
-    const next = html.replace(re, `$1${value}$2`);
-    if (next !== html) {
-      html = next;
-      changed = true;
+    if (changed) {
+      fs.writeFileSync(targetPath, html, "utf8");
+      console.log(`Patched ${path.relative(root, targetPath)} (data-ops fallbacks)`);
     }
-  }
-  if (changed) {
-    fs.writeFileSync(siteIndexHtmlPath, html, "utf8");
-    console.log(`Patched ${path.relative(root, siteIndexHtmlPath)} (data-ops fallbacks)`);
   }
 }
 

--- a/scripts/generate-site-data.js
+++ b/scripts/generate-site-data.js
@@ -13,6 +13,7 @@ const siteCountsJsOutPath = path.join(root, "site", "data", "counts.js");
 const siteOpsJsonOutPath = path.join(root, "site", "assets", "data", "ops-metrics.json");
 const siteOpsJsOutPath = path.join(root, "site", "data", "ops-metrics.js");
 const detectionsDataPath = path.join(root, "site", "assets", "data", "detections.json");
+const siteIndexHtmlPath = path.join(root, "site", "index.html");
 const withProofPack = process.argv.includes("--with-proof-pack");
 const regenerateMetricsFlag = process.argv.includes("--regenerate-metrics");
 
@@ -282,6 +283,29 @@ function writeSiteOpsMetrics(payload) {
   fs.writeFileSync(siteOpsJsOutPath, `window.HAWKINSOPS_OPS_METRICS = ${JSON.stringify(payload, null, 2)};\n`, "utf8");
 }
 
+function patchIndexHtmlFallbacks(payload) {
+  if (!fs.existsSync(siteIndexHtmlPath)) return;
+  const keys = ["stable_locked_date", "lifetime_last_updated"];
+  let html = fs.readFileSync(siteIndexHtmlPath, "utf8");
+  let changed = false;
+  for (const key of keys) {
+    const value = payload && payload.metrics ? payload.metrics[key] : undefined;
+    if (typeof value !== "string" || !value) {
+      throw new Error(`generate-site-data: metrics.${key} missing or non-string; cannot patch site/index.html fallback`);
+    }
+    const re = new RegExp(`(<span data-ops="${key}">)[^<]*(</span>)`, "g");
+    const next = html.replace(re, `$1${value}$2`);
+    if (next !== html) {
+      html = next;
+      changed = true;
+    }
+  }
+  if (changed) {
+    fs.writeFileSync(siteIndexHtmlPath, html, "utf8");
+    console.log(`Patched ${path.relative(root, siteIndexHtmlPath)} (data-ops fallbacks)`);
+  }
+}
+
 if (!fs.existsSync(srcPath)) {
   console.error(`Missing source file: ${srcPath}`);
   process.exit(1);
@@ -313,6 +337,7 @@ fs.writeFileSync(siteOutPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 writeSiteCountsJs(payload);
 syncDetectionsData(parsed.counts);
 writeSiteOpsMetrics(metricsPayload);
+patchIndexHtmlFallbacks(metricsPayload);
 
 if (withProofPack) {
   fs.writeFileSync(canonicalOutPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");

--- a/site/case-study-splunk-detection-audit.html
+++ b/site/case-study-splunk-detection-audit.html
@@ -168,6 +168,7 @@ Wazuh agent forwarding Security Event Log as <span class="m-inline-code">XmlWinE
 
         <h2>Operational Impact</h2>
         <div class="outcome-bar">
+          <!-- drift-scan-ignore: "25 additional subcategories" is Windows Audit Policy subcategory count, unrelated to authority wazuh_xml_files=25 -->
           <p><strong>This audit directly triggered two follow-on actions:</strong> Phase 1 Audit Policy Hardening (command-line logging, failed logon auditing, 25 additional subcategories) and detection rule dependency flags on every SPL rule.</p>
         </div>
         <p>Every new detection now includes a &ldquo;deployment prerequisites&rdquo; section before the SPL, not after. Rules are not marked stable until their dependencies are confirmed present.</p>

--- a/site/index.html
+++ b/site/index.html
@@ -405,7 +405,7 @@
       <ul class="sf-body" style="font-size:0.78rem;color:var(--muted);margin-top:8px;display:grid;gap:3px;list-style:none;padding:0;">
         <li><strong>Public benchmark snapshot:</strong> reviewer-authoritative values from <code>data/truth/current-authority.json</code>.</li>
         <li><strong>Runtime snapshot:</strong> informational telemetry remains subordinate and is disclosed on <a href="/proof" class="sf-inline-link">/proof</a>.</li>
-        <li><strong>Generated at:</strong> <span data-ops="stable_locked_date">LOCKED</span></li>
+        <li><strong>Generated at:</strong> <span data-ops="stable_locked_date">04-07-2026</span></li>
         <li><strong>Source artifact:</strong> <code>site/data/truth/current-authority.json</code></li>
       </ul>
       <div class="sf-metrics" role="status" aria-live="polite" aria-label="Stable benchmark metrics">
@@ -431,7 +431,7 @@
         </article>
         <article class="sf-card sf-metric" data-aos="fade-up" data-aos-delay="400" aria-label="Stable benchmark date" data-modal="tpl-benchmark" data-modal-title="Benchmark Lock Date">
           <span class="sf-metric-label">Locked</span>
-          <span class="sf-metric-value"><span data-ops="stable_locked_date">LOCKED</span></span>
+          <span class="sf-metric-value"><span data-ops="stable_locked_date">04-07-2026</span></span>
           <p class="sf-metric-note">Snapshot date.</p>
         </article>
       </div>


### PR DESCRIPTION
Fixes all 3 failing required status checks on `main` (verify, update-site-data, drift-scan) with control-layer corrections only — no prose edits to any case study.

## Commits

1. **drift-scan regex extension** (`18a1300`)
   `scripts/drift_scan.py` gains:
   - Natural-language date mask: `Month DD, YYYY` (with optional ordinal suffix), `Month DD-DD` ranges, `Month DD-DD, YYYY` — in addition to the existing ISO-hyphenated mask
   - Inline ignore directive: `<!-- drift-scan-ignore -->` (same-line or preceding-line standalone comment), with optional `:reason` suffix
   - Docstring updated to document both features

2. **annotation of one legitimate false positive** (`6b10846`)
   `site/case-study-splunk-detection-audit.html:171` — one-line `<!-- drift-scan-ignore: ... -->` comment above the existing `<p>`, documenting that `25 additional subcategories` is a Windows Audit Policy count, unrelated to authority `wazuh_xml_files=25`. **No prose modified.**

3. **generator propagates authority dates to HTML fallback** (`cdc0476`)
   `scripts/generate-site-data.js` gains `patchIndexHtmlFallbacks()` that writes `stable_locked_date` and `lifetime_last_updated` into the `<span data-ops="...">` fallbacks in `site/index.html` whenever the generator runs. Closes the hand-maintained gap that `site-runtime-contract.js` exists to catch. Two pre-existing placeholder spans (`LOCKED` → resolved date) are brought into sync as a side-effect.

## Why this fixes each check

- **verify**: `site-runtime-contract.js` now finds HTML and `ops-metrics.json` regenerated from the same authority payload on the same run.
- **update-site-data**: Same validator embedded in its final step.
- **drift-scan**: Date mask clears the two `march-2026-deep-dive.html` false positives. Ignore directive clears the one `case-study-splunk-detection-audit.html` false positive. No content changed to satisfy the scanner.

## Verified locally

```
node scripts/generate-site-data.js             -> Patched site/index.html (data-ops fallbacks)
node scripts/verify/site-runtime-contract.js   -> Site runtime contract passed.
python scripts/drift_scan.py                   -> DRIFT SCAN: PASS
```

## Scope

Four files touched across three commits: `scripts/drift_scan.py`, `site/case-study-splunk-detection-audit.html` (one-line comment), `scripts/generate-site-data.js`, `site/index.html` (generator-written). No runtime files, no proof artifacts, no `data/metrics.json`.