### PR TITLE
Route HawkinsOps homepage readers to HawkinsOperations

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,16 +1,16 @@
 <!doctype html>
 <html lang="en">
 <head>
-<title>Raylee Hawkins | HawkinsOps | Detection Engineer &amp; SOC Automation</title>
-<meta name="description" content="Raylee Hawkins is a detection engineer and SOC automation builder behind HawkinsOps and SignalFoundry, with public LinkedIn, GitHub, proof artifacts, and detection-as-code work across Wazuh, Sigma, Splunk, and Python.">
+<title>HawkinsOps V1 Archive | Current System: HawkinsOperations</title>
+<meta name="description" content="HawkinsOps V1 is the retired legacy archive. Current governed detection engineering, SOC automation, validation, proof records, and reviewer routing now live in HawkinsOperations.">
 <meta name="author" content="Raylee Hawkins">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#07070b">
 <link rel="canonical" href="https://hawkinsops.com/">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Raylee Hawkins | HawkinsOps | Detection Engineer &amp; SOC Automation">
-<meta property="og:description" content="Raylee Hawkins is a detection engineer and SOC automation builder behind HawkinsOps and SignalFoundry, with public LinkedIn, GitHub, proof artifacts, and detection-as-code work.">
+<meta property="og:title" content="HawkinsOps V1 Archive | Current System: HawkinsOperations">
+<meta property="og:description" content="HawkinsOps V1 is retired. Current governed detection engineering, validation, proof records, and reviewer routing now live in HawkinsOperations.">
 <meta property="og:url" content="https://hawkinsops.com/">
 <meta property="og:site_name" content="HawkinsOps">
 <meta property="og:image" content="https://hawkinsops.com/assets/og-card.png">
@@ -18,8 +18,8 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Raylee Hawkins | HawkinsOps | Detection Engineer &amp; SOC Automation">
-<meta name="twitter:description" content="Raylee Hawkins is a detection engineer and SOC automation builder behind HawkinsOps and SignalFoundry, with LinkedIn, GitHub, and proof artifacts.">
+<meta name="twitter:title" content="HawkinsOps V1 Archive | Current System: HawkinsOperations">
+<meta name="twitter:description" content="HawkinsOps V1 is retired. Current governed detection engineering, validation, proof records, and reviewer routing now live in HawkinsOperations.">
 <meta name="twitter:image" content="https://hawkinsops.com/assets/og-card.png">
 <script type="application/ld+json">
 {
@@ -29,7 +29,7 @@
       "@type": "WebSite",
       "name": "HawkinsOps",
       "url": "https://hawkinsops.com",
-      "description": "HawkinsOps is the primary detection engineering portfolio for Raylee Hawkins, focused on SOC automation, detection-as-code, proof artifacts, and evidence-backed security workflows.",
+      "description": "HawkinsOps V1 is the retired legacy archive for Raylee Hawkins' original SOC automation and detection engineering work. Current governed work lives in HawkinsOperations.",
       "author": {
         "@id": "https://hawkinsops.com/#person"
       }
@@ -132,58 +132,110 @@
 <main class="sf-home">
   <div class="sf-shell">
 
-    <!-- 
-         SECTION 1: HERO - Candidate first
+    <!--
+         SECTION 1: LEGACY ROUTING BRIDGE
           -->
-    <section id="hero" class="sf-section sf-hero" aria-labelledby="hero-title" style="display:grid;grid-template-columns:1fr 280px;gap:40px;align-items:center;">
-      <!-- LEFT: Name, system, CTAs -->
-      <div>
-        <h1 id="hero-title">Raylee Hawkins</h1>
-        <div class="sf-role-line">
-          <span class="sf-role-tag typed-target"></span>
+    <section id="hero" class="sf-section sf-hero" aria-labelledby="hero-title">
+      <div class="sf-hero-grid">
+        <div>
+          <div class="sf-section-label">HawkinsOps V1 is retired.</div>
+          <h1 id="hero-title">The active system is HawkinsOperations.</h1>
+          <p class="sf-body" style="line-height:1.7;margin-bottom:14px;font-weight:600;color:#71c7b8;">HawkinsOps V1 remains online as a historical archive of the original SOC automation and detection engineering work.</p>
+          <p class="sf-body" style="line-height:1.7;margin-bottom:18px;">The current governed rebuild lives in the <a href="https://github.com/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="sf-inline-link">HawkinsOperations GitHub organization</a> and on <a href="https://hawkinsoperations.com" target="_blank" rel="noopener noreferrer" class="sf-inline-link">hawkinsoperations.com</a>, where source, validation, platform contracts, proof records, governance routing, and public rendering are separated.</p>
+          <div class="sf-actions" aria-label="Current HawkinsOperations routes">
+            <a class="sf-button sf-button-primary" href="https://hawkinsoperations.com" target="_blank" rel="noopener noreferrer">View Current System</a>
+            <a class="sf-button sf-button-secondary" href="https://github.com/HawkinsOperations" target="_blank" rel="noopener noreferrer">Open GitHub Organization</a>
+            <a class="sf-button sf-button-secondary" href="https://hawkinsoperations.com/proof/ho-det-001/" target="_blank" rel="noopener noreferrer">View HO-DET-001 Proof Route</a>
+          </div>
         </div>
-        <p class="sf-body" style="line-height:1.7;margin-bottom:14px;font-weight:600;color:#71c7b8;">This is a closed V1 security operations proof surface, not a static portfolio.</p>
-        <p class="sf-body" style="line-height:1.7;margin-bottom:14px;">SignalFoundry processed Wazuh alerts through a deterministic triage pipeline for the locked V1 reviewer snapshot. <span data-ops="stable_total_cases">324,074</span> cases triaged. Approximately 88 percent auto-closed. <span data-ops="stable_escalated">8,574</span> reviewable evidence packs produced. <span data-verified="detections">211</span> detections across Sigma, Wazuh, and Splunk, plus 10 IR playbooks. Detection content is CI-verified via <code>verify-counts.ps1</code>. Case-volume provenance is documented at <a href="/proof" class="sf-inline-link">/proof</a>, including what is script-verified versus manually transcribed. The AI Analyst positioning is summarized at <a href="/ai-security-operations-proof" class="sf-inline-link">/ai-security-operations-proof</a>.</p>
-        <p class="sf-body" style="line-height:1.7;color:var(--muted);margin-bottom:20px;">This site is the closed HawkinsOps V1 proof surface. The governed successor architecture lives at <a href="https://github.com/HawkinsOperations" target="_blank" rel="noopener noreferrer" class="sf-inline-link">github.com/HawkinsOperations</a>, which separates detections, validation, platform, proof, and website surfaces into audience-split repositories. The migration is governed in public — both this repository and the successor organization document which surface answers which question.</p>
-      </div>
-      <!-- RIGHT: Photo -->
-      <div style="text-align:center;">
-        <img src="/assets/raylee-hawkins-headshot.jpg" alt="Raylee Hawkins" width="240" height="240" style="border-radius:50%;border:3px solid rgba(0,212,255,0.2);box-shadow:0 0 24px rgba(0,212,255,0.08);object-fit:cover;width:240px;height:240px;">
-        <div style="margin-top:12px;font-size:0.78rem;color:var(--muted);line-height:1.6;">
-          Open to relocation<br>
-          <span style="color:#22c55e;">Available for Detection Engineering roles</span>
+        <div style="display:grid;gap:12px;">
+          <div class="sf-card" style="padding:18px;border-left:3px solid #fbbf24;">
+            <div class="sf-section-label" style="margin-bottom:6px;">HawkinsOps V1</div>
+            <p class="sf-body" style="margin:0;">Single public proof surface, historical snapshot, original SOC automation work.</p>
+          </div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:0.78rem;letter-spacing:0.08em;text-transform:uppercase;color:#7ab8ff;text-align:center;">routes to</div>
+          <div class="sf-card" style="padding:18px;border-left:3px solid #22c55e;">
+            <div class="sf-section-label" style="margin-bottom:6px;">HawkinsOperations</div>
+            <p class="sf-body" style="margin:0;">Six-repo governed system: source truth, validation truth, platform contracts, proof records, governance routing, public navigation.</p>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- METRICS BAR -->
+    <!-- HISTORICAL SNAPSHOT -->
     <section style="padding:24px 0 32px;">
-      <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:0;text-align:center;max-width:800px;margin:0 auto;border:1px solid rgba(122,184,255,0.12);border-radius:6px;background:rgba(17,24,39,0.5);">
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:0;text-align:center;max-width:900px;margin:0 auto;border:1px solid rgba(122,184,255,0.12);border-radius:6px;background:rgba(17,24,39,0.5);overflow:hidden;">
         <div style="padding:20px 12px;border-right:1px solid rgba(122,184,255,0.08);">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:1.6rem;font-weight:700;color:#7ab8ff;" class="counter" data-target="324074">0</div>
-          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Cases</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:1.45rem;font-weight:700;color:#7ab8ff;" class="counter" data-target="324074">0</div>
+          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Historical V1 cases</div>
         </div>
         <div style="padding:20px 12px;border-right:1px solid rgba(122,184,255,0.08);">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:1.6rem;font-weight:700;color:#4ade80;">~88%</div>
-          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Auto-Closed</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:1.45rem;font-weight:700;color:#4ade80;">~88%</div>
+          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Historical auto-close</div>
         </div>
         <div style="padding:20px 12px;border-right:1px solid rgba(122,184,255,0.08);">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:1.6rem;font-weight:700;color:#fbbf24;" class="counter" data-target="8574">0</div>
-          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Escalated</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:1.45rem;font-weight:700;color:#fbbf24;" class="counter" data-target="8574">0</div>
+          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Historical evidence packs</div>
         </div>
         <div style="padding:20px 12px;">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:1.6rem;font-weight:700;color:#4ade80;">0</div>
-          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Errors</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:1.45rem;font-weight:700;color:#4ade80;"><span data-verified="detections">211</span></div>
+          <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.08em;color:#7a94aa;margin-top:4px;">Historical artifacts</div>
         </div>
+      </div>
+      <p class="sf-body" style="max-width:900px;margin:12px auto 0;font-size:.78rem;color:var(--muted);text-align:center;">Historical HawkinsOps V1 context only. These metrics are not current HawkinsOperations runtime proof, production proof, public-safe proof, customer deployment proof, or SOCaaS availability proof.</p>
+    </section>
+
+    <!-- WHY HAWKINSOPERATIONS EXISTS -->
+    <section id="why-hawkinsoperations" class="sf-section" data-aos="fade-up" aria-labelledby="why-hawkinsoperations-title" style="padding:28px 0 18px;">
+      <div class="sf-section-label">Why HawkinsOperations Exists</div>
+      <h2 id="why-hawkinsoperations-title">The successor separates what V1 bundled together.</h2>
+      <div class="sf-grid-3" style="margin-top:18px;">
+        <article class="sf-card" style="padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Proof boundaries</div>
+          <p class="sf-body" style="margin:0;">V1 showed output. HawkinsOperations shows controlled proof boundaries.</p>
+        </article>
+        <article class="sf-card" style="padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Separated surfaces</div>
+          <p class="sf-body" style="margin:0;">V1 bundled story and proof together. HawkinsOperations separates source, validation, platform, proof, governance, and rendering.</p>
+        </article>
+        <article class="sf-card" style="padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Governed successor</div>
+          <p class="sf-body" style="margin:0;">V1 was a closed snapshot. HawkinsOperations is the active governed system for review, validation, routing, and claim control.</p>
+        </article>
       </div>
     </section>
 
-    <!-- LATEST ENGINEERING -->
-    <section data-aos="fade-up" style="padding:0 0 12px;">
-      <div style="max-width:800px;margin:0 auto;padding:14px 20px;border:1px solid rgba(0,196,212,0.15);border-left:3px solid #00c4d4;border-radius:6px;background:rgba(0,196,212,0.03);display:flex;align-items:center;gap:14px;flex-wrap:wrap;">
-        <div style="font-family:'JetBrains Mono',monospace;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.1em;color:#00c4d4;white-space:nowrap;">Latest &mdash; 04-08-2026</div>
-        <div style="font-size:0.88rem;color:#d4e0ec;flex:1;min-width:200px;">Wazuh Windows telemetry remediation: three-phase fix restoring process creation visibility across the lab fleet. <a href="/case-study-wazuh" style="color:#00c4d4;text-decoration:none;font-weight:600;">Read case study &rarr;</a></div>
+    <!-- CURRENT ORGANIZATION MAP -->
+    <section id="current-organization" class="sf-section" data-aos="fade-up" aria-labelledby="current-organization-title" style="padding:32px 0 18px;">
+      <div class="sf-section-label">What the New Organization Does Better</div>
+      <h2 id="current-organization-title">Current reviewer routes are split by authority.</h2>
+      <div class="sf-grid-3" style="margin-top:18px;">
+        <a class="sf-card" href="https://github.com/HawkinsOperations/hawkinsoperations-detections" target="_blank" rel="noopener noreferrer" style="text-decoration:none;padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Source Truth</div>
+          <p class="sf-body" style="margin:0;">Detection source lives in hawkinsoperations-detections.</p>
+        </a>
+        <a class="sf-card" href="https://github.com/HawkinsOperations/hawkinsoperations-validation" target="_blank" rel="noopener noreferrer" style="text-decoration:none;padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Validation Truth</div>
+          <p class="sf-body" style="margin:0;">Controlled validation lives in hawkinsoperations-validation.</p>
+        </a>
+        <a class="sf-card" href="https://github.com/HawkinsOperations/hawkinsoperations-platform" target="_blank" rel="noopener noreferrer" style="text-decoration:none;padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Platform Contracts</div>
+          <p class="sf-body" style="margin:0;">Ledgers, case packets, and automation boundaries live in hawkinsoperations-platform.</p>
+        </a>
+        <a class="sf-card" href="https://github.com/HawkinsOperations/hawkinsoperations-proof" target="_blank" rel="noopener noreferrer" style="text-decoration:none;padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Proof Authority</div>
+          <p class="sf-body" style="margin:0;">Proof records and claim ceilings live in hawkinsoperations-proof.</p>
+        </a>
+        <a class="sf-card" href="https://github.com/HawkinsOperations/.github" target="_blank" rel="noopener noreferrer" style="text-decoration:none;padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Governance Routing</div>
+          <p class="sf-body" style="margin:0;">Reviewer routes and authority maps live in .github.</p>
+        </a>
+        <a class="sf-card" href="https://hawkinsoperations.com" target="_blank" rel="noopener noreferrer" style="text-decoration:none;padding:18px;">
+          <div class="sf-section-label" style="margin-bottom:6px;">Public Navigation</div>
+          <p class="sf-body" style="margin:0;">hawkinsoperations.com renders reviewer paths, but does not create proof.</p>
+        </a>
       </div>
+      <p class="sf-body" style="max-width:900px;margin-top:18px;color:var(--muted);">HawkinsOps V1 remains useful for historical context, prior artifacts, and the closed V1 proof surface, but it should not be treated as the active operating architecture. Website rendering is not proof. GitHub rendering is not runtime truth. Green CI is not final authority. AI is support labor, not final security authority.</p>
     </section>
 
     <!-- PIPELINE — THE ANCHOR -->


### PR DESCRIPTION
## Summary\n- Updates the hawkinsops.com homepage first screen to say HawkinsOps V1 is retired and HawkinsOperations is the active system.\n- Adds current-system CTAs for hawkinsoperations.com, the HawkinsOperations GitHub organization, and the HO-DET-001 proof route.\n- Adds a compact V1 to HawkinsOperations routing map, historical V1 metric boundary, and six-repo authority map.\n\n## Validation\n- node ./scripts/diagnose-site.js --fail-on-issues: PASS\n- python ./scripts/drift_scan.py: PASS\n- node ./scripts/verify/site-runtime-contract.js: PASS\n- pwsh ./scripts/verify/verify-counts.ps1: PASS\n- git diff --check: PASS\n- Live target links returned HTTP 200 on June 1, 2026.\n- Browser screenshot capture was not run because visual artifact capture was not route-approved and the Playwright MCP browser was locked; source-level first-viewport checks confirmed required hero copy and CTAs.\n\n## Proof Boundary\nThis is a legacy-routing and reviewer-clarity update only. V1 metrics remain historical context and are not current HawkinsOperations runtime proof, production proof, public-safe proof, customer deployment proof, or SOCaaS availability proof. Website rendering is not proof. GitHub rendering is not runtime truth. AI is support labor, not final security authority.\n\n## Merge\nDo not merge until Raylee gives MERGE_APPROVED.